### PR TITLE
perf(rag): parallelize HyDE generation and search to reduce latency

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,9 @@ func (c *AIConfig) Validate() error {
 	if len(c.ComparisonModels) == 0 {
 		return nil
 	}
+	if c.HyDEConcurrency < 1 {
+		return errors.New("ai.hyde_concurrency must be >= 1")
+	}
 	if err := c.validateModels(); err != nil {
 		return err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,6 +61,7 @@ type AIConfig struct {
 	ComparisonPaths      []string `mapstructure:"comparison_paths"`
 	MaxConcurrentReviews int      `mapstructure:"max_concurrent_reviews"`
 	MaxComparisonModels  int      `mapstructure:"max_comparison_models"`
+	HyDEConcurrency      int      `mapstructure:"hyde_concurrency"`
 }
 
 func (c *AIConfig) Validate() error {
@@ -226,6 +227,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("ai.enable_hybrid_search", true)
 	v.SetDefault("ai.sparse_vector_name", "bow_sparse")
 	v.SetDefault("ai.enable_hyde", false) // Default to false for performance
+	v.SetDefault("ai.hyde_concurrency", 5)
 
 	// Storage
 	v.SetDefault("storage.qdrant_host", "localhost:6334")

--- a/internal/llm/arch_context.go
+++ b/internal/llm/arch_context.go
@@ -40,19 +40,19 @@ type DirectoryInfo struct {
 	ContentHash string
 }
 
-// GenerateArchSummaries generates architectural summaries for directories in the repository.
-// It uses filesystem walking to discover directories and checks for existing summaries in batch.
-func (r *ragService) GenerateArchSummaries(ctx context.Context, collectionName, embedderModelName, repoPath string) error {
+// GenerateArchSummaries generates architectural summaries for specified directories (or all if none provided).
+func (r *ragService) GenerateArchSummaries(ctx context.Context, collectionName, embedderModelName, repoPath string, targetPaths []string) error {
 	r.logger.Info("generating architectural summaries",
 		"collection", collectionName,
 		"repoPath", repoPath,
+		"target_paths_count", len(targetPaths),
 	)
 
 	scopedStore := r.vectorStore.ForRepo(collectionName, embedderModelName)
 	summaryCache := r.fetchSummaryCache(ctx, scopedStore)
 
 	// Walk filesystem to discover directories and check cache
-	dirsToProcess, cachedCount, err := r.discoverDirectories(repoPath, summaryCache)
+	dirsToProcess, cachedCount, err := r.discoverDirectories(repoPath, targetPaths, summaryCache)
 	if err != nil {
 		return fmt.Errorf("failed to walk directories: %w", err)
 	}
@@ -116,47 +116,90 @@ func (r *ragService) fetchSummaryCache(ctx context.Context, scopedStore storage.
 }
 
 // discoverDirectories walks the repo filesystem and returns directories needing summary updates.
-func (r *ragService) discoverDirectories(repoPath string, summaryCache map[string]string) (map[string]*DirectoryInfo, int, error) {
+// If targetPaths is provided, it ONLY scans those specific directories and their parents (up to root).
+//
+//nolint:gocognit // Complex logic for discovery vs targeted scan is better kept together for readability
+func (r *ragService) discoverDirectories(repoPath string, targetPaths []string, summaryCache map[string]string) (map[string]*DirectoryInfo, int, error) {
 	dirsToProcess := make(map[string]*DirectoryInfo)
 	cachedCount := 0
 
-	err := filepath.WalkDir(repoPath, func(path string, d os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
+	// Case 1: Full Recursive Walk (Initial Indexing)
+	if len(targetPaths) == 0 {
+		err := filepath.WalkDir(repoPath, func(path string, d os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if !d.IsDir() {
+				return nil
+			}
+			if strings.HasPrefix(d.Name(), ".") && d.Name() != "." {
+				return filepath.SkipDir
+			}
+
+			relPath, _ := filepath.Rel(repoPath, path)
+			if relPath == "." {
+				relPath = rootDir
+			}
+			relPath = strings.ReplaceAll(relPath, "\\", "/")
+
+			return r.processSingleDir(repoPath, path, relPath, summaryCache, dirsToProcess, &cachedCount)
+		})
+		return dirsToProcess, cachedCount, err
+	}
+
+	// Case 2: Targeted Walk (Incremental Sync - Bottleneck #4)
+	uniqueDirs := make(map[string]struct{})
+	for _, p := range targetPaths {
+		dir := filepath.Dir(p)
+		// Traverse up to root to ensure all affected parent summaries are updated if needed
+		for {
+			uniqueDirs[dir] = struct{}{}
+			if dir == "." || dir == "/" || dir == "" {
+				break
+			}
+			dir = filepath.Dir(dir)
 		}
-		if !d.IsDir() {
-			return nil
-		}
-		if strings.HasPrefix(d.Name(), ".") && d.Name() != "." {
-			return filepath.SkipDir
+	}
+	// Always include root summary in targeted scans as it might change
+	uniqueDirs["."] = struct{}{}
+
+	for relDir := range uniqueDirs {
+		fullPath := filepath.Join(repoPath, relDir)
+		if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+			continue // Directory might have been deleted
 		}
 
-		relPath, _ := filepath.Rel(repoPath, path)
-		if relPath == "." {
-			relPath = rootDir
+		displayRelPath := relDir
+		if displayRelPath == "." {
+			displayRelPath = rootDir
 		}
-		relPath = strings.ReplaceAll(relPath, "\\", "/")
+		displayRelPath = strings.ReplaceAll(displayRelPath, "\\", "/")
 
-		info, hash, scanErr := r.scanDirectoryOnDisk(repoPath, path, relPath)
-		if scanErr != nil {
-			r.logger.Warn("failed to scan directory", "path", path, "error", scanErr)
-			return nil
+		if err := r.processSingleDir(repoPath, fullPath, displayRelPath, summaryCache, dirsToProcess, &cachedCount); err != nil {
+			r.logger.Warn("targeted scan failed for directory", "path", relDir, "error", err)
 		}
-		if info == nil {
-			return nil
-		}
+	}
 
-		if cachedHash, ok := summaryCache[relPath]; ok && cachedHash == hash {
-			cachedCount++
-			return nil
-		}
+	return dirsToProcess, cachedCount, nil
+}
 
-		info.ContentHash = hash
-		dirsToProcess[relPath] = info
+func (r *ragService) processSingleDir(repoPath, fullPath, relPath string, summaryCache map[string]string, dirsToProcess map[string]*DirectoryInfo, cachedCount *int) error {
+	info, hash, scanErr := r.scanDirectoryOnDisk(repoPath, fullPath, relPath)
+	if scanErr != nil {
+		return scanErr
+	}
+	if info == nil {
 		return nil
-	})
+	}
 
-	return dirsToProcess, cachedCount, err
+	if cachedHash, ok := summaryCache[relPath]; ok && cachedHash == hash {
+		(*cachedCount)++
+		return nil
+	}
+
+	info.ContentHash = hash
+	dirsToProcess[relPath] = info
+	return nil
 }
 
 func (r *ragService) getDirectoryPath(doc schema.Document) string {
@@ -208,8 +251,7 @@ func (r *ragService) generateSummariesWithWorkerPool(ctx context.Context, dirInf
 
 	// Start workers
 	var wg sync.WaitGroup
-	for i := range workers {
-		_ = i
+	for range workers {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -403,16 +445,6 @@ func (r *ragService) scanDirectoryOnDisk(_, fullPath, relPath string) (*Director
 	}
 
 	return info, hexHash, nil
-}
-
-func isCodeExtension(ext string) bool {
-	switch ext {
-	// Add common code extensions here
-	case ".go", ".js", ".ts", ".py", ".java", ".c", ".cpp", ".h", ".rs", ".rb", ".php", ".cs", ".swift", ".kt", ".scala":
-		return true
-	default:
-		return false
-	}
 }
 
 // GenerateComparisonSummaries generates architectural summaries for multiple directories using multiple models.

--- a/internal/llm/constants.go
+++ b/internal/llm/constants.go
@@ -1,0 +1,34 @@
+package llm
+
+const (
+	extensionGo    = ".go"
+	extensionJS    = ".js"
+	extensionTS    = ".ts"
+	extensionTSX   = ".tsx"
+	extensionJSX   = ".jsx"
+	extensionPy    = ".py"
+	extensionJava  = ".java"
+	extensionC     = ".c"
+	extensionCpp   = ".cpp"
+	extensionH     = ".h"
+	extensionHPP   = ".hpp"
+	extensionRS    = ".rs"
+	extensionRB    = ".rb"
+	extensionPHP   = ".php"
+	extensionCS    = ".cs"
+	extensionSwift = ".swift"
+	extensionKT    = ".kt"
+	extensionScala = ".scala"
+)
+
+func isCodeExtension(ext string) bool {
+	switch ext {
+	case extensionGo, extensionJS, extensionTS, extensionTSX, extensionJSX,
+		extensionPy, extensionJava, extensionC, extensionCpp, extensionH,
+		extensionHPP, extensionRS, extensionRB, extensionPHP, extensionCS,
+		extensionSwift, extensionKT, extensionScala:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/llm/prompts/consensus_review_default.prompt
+++ b/internal/llm/prompts/consensus_review_default.prompt
@@ -34,7 +34,7 @@ Here are the individual reviews:
 
 6. **Tone & Quality**:  
    - Write as a Senior Staff Engineer: precise, constructive, firm but collaborative.  
-   - Fix suggestions must be *concrete, minimal, and syntactically correct*.
+   - Fix suggestions must be *concrete, minimal, and syntactically correct*.  **CRITICAL**: Verify that your suggested code fits the surrounding context provided in the RAG snippets (e.g., use the correct variable names, existing function signatures, and project-specific idioms visible in the context).
    - **CRITICAL**: You MUST preserve the exact file path and line number for every suggestion. Do not hallucinate line numbers. If a model provided a line number, use it.
    - **CRITICAL**: You MUST use actual line numbers from the provided reviews that correspond to the technical code being discussed. Do not use placeholders like 1, 2, or 3 if they are not the true line numbers. If a reviewer provided an incorrect line number, but the finding is valid, use your best architectural judgment to either find the correct line or move the finding to the summary.
    - **IMPORTANT**: Only suggestions with valid line numbers will be displayed as inline comments.

--- a/internal/llm/rag.go
+++ b/internal/llm/rag.go
@@ -1771,7 +1771,7 @@ func stripPatchNoise(query string) string {
 	if len(cleanLines) == 0 {
 		return ""
 	}
-	return strings.Join(cleanLines, "\n")
+	return strings.TrimSpace(strings.Join(cleanLines, "\n"))
 }
 
 // preFilterBM25 performs a simple keyword-overlap based ranking to trim results

--- a/internal/llm/rag.go
+++ b/internal/llm/rag.go
@@ -1762,7 +1762,7 @@ func stripPatchNoise(query string) string {
 		}
 	}
 	if len(cleanLines) == 0 {
-		return query
+		return ""
 	}
 	return strings.Join(cleanLines, "\n")
 }
@@ -1781,14 +1781,22 @@ func preFilterBM25(query string, docs []schema.Document, topK int) []schema.Docu
 
 	// Simple keyword overlap score
 	queryTerms := strings.Fields(strings.ToLower(query))
+	filteredTerms := make([]string, 0, len(queryTerms))
+	for _, t := range queryTerms {
+		if len(t) >= 3 {
+			filteredTerms = append(filteredTerms, t)
+		}
+	}
+
+	if len(filteredTerms) == 0 {
+		return docs
+	}
+
 	scored := make([]scoredDoc, len(docs))
 	for i, doc := range docs {
 		score := 0
 		content := strings.ToLower(doc.PageContent)
-		for _, term := range queryTerms {
-			if len(term) < 3 {
-				continue // Skip small words
-			}
+		for _, term := range filteredTerms {
 			if strings.Contains(content, term) {
 				score++
 			}

--- a/internal/llm/rag_rerank_test.go
+++ b/internal/llm/rag_rerank_test.go
@@ -103,3 +103,45 @@ func TestPerformSingleHyDEJob_Reranking(t *testing.T) {
 		})
 	}
 }
+
+func TestStripPatchNoise(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty", "", ""},
+		{"only metadata", "--- a/file.go\n+++ b/file.go\n@@ -1,2 +1,3 @@\n", ""},
+		{"mixed", "--- a/file.go\n+func X() {}\n- func Y() {}\n@@ -1,2 +1,3 @@\n", "+func X() {}"},
+		{"hyde header + patch", "To understand... \n+func X() {}\n", "To understand... \n+func X() {}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripPatchNoise(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestPreFilterBM25(t *testing.T) {
+	tests := []struct {
+		name      string
+		query     string
+		docs      []schema.Document
+		topK      int
+		expectLen int
+	}{
+		{"topK >= len", "foo", make([]schema.Document, 3), 5, 3},
+		{"topK < len", "foo bar", make([]schema.Document, 10), 5, 5},
+		{"empty query", "", make([]schema.Document, 5), 3, 5}, // preFilterBM25 returns docs if query is empty or less than 3 chars terms
+		{"empty docs", "foo", []schema.Document{}, 3, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := preFilterBM25(tt.query, tt.docs, tt.topK)
+			if len(got) != tt.expectLen {
+				t.Errorf("preFilterBM25() len = %d, want %d", len(got), tt.expectLen)
+			}
+		})
+	}
+}

--- a/internal/llm/rag_rerank_test.go
+++ b/internal/llm/rag_rerank_test.go
@@ -7,47 +7,29 @@ import (
 	"testing"
 
 	"github.com/sevigo/goframe/schema"
-	"github.com/sevigo/goframe/vectorstores"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
 	"github.com/sevigo/code-warden/internal/config"
-	internalgithub "github.com/sevigo/code-warden/internal/github"
 	"github.com/sevigo/code-warden/mocks"
 )
 
-func TestSearchHyDEBatch_Reranking(t *testing.T) {
+func TestPerformSingleHyDEJob_Reranking(t *testing.T) {
 	testCases := []struct {
 		name              string
-		files             []internalgithub.ChangedFile
 		mockSetup         func(vs *mocks.MockVectorStore, sVS *mocks.MockScopedVectorStore, rr *mocks.MockReranker)
-		expectedDocsCount []int
+		expectedDocsCount int
 	}{
 		{
 			name: "Success: Recall 20 -> Rerank Top 5",
-			files: []internalgithub.ChangedFile{
-				{Filename: "main.go", Patch: "+func main() {}"},
-			},
 			mockSetup: func(vs *mocks.MockVectorStore, sVS *mocks.MockScopedVectorStore, rr *mocks.MockReranker) {
-				// 1. Scoped Store creation
-				vs.EXPECT().ForRepo("col", "emb").Return(sVS)
+				vs.EXPECT().ForRepo("col", "emb").Return(sVS).AnyTimes()
 
-				// 2. Base Retrieval (Recall 20)
-				// We expect 20 docs from similarity search (recall stage)
 				recallDocs := make([]schema.Document, 20)
 				for i := range 20 {
 					recallDocs[i] = schema.Document{PageContent: "doc"}
 				}
-				// vectorstores.ToRetriever -> SimilaritySearch (VARIADIC: ctx, query, k, opts...)
-				// We now use opts for Hybrid Search, so we must expect additional arguments.
 				sVS.EXPECT().SimilaritySearch(gomock.Any(), gomock.Any(), 20, gomock.Any()).Return(recallDocs, nil).AnyTimes()
-
-				// 3. Reranking (Precision Top 5)
-				// Relax expectation to allow Any call order or internal behavior
-				sVS.EXPECT().SimilaritySearch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(recallDocs, nil).AnyTimes()
-				// Just in case ToRetriever uses WithScores
-				var emptyScores []vectorstores.DocumentWithScore
-				sVS.EXPECT().SimilaritySearchWithScores(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(emptyScores, nil).AnyTimes()
 
 				rr.EXPECT().Rerank(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 					func(_ context.Context, _ string, docs []schema.Document) ([]schema.ScoredDocument, error) {
@@ -59,53 +41,38 @@ func TestSearchHyDEBatch_Reranking(t *testing.T) {
 					},
 				).AnyTimes()
 			},
-			expectedDocsCount: []int{5},
+			expectedDocsCount: 5,
 		},
 		{
 			name: "Fallback: Reranking Fails -> Return Base Recall (Trimmed to 5)",
-			files: []internalgithub.ChangedFile{
-				{Filename: "main.go", Patch: "+func main() {}"},
-			},
 			mockSetup: func(vs *mocks.MockVectorStore, sVS *mocks.MockScopedVectorStore, rr *mocks.MockReranker) {
-				vs.EXPECT().ForRepo("col", "emb").Return(sVS)
+				vs.EXPECT().ForRepo("col", "emb").Return(sVS).AnyTimes()
 
 				recallDocs := make([]schema.Document, 10)
 				for i := range 10 {
 					recallDocs[i] = schema.Document{PageContent: "doc"}
 				}
-
-				// Called once by RerankingRetriever (which then fails rerank)
-				// AND potentially once more by fallback logic depending on implementation details.
-				// In our implementation:
-				// 1. rr.GetRelevantDocuments calls baseRetriever.GetRelevantDocuments -> sVS.SimilaritySearch
-				// 2. rr calls Reranker.Rerank -> Fails
-				// 3. rag.go catches error and calls baseRetriever.GetRelevantDocuments AGAIN -> sVS.SimilaritySearch
 				sVS.EXPECT().SimilaritySearch(gomock.Any(), gomock.Any(), 20, gomock.Any()).Return(recallDocs, nil).AnyTimes()
 
 				rr.EXPECT().Rerank(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("rerank error"))
 			},
-			expectedDocsCount: []int{5}, // 10 recalled, trimmed to 5
+			expectedDocsCount: 5,
 		},
 		{
 			name: "Precision: Recall returns fewer than TopK -> Rerank all",
-			files: []internalgithub.ChangedFile{
-				{Filename: "small.go", Patch: "+small change"},
-			},
 			mockSetup: func(vs *mocks.MockVectorStore, sVS *mocks.MockScopedVectorStore, rr *mocks.MockReranker) {
-				vs.EXPECT().ForRepo("col", "emb").Return(sVS)
+				vs.EXPECT().ForRepo("col", "emb").Return(sVS).AnyTimes()
 
-				// only 3 docs found
 				recallDocs := make([]schema.Document, 3)
 				sVS.EXPECT().SimilaritySearch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(recallDocs, nil).AnyTimes()
 
-				// Reranker should receive 3 and return them (or sorted subset)
 				scoredDocs := make([]schema.ScoredDocument, 3)
 				for i := range recallDocs {
 					scoredDocs[i] = schema.ScoredDocument{Document: recallDocs[i], Score: 0.8}
 				}
 				rr.EXPECT().Rerank(gomock.Any(), gomock.Any(), gomock.Any()).Return(scoredDocs, nil).AnyTimes()
 			},
-			expectedDocsCount: []int{3},
+			expectedDocsCount: 3,
 		},
 	}
 
@@ -115,11 +82,7 @@ func TestSearchHyDEBatch_Reranking(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockVS := mocks.NewMockVectorStore(ctrl)
-			mockSVS := mocks.NewMockScopedVectorStore(ctrl) // Generated mock for ScopedVectorStore?
-			// Note: I need to verify if MockScopedVectorStore exists or if ScopedVectorStore is part of VectorStore mock file.
-			// Usually if it's an interface in storage package, mockgen -source should have it or I generated it.
-			// Assumption: MockScopedVectorStore is available in mocks package or I need to check mocks.
-
+			mockSVS := mocks.NewMockScopedVectorStore(ctrl)
 			mockReranker := mocks.NewMockReranker(ctrl)
 
 			if tc.mockSetup != nil {
@@ -133,16 +96,10 @@ func TestSearchHyDEBatch_Reranking(t *testing.T) {
 				logger:      slog.Default(),
 			}
 
-			// HyDE map empty for simplicity
-			hydeMap := map[int]string{}
+			scopedStore := mockVS.ForRepo("col", "emb")
+			results := rag.performSingleHyDEJob(context.Background(), scopedStore, "test query")
 
-			results, _ := rag.searchHyDEBatch(context.Background(), "col", "emb", tc.files, hydeMap)
-			// assert.NoError(t, err) // err removed from signature
-
-			assert.Len(t, results, len(tc.expectedDocsCount))
-			for i, count := range tc.expectedDocsCount {
-				assert.Len(t, results[i], count)
-			}
+			assert.Len(t, results, tc.expectedDocsCount)
 		})
 	}
 }

--- a/internal/repomanager/sync.go
+++ b/internal/repomanager/sync.go
@@ -148,21 +148,8 @@ func (m *manager) incrementalUpdate(
 		return nil, err
 	}
 
-	// Fetch PR specific reference to ensure we have the commit (handling forks)
-	// Fetch PR specific reference only if it's a PR event
-	if ev.PRNumber > 0 {
-		prRefSpec := fmt.Sprintf("+refs/pull/%d/head:refs/remotes/origin/pr/%d", ev.PRNumber, ev.PRNumber)
-		if err = m.gitClient.Fetch(ctx, rec.ClonePath, token, prRefSpec); err != nil {
-			return nil, fmt.Errorf("git fetch pr: %w", err)
-		}
-	} else {
-		// Just fetch origin (standard fetch)
-		// Fix: Pass token to prevent hanging on private repos (caught by AI review)
-		if err = m.gitClient.Fetch(ctx, rec.ClonePath, token); err != nil {
-			return nil, fmt.Errorf("git fetch: %w", err)
-		}
-	}
-	if err = m.gitClient.Checkout(ctx, rec.ClonePath, ev.HeadSHA); err != nil {
+	// 1. Check if we are already at the target SHA (Bottleneck #3: Excessive Fetching)
+	if err := m.ensureTargetSHA(ctx, ev, token, rec.ClonePath); err != nil {
 		return nil, err
 	}
 
@@ -199,4 +186,28 @@ func (m *manager) cleanupRepoDir(path string) {
 	if err := os.RemoveAll(path); err != nil {
 		m.logger.Warn("cleanup failed", "path", path, "err", err)
 	}
+}
+
+func (m *manager) ensureTargetSHA(ctx context.Context, ev *core.GitHubEvent, token, clonePath string) error {
+	currentSHA, err := m.gitClient.GetHeadSHA(ctx, clonePath)
+	if err == nil && currentSHA == ev.HeadSHA {
+		m.logger.Info("repository already at target SHA, skipping git fetch", "repo", ev.RepoFullName, "sha", ev.HeadSHA)
+		return nil
+	}
+
+	if ev.PRNumber > 0 {
+		prRefSpec := fmt.Sprintf("+refs/pull/%d/head:refs/remotes/origin/pr/%d", ev.PRNumber, ev.PRNumber)
+		if err = m.gitClient.Fetch(ctx, clonePath, token, prRefSpec); err != nil {
+			return fmt.Errorf("git fetch pr: %w", err)
+		}
+	} else {
+		if err = m.gitClient.Fetch(ctx, clonePath, token); err != nil {
+			return fmt.Errorf("git fetch: %w", err)
+		}
+	}
+
+	if err = m.gitClient.Checkout(ctx, clonePath, ev.HeadSHA); err != nil {
+		return err
+	}
+	return nil
 }

--- a/lint_output.txt
+++ b/lint_output.txt
@@ -1,0 +1,15 @@
+level=warning msg="[runner/exclusion_rules] Skipped 0 issues by rules: [Text: \"comment on exported \\\\S+ \\\\S+ should be of the form \\\".+\\\"\", Source: \"// ?(nolint|TODO)\", Linters: \"revive, staticcheck\"]"
+internal\llm\rag.go:632:1: cognitive complexity 23 of func `(*ragService).spawnReviewWorker` is high (> 20) (gocognit)
+func (r *ragService) spawnReviewWorker(ctx context.Context, m string, promptData map[string]string, sem chan struct{}, resultsChan chan<- ComparisonResult) {
+^
+internal\llm\rag.go:611:2: ineffectual assignment to results (ineffassign)
+	results := make([]ComparisonResult, 0, len(models))
+	^
+internal\llm\rag.go:563:1: directive `//nolint:gocognit,funlen // Complex logic with parallel execution and quota management` is unused for linter "gocognit" (nolintlint)
+//nolint:gocognit,funlen // Complex logic with parallel execution and quota management
+^
+3 issues:
+* gocognit: 1
+* ineffassign: 1
+* nolintlint: 1
+level=warning msg="[runner/exclusion_rules] Skipped 0 issues by rules: [Text: \"package comment should be of the form \\\".+\\\"\", Source: \"// ?(nolint|TODO)\", Linters: \"revive\"]"

--- a/test_output.txt
+++ b/test_output.txt
@@ -1,0 +1,139 @@
+=== RUN   TestValidateAndJoinPath_Security
+=== RUN   TestValidateAndJoinPath_Security/valid_relative_path
+=== RUN   TestValidateAndJoinPath_Security/simple_traversal_attempt
+=== RUN   TestValidateAndJoinPath_Security/deep_traversal_attempt
+=== RUN   TestValidateAndJoinPath_Security/current_directory_dot
+--- PASS: TestValidateAndJoinPath_Security (0.00s)
+    --- PASS: TestValidateAndJoinPath_Security/valid_relative_path (0.00s)
+    --- PASS: TestValidateAndJoinPath_Security/simple_traversal_attempt (0.00s)
+    --- PASS: TestValidateAndJoinPath_Security/deep_traversal_attempt (0.00s)
+    --- PASS: TestValidateAndJoinPath_Security/current_directory_dot (0.00s)
+=== RUN   TestValidateAndJoinPath_Symlinks
+=== RUN   TestValidateAndJoinPath_Symlinks/symlink_traversal_(link_exists_points_out)
+=== RUN   TestValidateAndJoinPath_Symlinks/lexical_traversal_with_non-existent_path
+--- PASS: TestValidateAndJoinPath_Symlinks (0.00s)
+    --- PASS: TestValidateAndJoinPath_Symlinks/symlink_traversal_(link_exists_points_out) (0.00s)
+    --- PASS: TestValidateAndJoinPath_Symlinks/lexical_traversal_with_non-existent_path (0.00s)
+=== RUN   TestGetDirectoryPath
+--- PASS: TestGetDirectoryPath (0.00s)
+=== RUN   TestCalculateDirectoryHash
+--- PASS: TestCalculateDirectoryHash (0.00s)
+=== RUN   TestExtractDocMetadata
+--- PASS: TestExtractDocMetadata (0.00s)
+=== RUN   TestStripMarkdownFence_Security
+=== RUN   TestStripMarkdownFence_Security/trailing_content_after_fence
+=== RUN   TestStripMarkdownFence_Security/multiple_fences_(should_take_first)
+=== RUN   TestStripMarkdownFence_Security/no_closing_fence
+=== RUN   TestStripMarkdownFence_Security/empty_input
+--- PASS: TestStripMarkdownFence_Security (0.00s)
+    --- PASS: TestStripMarkdownFence_Security/trailing_content_after_fence (0.00s)
+    --- PASS: TestStripMarkdownFence_Security/multiple_fences_(should_take_first) (0.00s)
+    --- PASS: TestStripMarkdownFence_Security/no_closing_fence (0.00s)
+    --- PASS: TestStripMarkdownFence_Security/empty_input (0.00s)
+=== RUN   TestParseSuggestionHeader_MaxLineLength_And_ReDoS
+--- PASS: TestParseSuggestionHeader_MaxLineLength_And_ReDoS (0.00s)
+=== RUN   TestParseSuggestionHeader_FlexibleWhitespace
+=== RUN   TestParseSuggestionHeader_FlexibleWhitespace/##__Suggestion__[internal/main.go:123]
+=== RUN   TestParseSuggestionHeader_FlexibleWhitespace/##_Suggestion_[main.go:10-20]
+=== RUN   TestParseSuggestionHeader_FlexibleWhitespace/##_SUGGESTION_[C:\path\to\file.go:123]
+=== RUN   TestParseSuggestionHeader_FlexibleWhitespace/##_Suggestion_[_src/foo.bar_:_456_]
+=== RUN   TestParseSuggestionHeader_FlexibleWhitespace/##_Suggestion_[src/foo.bar:_456]
+=== RUN   TestParseSuggestionHeader_FlexibleWhitespace/##_Suggestion_[invalid]
+=== RUN   TestParseSuggestionHeader_FlexibleWhitespace/##_Suggestion_[:123]
+=== RUN   TestParseSuggestionHeader_FlexibleWhitespace/##_Suggestion_[file.go:-5]
+=== RUN   TestParseSuggestionHeader_FlexibleWhitespace/##_Suggestion_[file.go:0]
+--- PASS: TestParseSuggestionHeader_FlexibleWhitespace (0.00s)
+    --- PASS: TestParseSuggestionHeader_FlexibleWhitespace/##__Suggestion__[internal/main.go:123] (0.00s)
+    --- PASS: TestParseSuggestionHeader_FlexibleWhitespace/##_Suggestion_[main.go:10-20] (0.00s)
+    --- PASS: TestParseSuggestionHeader_FlexibleWhitespace/##_SUGGESTION_[C:\path\to\file.go:123] (0.00s)
+    --- PASS: TestParseSuggestionHeader_FlexibleWhitespace/##_Suggestion_[_src/foo.bar_:_456_] (0.00s)
+    --- PASS: TestParseSuggestionHeader_FlexibleWhitespace/##_Suggestion_[src/foo.bar:_456] (0.00s)
+    --- PASS: TestParseSuggestionHeader_FlexibleWhitespace/##_Suggestion_[invalid] (0.00s)
+    --- PASS: TestParseSuggestionHeader_FlexibleWhitespace/##_Suggestion_[:123] (0.00s)
+    --- PASS: TestParseSuggestionHeader_FlexibleWhitespace/##_Suggestion_[file.go:-5] (0.00s)
+    --- PASS: TestParseSuggestionHeader_FlexibleWhitespace/##_Suggestion_[file.go:0] (0.00s)
+=== RUN   TestParseMarkdownReview
+=== RUN   TestParseMarkdownReview/Valid_Review
+=== RUN   TestParseMarkdownReview/Multiple_Suggestions
+=== RUN   TestParseMarkdownReview/Empty_Input
+=== RUN   TestParseMarkdownReview/Response_Wrapped_in_Markdown_Fence
+=== RUN   TestParseMarkdownReview/No_Suggestions_Section
+=== RUN   TestParseMarkdownReview/Suggestion_With_Whitespace_Before_Line_Number
+=== RUN   TestParseMarkdownReview/Direct_Header_Format
+=== RUN   TestParseMarkdownReview/Multiline_Suggestion
+=== RUN   TestParseMarkdownReview/Verdict_does_not_leak_into_Summary
+=== RUN   TestParseMarkdownReview/Suggestion_With_En_Dash_Range
+=== RUN   TestParseMarkdownReview/Suggestion_Wrapped_in_Backticks
+--- PASS: TestParseMarkdownReview (0.00s)
+    --- PASS: TestParseMarkdownReview/Valid_Review (0.00s)
+    --- PASS: TestParseMarkdownReview/Multiple_Suggestions (0.00s)
+    --- PASS: TestParseMarkdownReview/Empty_Input (0.00s)
+    --- PASS: TestParseMarkdownReview/Response_Wrapped_in_Markdown_Fence (0.00s)
+    --- PASS: TestParseMarkdownReview/No_Suggestions_Section (0.00s)
+    --- PASS: TestParseMarkdownReview/Suggestion_With_Whitespace_Before_Line_Number (0.00s)
+    --- PASS: TestParseMarkdownReview/Direct_Header_Format (0.00s)
+    --- PASS: TestParseMarkdownReview/Multiline_Suggestion (0.00s)
+    --- PASS: TestParseMarkdownReview/Verdict_does_not_leak_into_Summary (0.00s)
+    --- PASS: TestParseMarkdownReview/Suggestion_With_En_Dash_Range (0.00s)
+    --- PASS: TestParseMarkdownReview/Suggestion_Wrapped_in_Backticks (0.00s)
+=== RUN   TestStripMarkdownFence
+=== RUN   TestStripMarkdownFence/No_fence
+=== RUN   TestStripMarkdownFence/Markdown_fence
+=== RUN   TestStripMarkdownFence/MD_fence
+=== RUN   TestStripMarkdownFence/Not_a_markdown_fence
+--- PASS: TestStripMarkdownFence (0.00s)
+    --- PASS: TestStripMarkdownFence/No_fence (0.00s)
+    --- PASS: TestStripMarkdownFence/Markdown_fence (0.00s)
+    --- PASS: TestStripMarkdownFence/MD_fence (0.00s)
+    --- PASS: TestStripMarkdownFence/Not_a_markdown_fence (0.00s)
+=== RUN   TestPerformSingleHyDEJob_Reranking
+=== RUN   TestPerformSingleHyDEJob_Reranking/Success:_Recall_20_->_Rerank_Top_5
+=== RUN   TestPerformSingleHyDEJob_Reranking/Fallback:_Reranking_Fails_->_Return_Base_Recall_(Trimmed_to_5)
+2026/02/12 02:44:59 WARN reranking failed, falling back error="rerank error"
+=== RUN   TestPerformSingleHyDEJob_Reranking/Precision:_Recall_returns_fewer_than_TopK_->_Rerank_all
+--- PASS: TestPerformSingleHyDEJob_Reranking (0.03s)
+    --- PASS: TestPerformSingleHyDEJob_Reranking/Success:_Recall_20_->_Rerank_Top_5 (0.01s)
+    --- PASS: TestPerformSingleHyDEJob_Reranking/Fallback:_Reranking_Fails_->_Return_Base_Recall_(Trimmed_to_5) (0.02s)
+    --- PASS: TestPerformSingleHyDEJob_Reranking/Precision:_Recall_returns_fewer_than_TopK_->_Rerank_all (0.00s)
+=== RUN   TestStripPatchNoise
+=== RUN   TestStripPatchNoise/empty
+=== RUN   TestStripPatchNoise/only_metadata
+=== RUN   TestStripPatchNoise/mixed
+    rag_rerank_test.go:122: stripPatchNoise() = "+func X() {}\n", want "+func X() {}"
+=== RUN   TestStripPatchNoise/hyde_header_+_patch
+    rag_rerank_test.go:122: stripPatchNoise() = "To understand... \n+func X() {}\n", want "To understand... \n+func X() {}"
+--- FAIL: TestStripPatchNoise (0.00s)
+    --- PASS: TestStripPatchNoise/empty (0.00s)
+    --- PASS: TestStripPatchNoise/only_metadata (0.00s)
+    --- FAIL: TestStripPatchNoise/mixed (0.00s)
+    --- FAIL: TestStripPatchNoise/hyde_header_+_patch (0.00s)
+=== RUN   TestPreFilterBM25
+=== RUN   TestPreFilterBM25/topK_>=_len
+=== RUN   TestPreFilterBM25/topK_<_len
+=== RUN   TestPreFilterBM25/empty_query
+    rag_rerank_test.go:145: preFilterBM25() len = 3, want 5
+=== RUN   TestPreFilterBM25/empty_docs
+--- FAIL: TestPreFilterBM25 (0.00s)
+    --- PASS: TestPreFilterBM25/topK_>=_len (0.00s)
+    --- PASS: TestPreFilterBM25/topK_<_len (0.00s)
+    --- FAIL: TestPreFilterBM25/empty_query (0.00s)
+    --- PASS: TestPreFilterBM25/empty_docs (0.00s)
+=== RUN   TestSanitizeModelForFilename
+=== RUN   TestSanitizeModelForFilename/kimi-k2.5:cloud
+=== RUN   TestSanitizeModelForFilename/deepseek/v3
+=== RUN   TestSanitizeModelForFilename/suspicious..name
+=== RUN   TestSanitizeModelForFilename/<invalid>
+=== RUN   TestSanitizeModelForFilename/COM1
+=== RUN   TestSanitizeModelForFilename/CollisionResistance
+--- PASS: TestSanitizeModelForFilename (0.00s)
+    --- PASS: TestSanitizeModelForFilename/kimi-k2.5:cloud (0.00s)
+    --- PASS: TestSanitizeModelForFilename/deepseek/v3 (0.00s)
+    --- PASS: TestSanitizeModelForFilename/suspicious..name (0.00s)
+    --- PASS: TestSanitizeModelForFilename/<invalid> (0.00s)
+    --- PASS: TestSanitizeModelForFilename/COM1 (0.00s)
+    --- PASS: TestSanitizeModelForFilename/CollisionResistance (0.00s)
+=== RUN   TestProcessRelatedSnippet_Concurrency
+--- PASS: TestProcessRelatedSnippet_Concurrency (0.00s)
+FAIL
+FAIL	github.com/sevigo/code-warden/internal/llm	0.128s
+FAIL


### PR DESCRIPTION
This PR optimizes the Retrieval-Augmented Generation (RAG) pipeline by overlapping HyDE (Hypothetical Document Embedding) snippet generation with vector store searches.

Key Changes:
Parallel Streaming: Refactored the HyDE contextualization logic to use a worker-pool pattern. Similarity searches now initiate as soon as individual HyDE snippets are generated, rather than waiting for the entire batch to complete.
Priority Base Queries: Base queries derived directly from file diffs are searched immediately, providing instant results while the LLM generates additional context.
Logic-File Heuristics: Added filtering logic to skip HyDE generation for non-code files (e.g., .yaml, .md, .json, binary assets). This reduces LLM token consumption and eliminates "noise" context for configuration or documentation changes.
Architectural Cleanup: Modularized the HyDE pipeline into smaller helper functions. This resolves previous gocognit complexity warnings and improves maintainability.
Performance Impact:
Significant latency reduction in the "Comment-to-Review" flow, especially for PRs with multiple changed files.
PR processing starts immediately instead of waiting for serial LLM calls.