### PR TITLE
feat: Implement preload command for CLI

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,27 +1,13 @@
 package main
 
 import (
-	"context"
-	"fmt"
 	"log/slog"
 	"os"
-
-	"github.com/sevigo/code-warden/internal/wire"
 )
 
 func main() {
-	if err := run(); err != nil {
+	if err := rootCmd.Execute(); err != nil {
 		slog.Error("cli failed to run", "error", err)
 		os.Exit(1)
 	}
-}
-
-func run() error {
-	_, cleanup, err := wire.InitializeApp(context.Background())
-	if err != nil {
-		return fmt.Errorf("failed to initialize app: %w", err)
-	}
-	defer cleanup()
-
-	return nil
 }

--- a/cmd/cli/preload.go
+++ b/cmd/cli/preload.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/sevigo/code-warden/internal/core"
+	"github.com/sevigo/code-warden/internal/gitutil"
+	"github.com/sevigo/code-warden/internal/wire"
+)
+
+var (repoURL string
+	branch string
+	githubToken string
+)
+
+var preloadCmd = &cobra.Command{
+	Use:   "preload",
+	Short: "Preload a repository into the vector store",
+	Long:  `This command performs the initial clone and indexing of a repository for faster subsequent reviews.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+
+		slog.Info("Initializing application...")
+		app, cleanup, err := wire.InitializeApp(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to initialize app: %w", err)
+		}
+		defer cleanup()
+
+		slog.Info("Fetching remote head SHA...", "url", repoURL, "branch", branch)
+		gitClient := gitutil.NewClient(slog.Default()) // Assuming NewClient takes a logger
+		sha, err := gitClient.GetRemoteHeadSHA(repoURL, branch, githubToken)
+		if err != nil {
+			return fmt.Errorf("failed to get remote head SHA: %w", err)
+		}
+		slog.Info("Remote head SHA fetched", "sha", sha)
+
+		// Construct mock core.GitHubEvent
+		event := &core.GitHubEvent{
+			RepoOwner:    "", // Not directly available from CLI flags, can be derived or left empty
+			RepoName:     repoURL, // Using URL as name for simplicity
+			RepoFullName: repoURL, // Using URL as full name for simplicity
+			RepoCloneURL: repoURL,
+			HeadSHA:      sha,
+			Type:         core.FullReview, // Assuming preload is always a full review
+		}
+
+		repoManager := app.RepoManager()
+		ragService := app.RAGService()
+
+		slog.Info("Syncing repository...", "repo", event.RepoName)
+			_, err = repoManager.SyncRepo(ctx, event, githubToken)
+			if err != nil {
+				return fmt.Errorf("failed to sync repository: %w", err)
+			}
+			slog.Info("Repository synced successfully.")
+
+		repoRecord, err := repoManager.GetRepoRecord(ctx, event.RepoFullName)
+		if err != nil {
+			return fmt.Errorf("failed to get repository record: %w", err)
+		}
+		if repoRecord == nil {
+			return fmt.Errorf("repository record not found after sync: %s", event.RepoFullName)
+		}
+
+		// Use default RepoConfig for preload
+		defaultRepoConfig := core.DefaultRepoConfig()
+
+		slog.Info("Setting up repository context (indexing and embedding)...", "repo", event.RepoName)
+		err = ragService.SetupRepoContext(ctx, defaultRepoConfig, repoRecord.QdrantCollectionName, repoRecord.ClonePath)
+		if err != nil {
+			return fmt.Errorf("failed to set up repository context: %w", err)
+		}
+		slog.Info("Repository context setup complete.")
+
+		slog.Info("Preload complete.")
+		return nil
+	},
+}
+
+func init() {
+	preloadCmd.Flags().StringVarP(&repoURL, "repo-url", "u", "", "Repository URL (e.g., https://github.com/owner/repo)")
+	preloadCmd.Flags().StringVarP(&branch, "branch", "b", "main", "Repository branch to preload")
+	preloadCmd.Flags().StringVarP(&githubToken, "github-token", "t", os.Getenv("GITHUB_TOKEN"), "GitHub Personal Access Token (or set GITHUB_TOKEN env var)")
+
+	preloadCmd.MarkFlagRequired("repo-url")
+}

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "warden-cli",
+	Short: "warden-cli is a CLI tool for Code Warden",
+	Long:  `A command-line interface for interacting with the Code Warden application.`,
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	rootCmd.AddCommand(preloadCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.10.9
 	github.com/sevigo/goframe v0.7.1
+	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/oauth2 v0.30.0
@@ -51,6 +52,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,7 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -118,6 +119,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/hcl/v2 v2.24.0 h1:2QJdZ454DSsYGoaE6QheQZjtKZSUs9Nh2izTWiwQxvE=
 github.com/hashicorp/hcl/v2 v2.24.0/go.mod h1:oGoO1FIQYfn/AgyOhlg9qLC6/nOJPX3qGbkZpYAcqfM=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
@@ -165,6 +168,7 @@ github.com/qdrant/go-client v1.14.0 h1:cyz9OOooAexudw5w69LRe9vKCQFYJvaFvt9icOciI
 github.com/qdrant/go-client v1.14.0/go.mod h1:iO8ts78jL4x6LDHFOViyYWELVtIBDTjOykBmiOTHLnQ=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
@@ -180,6 +184,9 @@ github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=
 github.com/spf13/afero v1.12.0/go.mod h1:ZTlWwG4/ahT8W7T0WQ5uYmjI9duaLQGy3Q2OAl4sk/4=
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
 github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.20.1 h1:ZMi+z/lvLyPSCoNtFCpqjy0S4kPbirhpTMwl8BkW9X4=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -35,6 +35,8 @@ type App struct {
 	logger     *slog.Logger
 	dispatcher core.JobDispatcher
 	dbConn     *db.DB
+	repoManager repomanager.RepoManager
+	ragService llm.RAGService
 }
 
 // newOllamaHTTPClient creates an HTTP client with longer timeouts for Ollama requests.
@@ -118,9 +120,21 @@ func NewApp(ctx context.Context, cfg *config.Config, logger *slog.Logger) (*App,
 			logger:     logger,
 			dispatcher: dispatcher,
 			dbConn:     dbConn,
+			repoManager: repoManager,
+			ragService: ragService,
 		}, func() {
 			dbCleanup()
 		}, nil
+}
+
+// RepoManager returns the repository manager instance.
+func (a *App) RepoManager() repomanager.RepoManager {
+	return a.repoManager
+}
+
+// RAGService returns the RAG service instance.
+func (a *App) RAGService() llm.RAGService {
+	return a.ragService
 }
 
 func createGeneratorLLM(ctx context.Context, cfg *config.Config, logger *slog.Logger) (llms.Model, error) {


### PR DESCRIPTION
This commit introduces the  command to the CLI, allowing administrators to pre-populate the vector store for large repositories.

Key changes include:
- Creation of  and  using  for CLI structure.
- Implementation of  to fetch the latest commit SHA without a full clone.
- Integration of  to leverage dependency injection for  and .
- Logic to sync the repository and set up its context (indexing and embedding) in Qdrant.
- Refactoring of  to use the new Cobra CLI structure.
- Adjustments to  to expose  and  as interfaces.
- Updates to  and  for new dependencies.