### PR TITLE
feat: add Smart Scan indexing optimization with auto-migration

### DIFF
--- a/cmd/cli/preload.go
+++ b/cmd/cli/preload.go
@@ -74,8 +74,9 @@ avoiding cold-start delays on large repositories.`,
 			return fmt.Errorf("failed to retrieve repository record after sync: %w", err)
 		}
 
-		fmt.Printf("Performing initial indexing and embedding... collection: %s\n", repoRecord.QdrantCollectionName)
-		err = app.RAGService.SetupRepoContext(ctx, core.DefaultRepoConfig(), repoRecord.QdrantCollectionName, repoRecord.EmbedderModelName, updateResult.RepoPath)
+		// For initial setup, we need to index everything
+		app.Logger.Info("performing full initial indexing for repository", "path", updateResult.RepoPath)
+		err = app.RAGService.SetupRepoContext(ctx, core.DefaultRepoConfig(), repoRecord, updateResult.RepoPath)
 		if err != nil {
 			return fmt.Errorf("failed to setup repository context: %w", err)
 		}

--- a/cmd/cli/review.go
+++ b/cmd/cli/review.go
@@ -238,13 +238,12 @@ func generateReview(ctx context.Context, appInstance *app.App, repo *storage.Rep
 func handleIndexing(ctx context.Context, a *app.App, syncResult *core.UpdateResult, repo *storage.Repository, timer *stepTimer) error {
 	repoPath := syncResult.RepoPath
 	collectionName := repo.QdrantCollectionName
-	embedderModel := repo.EmbedderModelName
 
 	switch {
 	case syncResult.IsInitialClone:
 		timer.infof("Performing initial full indexing")
 		timer.infof("Collection: %s", collectionName)
-		if err := a.RAGService.SetupRepoContext(ctx, nil, collectionName, embedderModel, repoPath); err != nil {
+		if err := a.RAGService.SetupRepoContext(ctx, nil, repo, repoPath); err != nil {
 			return fmt.Errorf("failed to setup repo context: %w", err)
 		}
 	case len(syncResult.FilesToAddOrUpdate) > 0 || len(syncResult.FilesToDelete) > 0:

--- a/cmd/cli/scan.go
+++ b/cmd/cli/scan.go
@@ -77,8 +77,7 @@ var scanCmd = &cobra.Command{
 			err = app.RAGService.SetupRepoContext(
 				ctx,
 				repoConfig,
-				collectionName,
-				repoRecord.EmbedderModelName,
+				repoRecord,
 				updateResult.RepoPath,
 			)
 

--- a/cmd/terminal/commands.go
+++ b/cmd/terminal/commands.go
@@ -59,8 +59,7 @@ func scanRepoCmd(app *app.App, path, repoFullName string, force bool) tea.Cmd {
 			err = app.RAGService.SetupRepoContext(
 				ctx,
 				repoConfig,
-				collectionName,
-				repoRecord.EmbedderModelName,
+				repoRecord,
 				updateResult.RepoPath,
 			)
 		} else if len(updateResult.FilesToAddOrUpdate) > 0 || len(updateResult.FilesToDelete) > 0 {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -54,6 +54,14 @@ func NewDatabase(cfg *config.DBConfig) (*DB, func(), error) {
 		DB: conn,
 	}
 
+	// Run migrations automatically on startup
+	slog.Info("running database migrations")
+	if err := db.RunMigrations(); err != nil {
+		_ = conn.Close()
+		return nil, func() {}, fmt.Errorf("failed to run migrations: %w", err)
+	}
+	slog.Info("database migrations completed successfully")
+
 	return db, func() {
 		if err := conn.Close(); err != nil {
 			slog.Error("failed to close database connection", "error", err)

--- a/internal/db/migrations/000005_create_repository_files_table.down.sql
+++ b/internal/db/migrations/000005_create_repository_files_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS repository_files;

--- a/internal/db/migrations/000005_create_repository_files_table.up.sql
+++ b/internal/db/migrations/000005_create_repository_files_table.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS repository_files (
+    id SERIAL PRIMARY KEY,
+    repository_id INTEGER NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+    file_path TEXT NOT NULL,
+    file_hash TEXT NOT NULL,
+    metadata JSONB, -- For future extensions: symbols, imports, summaries
+    last_indexed_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    UNIQUE (repository_id, file_path)
+);
+
+CREATE INDEX idx_repository_files_repo_hash ON repository_files(repository_id, file_hash);

--- a/internal/jobs/review.go
+++ b/internal/jobs/review.go
@@ -216,7 +216,7 @@ func (j *ReviewJob) updateVectorStoreAndSHA(ctx context.Context, repoConfig *cor
 	switch {
 	case updateResult.IsInitialClone:
 		j.logger.Info("Performing initial repository indexing", "repo", repo.FullName)
-		err := j.ragService.SetupRepoContext(ctx, repoConfig, repo.QdrantCollectionName, repo.EmbedderModelName, updateResult.RepoPath)
+		err := j.ragService.SetupRepoContext(ctx, repoConfig, repo, updateResult.RepoPath)
 		if err != nil {
 			return fmt.Errorf("failed to perform initial repository indexing: %w", err)
 		}


### PR DESCRIPTION
- Add repository_files table to track file hashes (migration 000005)
- Implement GetFilesForRepo, UpsertFiles, DeleteFiles in storage layer
- Refactor SetupRepoContext to skip unchanged files based on hash
- Add auto-migration on startup in NewDatabase()
- Remove debug prints and fix duplicate comments

This optimization significantly reduces re-indexing time for large repos by only processing files that have actually changed.