### PR TITLE
fix: resolve critical indexing corruption, narrow mutex scope, and improve RAG quality

### DIFF
--- a/internal/core/repomanager.go
+++ b/internal/core/repomanager.go
@@ -6,6 +6,18 @@ type UpdateResult struct {
 	FilesToDelete      []string
 	RepoPath           string
 	RepoFullName       string
-	HeadSHA            string
-	IsInitialClone     bool
+
+	// HeadSHA is the PR's head SHA — used for logging and DB records only.
+	// It is never written to Qdrant; only DefaultBranchSHA is indexed.
+	HeadSHA string
+
+	// DefaultBranchSHA is the SHA of the default branch (main) that was synced.
+	// This is what gets persisted as LastIndexedSHA in the database.
+	DefaultBranchSHA string
+
+	// DefaultBranchChanged is true when the default branch advanced since the
+	// last indexed SHA, meaning the Qdrant collection must be updated.
+	DefaultBranchChanged bool
+
+	IsInitialClone bool
 }

--- a/internal/gitutil/cloner.go
+++ b/internal/gitutil/cloner.go
@@ -125,6 +125,21 @@ func (c *Client) Checkout(ctx context.Context, path string, sha string) error {
 	return nil
 }
 
+// ResetToUpstream forcefully resets the current branch to match its remote tracking branch.
+// This is necessary because Fetch only updates remote refs (like origin/main), while the
+// local working tree pointer remains unchanged until specifically moved via merge or reset.
+func (c *Client) ResetToUpstream(ctx context.Context, path string) error {
+	c.Logger.InfoContext(ctx, "resetting worktree to upstream tracking branch")
+
+	cmd := exec.CommandContext(ctx, "git", "-c", "core.longpaths=true", "reset", "--hard", "@{u}")
+	cmd.Dir = path
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git reset --hard @{u} failed: %s: %w", string(out), err)
+	}
+	return nil
+}
+
 // GetRemoteHeadSHA fetches the HEAD commit SHA of a specific remote branch without cloning.
 func (c *Client) GetRemoteHeadSHA(repoURL, branch, token string) (string, error) {
 	authURL, err := c.getAuthenticatedURL(repoURL, token)

--- a/internal/jobs/review.go
+++ b/internal/jobs/review.go
@@ -67,10 +67,6 @@ func (j *ReviewJob) Run(ctx context.Context, event *core.GitHubEvent) error {
 		return err
 	}
 
-	mutex := j.getRepoMutex(event.RepoFullName)
-	mutex.Lock()
-	defer mutex.Unlock()
-
 	switch event.Type {
 	case core.FullReview:
 		return j.runFullReview(ctx, event)
@@ -135,8 +131,7 @@ func (j *ReviewJob) executeReReviewWorkflow(ctx context.Context, event *core.Git
 	// Update reReviewContent for DB save
 	reReviewContent := structuredReview.Summary
 
-	// 5. Save the re-review as a new review record?
-	// Yes, to maintain history.
+	// 5. Save the re-review as a new review record? Yes, to maintain history.
 	dbReview := &core.Review{
 		RepoFullName:  event.RepoFullName,
 		PRNumber:      event.PRNumber,
@@ -193,26 +188,55 @@ type reviewEnvironment struct {
 	repoConfig    *core.RepoConfig
 }
 
-// setupReviewEnvironment initializes clients, syncs the repo, and loads all necessary configs.
+// setupReviewEnvironment initializes clients, syncs the repo to the default branch,
+// and loads all necessary configs. The repo mutex is held only for this phase to
+// prevent concurrent git operations on the same repo. It is released before any
+// LLM call so multiple PRs can generate reviews concurrently.
 func (j *ReviewJob) setupReviewEnvironment(ctx context.Context, event *core.GitHubEvent, title, summary string) (*reviewEnvironment, error) {
 	ghClient, ghToken, statusUpdater, checkRunID, err := j.setupReview(ctx, event, title, summary)
 	if err != nil {
 		return nil, err
 	}
 
-	updateResult, err := j.repoMgr.SyncRepo(ctx, event, ghToken)
-	if err != nil {
-		err = fmt.Errorf("failed to sync repository: %w", err)
-		j.updateStatusOnError(ctx, statusUpdater, event, checkRunID, err)
-		return nil, err
+	// ── Mutex: protect only the Git sync + optional Qdrant update phase ──────
+	// The lock is acquired here and released at the end of this function.
+	// GenerateReview (LLM call) runs completely outside the lock.
+	mutex := j.getRepoMutex(event.RepoFullName)
+	mutex.Lock()
+
+	updateResult, syncErr := j.repoMgr.SyncRepo(ctx, event, ghToken)
+	if syncErr != nil {
+		mutex.Unlock() // release before error return
+		syncErr = fmt.Errorf("failed to sync repository: %w", syncErr)
+		j.updateStatusOnError(ctx, statusUpdater, event, checkRunID, syncErr)
+		return nil, syncErr
 	}
 
-	repo, err := j.repoMgr.GetRepoRecord(ctx, event.RepoFullName)
-	if err != nil || repo == nil {
-		err = fmt.Errorf("failed to retrieve repository record after sync for %s: %w", event.RepoFullName, err)
-		j.updateStatusOnError(ctx, statusUpdater, event, checkRunID, err)
-		return nil, err
+	repo, repoErr := j.repoMgr.GetRepoRecord(ctx, event.RepoFullName)
+	if repoErr != nil || repo == nil {
+		mutex.Unlock()
+		repoErr = fmt.Errorf("failed to retrieve repository record after sync for %s: %w", event.RepoFullName, repoErr)
+		j.updateStatusOnError(ctx, statusUpdater, event, checkRunID, repoErr)
+		return nil, repoErr
 	}
+
+	// Update vector store only when the default branch has new commits.
+	// PR diffs are NEVER written to Qdrant; they are passed in-memory to the LLM.
+	if updateResult.IsInitialClone || updateResult.DefaultBranchChanged {
+		if vsErr := j.updateVectorStoreAndSHA(ctx, j.loadAndProcessRepoConfig(updateResult.RepoPath, event.RepoFullName), repo, updateResult); vsErr != nil {
+			mutex.Unlock()
+			j.updateStatusOnError(ctx, statusUpdater, event, checkRunID, vsErr)
+			return nil, vsErr
+		}
+	} else {
+		j.logger.Info("default branch unchanged — skipping Qdrant update, running review off existing index",
+			"repo", event.RepoFullName,
+			"default_branch_sha", updateResult.DefaultBranchSHA,
+		)
+	}
+
+	// ── Release lock before any LLM call ─────────────────────────────────────
+	mutex.Unlock()
 
 	repoConfig := j.loadAndProcessRepoConfig(updateResult.RepoPath, event.RepoFullName)
 
@@ -226,12 +250,9 @@ func (j *ReviewJob) setupReviewEnvironment(ctx context.Context, event *core.GitH
 	}, nil
 }
 
-// processRepository handles vector store updates and the actual review generation.
+// processRepository fetches the PR diff and changed files from GitHub, validates them,
+// and runs the LLM-based review. The Qdrant index is NOT modified here.
 func (j *ReviewJob) processRepository(ctx context.Context, event *core.GitHubEvent, env *reviewEnvironment) (*core.StructuredReview, string, map[string]map[int]struct{}, error) {
-	if err := j.updateVectorStoreAndSHA(ctx, env.repoConfig, env.repo, env.updateResult); err != nil {
-		return nil, "", nil, err
-	}
-
 	// Fetch diff and changed files once — used for both validation and review generation
 	diff, err := env.ghClient.GetPullRequestDiff(ctx, event.RepoOwner, event.RepoName, event.PRNumber)
 	if err != nil {
@@ -376,7 +397,9 @@ func truncateTitle(title string, maxLen int) string {
 	return title[:maxLen-3] + "..."
 }
 
-// updateVectorStoreAndSHA performs the indexing of changed files.
+// updateVectorStoreAndSHA performs incremental indexing of the default branch changes.
+// It persists DefaultBranchSHA (not the PR HeadSHA) as LastIndexedSHA to keep
+// the Qdrant baseline aligned with main.
 func (j *ReviewJob) updateVectorStoreAndSHA(ctx context.Context, repoConfig *core.RepoConfig, repo *storage.Repository, updateResult *core.UpdateResult) error {
 	switch {
 	case updateResult.IsInitialClone:
@@ -387,7 +410,11 @@ func (j *ReviewJob) updateVectorStoreAndSHA(ctx context.Context, repoConfig *cor
 		}
 
 	case len(updateResult.FilesToAddOrUpdate) > 0 || len(updateResult.FilesToDelete) > 0:
-		j.logger.Info("⚡ Incremental update required", "repo", repo.FullName, "changed_files", len(updateResult.FilesToAddOrUpdate))
+		j.logger.Info("⚡ Incremental update required (default branch advanced)",
+			"repo", repo.FullName,
+			"changed_files", len(updateResult.FilesToAddOrUpdate),
+			"deleted_files", len(updateResult.FilesToDelete),
+		)
 		err := j.ragService.UpdateRepoContext(ctx, repoConfig, repo, updateResult.RepoPath, updateResult.FilesToAddOrUpdate, updateResult.FilesToDelete)
 		if err != nil {
 			return fmt.Errorf("failed to update repository context in vector store: %w", err)
@@ -397,9 +424,20 @@ func (j *ReviewJob) updateVectorStoreAndSHA(ctx context.Context, repoConfig *cor
 		j.logger.Info("✅ Repository up-to-date. Skipping Scan.", "repo", repo.FullName)
 	}
 
-	if err := j.repoMgr.UpdateRepoSHA(ctx, repo.FullName, updateResult.HeadSHA); err != nil {
+	// Persist the DEFAULT BRANCH SHA (not the PR HeadSHA) so the next sync
+	// correctly computes the incremental diff against main.
+	shaToStore := updateResult.DefaultBranchSHA
+	if shaToStore == "" {
+		// Defensive fallback — should not happen with the new sync logic
+		shaToStore = updateResult.HeadSHA
+		j.logger.Warn("DefaultBranchSHA was empty, falling back to HeadSHA for persistence",
+			"repo", repo.FullName,
+		)
+	}
+
+	if err := j.repoMgr.UpdateRepoSHA(ctx, repo.FullName, shaToStore); err != nil {
 		j.logger.Error("CRITICAL: Vector store updated but failed to persist new SHA in database.",
-			"error", err, "repo", repo.FullName, "new_sha", updateResult.HeadSHA)
+			"error", err, "repo", repo.FullName, "new_sha", shaToStore)
 		return fmt.Errorf("CRITICAL: failed to update last indexed SHA after vector store update: %w", err)
 	}
 

--- a/internal/llm/prompt_manager.go
+++ b/internal/llm/prompt_manager.go
@@ -15,16 +15,17 @@ var promptFiles embed.FS
 type PromptKey string
 
 const (
-	CodeReviewPrompt        PromptKey = "code_review"
-	CodeGenerationPrompt    PromptKey = "code_generation"
-	ReReviewPrompt          PromptKey = "rereview"
-	ArchSummaryPrompt       PromptKey = "arch_summary"
-	QuestionPrompt          PromptKey = "question"
-	HyDEPrompt              PromptKey = "hyde_code"
-	ConsensusReviewPrompt   PromptKey = "consensus_review"
-	ValidateSnippetPrompt   PromptKey = "validate_snippet"
-	IntentExtractionPrompt  PromptKey = "intent_extraction"
-	ReuseVerificationPrompt PromptKey = "reuse_verification"
+	CodeReviewPrompt            PromptKey = "code_review"
+	CodeGenerationPrompt        PromptKey = "code_generation"
+	ReReviewPrompt              PromptKey = "rereview"
+	ArchSummaryPrompt           PromptKey = "arch_summary"
+	QuestionPrompt              PromptKey = "question"
+	HyDEPrompt                  PromptKey = "hyde_code"
+	ConsensusReviewPrompt       PromptKey = "consensus_review"
+	ValidateSnippetPrompt       PromptKey = "validate_snippet"
+	ValidateSnippetsBatchPrompt PromptKey = "validate_snippets_batch"
+	IntentExtractionPrompt      PromptKey = "intent_extraction"
+	ReuseVerificationPrompt     PromptKey = "reuse_verification"
 )
 
 type PromptManager struct {

--- a/internal/llm/prompts/validate_snippets_batch.prompt
+++ b/internal/llm/prompts/validate_snippets_batch.prompt
@@ -1,0 +1,15 @@
+You are a code relevance validator. Evaluate each numbered snippet below.
+
+PR Description / Context:
+{{.context}}
+
+Snippets to evaluate ({{.count}} total):
+{{.snippets}}
+
+For EACH snippet, decide: does it contain code relevant to the PR context?
+- Consider: Does it interact with changed functionality? Show related types/patterns? Would a developer need it to understand the changes?
+
+Respond ONLY with a JSON object mapping snippet index (as string) to boolean:
+{"0": true, "1": false, "2": true, ...}
+
+Include an entry for every index from 0 to {{.count}} minus 1.

--- a/internal/rag/rag_context.go
+++ b/internal/rag/rag_context.go
@@ -21,42 +21,138 @@ import (
 )
 
 func (r *ragService) buildContextForPrompt(docs []schema.Document) string {
-	var contextBuilder strings.Builder
-	seenDocs := make(map[string]struct{})
+	if len(docs) == 0 {
+		return ""
+	}
 
+	// ── Dedup by key ─────────────────────────────────────────────────────────
+	seenDocs := make(map[string]struct{})
+	unique := docs[:0]
 	for _, doc := range docs {
-		docKey := r.getDocKey(doc)
-		if _, exists := seenDocs[docKey]; exists {
+		key := r.getDocKey(doc)
+		if _, exists := seenDocs[key]; exists {
 			continue
 		}
-		seenDocs[docKey] = struct{}{}
+		seenDocs[key] = struct{}{}
+		unique = append(unique, doc)
+	}
 
+	// ── Group by source file ──────────────────────────────────────────────────
+	type fileEntry struct {
+		source string
+		docs   []schema.Document
+	}
+	order := make([]string, 0, len(unique))
+	groups := make(map[string]*fileEntry)
+	for _, doc := range unique {
 		source, _ := doc.Metadata["source"].(string)
-		contextBuilder.WriteString("---\n")
-		contextBuilder.WriteString(fmt.Sprintf("File: %s\n", source))
+		if _, seen := groups[source]; !seen {
+			order = append(order, source)
+			groups[source] = &fileEntry{source: source}
+		}
+		groups[source].docs = append(groups[source].docs, doc)
+	}
 
-		if pkg, ok := doc.Metadata["package_name"].(string); ok && pkg != "" {
+	var contextBuilder strings.Builder
+	for _, src := range order {
+		entry := groups[src]
+		contextBuilder.WriteString("---\n")
+		contextBuilder.WriteString(fmt.Sprintf("File: %s\n", src))
+
+		// Print package/identifier from the first doc in the group
+		first := entry.docs[0]
+		if pkg, ok := first.Metadata["package_name"].(string); ok && pkg != "" {
 			contextBuilder.WriteString(fmt.Sprintf("Package: %s\n", pkg))
 		}
-
-		if identifier, _ := doc.Metadata["identifier"].(string); identifier != "" {
-			if parentID, _ := doc.Metadata["parent_id"].(string); parentID == "" {
+		if identifier, _ := first.Metadata["identifier"].(string); identifier != "" {
+			if parentID, _ := first.Metadata["parent_id"].(string); parentID == "" {
 				contextBuilder.WriteString(fmt.Sprintf("Identifier: %s\n", identifier))
 			}
 		}
 
 		contextBuilder.WriteString("\n")
-		contextBuilder.WriteString(r.getDocContent(doc))
+		contextBuilder.WriteString(mergeChunksForFile(entry.docs, r))
 		contextBuilder.WriteString("\n---\n\n")
 	}
 	return contextBuilder.String()
 }
 
+// mergeChunksForFile merges consecutive chunks from the same source file,
+// removing overlapping text to produce a single continuous code block.
+// This prevents token waste and confusing duplicate snippets for the LLM.
+func mergeChunksForFile(docs []schema.Document, r *ragService) string {
+	if len(docs) == 1 {
+		return r.getDocContent(docs[0])
+	}
+
+	var merged strings.Builder
+	merged.WriteString(r.getDocContent(docs[0]))
+
+	for i := 1; i < len(docs); i++ {
+		prev := merged.String()
+		curr := r.getDocContent(docs[i])
+
+		// Try to detect and remove the overlapping prefix
+		overlapStart := findOverlapStart(prev, curr)
+		if overlapStart > 0 {
+			// curr[0:overlapStart] is already present at the end of prev
+			merged.WriteString(curr[overlapStart:])
+		} else {
+			merged.WriteString("\n")
+			merged.WriteString(curr)
+		}
+	}
+	return merged.String()
+}
+
+// findOverlapStart returns the length of the longest suffix of prev that is
+// also a prefix of curr. Checks overlaps of up to 300 characters.
+func findOverlapStart(prev, curr string) int {
+	const maxOverlap = 300
+	overlap := len(prev)
+	if overlap > maxOverlap {
+		overlap = maxOverlap
+		prev = prev[len(prev)-overlap:]
+	}
+	// Also cap at len(curr) to avoid out-of-bounds on curr[:size]
+	if overlap > len(curr) {
+		overlap = len(curr)
+	}
+	// Walk from largest possible overlap down to min 10 chars
+	for size := overlap; size >= 10; size-- {
+		if strings.HasSuffix(prev, curr[:size]) {
+			return size
+		}
+	}
+	return 0
+}
+
+// filterAddedLines extracts only the added ('+') lines from a git patch string,
+// stripping the leading '+' character. Lines starting with '+++' (file header) are excluded.
+// This prevents regex symbol extraction from matching deleted ('-') lines, which could
+// produce stale or incorrect symbol names.
+func filterAddedLines(patch string) string {
+	lines := strings.Split(patch, "\n")
+	var added []string
+	for _, line := range lines {
+		if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "++") {
+			added = append(added, line[1:]) // Strip the leading '+'
+		}
+	}
+	return strings.Join(added, "\n")
+}
+
 // extractSymbolsFromPatch extracts potential type/function names from a git patch.
-// Uses pre-compiled regexes for performance. This is a simple regex-based extraction
-// until ExtractUsedSymbols is available in GoFrame.
+// IMPORTANT: Only added lines ('+') are processed to avoid matching deleted symbols.
+// Uses pre-compiled regexes for performance.
 func extractSymbolsFromPatch(patch string) []string {
 	symbols := make(map[string]struct{})
+
+	// Only extract from added lines — never from deleted lines.
+	addedOnly := filterAddedLines(patch)
+	if addedOnly == "" {
+		return nil
+	}
 
 	// Use pre-compiled regexes from package level
 	patterns := []*regexp.Regexp{
@@ -68,7 +164,7 @@ func extractSymbolsFromPatch(patch string) []string {
 	}
 
 	for _, re := range patterns {
-		matches := re.FindAllStringSubmatch(patch, -1)
+		matches := re.FindAllStringSubmatch(addedOnly, -1)
 		for _, match := range matches {
 			if len(match) > 1 && len(match[1]) > 1 {
 				symbols[match[1]] = struct{}{}
@@ -326,9 +422,12 @@ func (r *ragService) resolveSymbolDefinition(ctx context.Context, symbol string,
 
 // buildRelevantContext performs similarity searches using file diffs to find related
 // code snippets from the repository. These results provide context to help the LLM
-// better understand the scope and impact of the changes. Duplicate entries are avoided.
-// It also fetches architectural summaries for the affected directories.
-// Returns the combined context string and the definitions context separately.
+// better understand the scope and impact of the changes.
+//
+// Design note (Issue #4 fix): gatherers now return []schema.Document instead of
+// pre-formatted strings. Deduplication and formatting happen in a single-threaded
+// pass after wg.Wait(), making the output fully deterministic regardless of which
+// goroutine wins a race to a shared doc.
 func (r *ragService) buildRelevantContext(ctx context.Context, collectionName, embedderModelName, repoPath string, changedFiles []internalgithub.ChangedFile, prDescription string) (string, string) {
 	if len(changedFiles) == 0 {
 		return "", ""
@@ -342,16 +441,18 @@ func (r *ragService) buildRelevantContext(ctx context.Context, collectionName, e
 	}
 
 	scopedStore := r.vectorStore.ForRepo(collectionName, embedderModelName)
-	var seenDocsMu sync.RWMutex
-	seenDocs := make(map[string]struct{})
 
-	// Run context gathering in parallel for lower latency
+	// Run context gathering concurrently. Each gatherer returns raw docs or a
+	// self-contained string (for arch and definitions which have their own
+	// dedup/formatting logic that doesn't share state with other stages).
 	var wg sync.WaitGroup
-	var archContext, impactContext, descriptionContext string
+	var archContext, definitionsContext string
+	var impactDocs, descDocs []schema.Document
 	var hydeResults [][]schema.Document
 	var indices []int
+	var impactMu, descMu sync.Mutex
 
-	// 1. Architectural Context
+	// 1. Architectural Context (returns formatted string — no shared state)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -369,39 +470,125 @@ func (r *ragService) buildRelevantContext(ctx context.Context, collectionName, e
 		r.logger.Info("stage skipped", "name", "HyDE", "reason", "disabled_in_config")
 	}
 
-	// 3. Impact Context
+	// 3. Impact Context — returns []schema.Document (no shared seenDocs)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		impactContext = r.gatherImpactContext(ctx, scopedStore, repoPath, changedFiles, seenDocs, &seenDocsMu)
+		docs := r.gatherImpactDocs(ctx, scopedStore, repoPath, changedFiles)
+		impactMu.Lock()
+		impactDocs = append(impactDocs, docs...)
+		impactMu.Unlock()
 	}()
 
-	// 4. Description Context (MultiQuery)
+	// 4. Description Context — returns []schema.Document (no shared seenDocs)
 	if prDescription != "" {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			descriptionContext = r.gatherDescriptionContext(ctx, collectionName, embedderModelName, prDescription, seenDocs, &seenDocsMu)
+			docs := r.gatherDescriptionDocs(ctx, collectionName, embedderModelName, prDescription)
+			descMu.Lock()
+			descDocs = append(descDocs, docs...)
+			descMu.Unlock()
 		}()
 	}
 
-	// 5. Symbol Resolution (Definitions)
-	var definitionsContext string
+	// 5. Symbol Resolution — returns formatted string (its own internal dedup)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		definitionsContext = r.gatherDefinitionsContext(ctx, scopedStore, changedFiles, seenDocs, &seenDocsMu)
+		// gatherDefinitionsContext owns its seenDocs internally
+		seenDocs := make(map[string]struct{})
+		var mu sync.RWMutex
+		definitionsContext = r.gatherDefinitionsContext(ctx, scopedStore, changedFiles, seenDocs, &mu)
 	}()
 
 	wg.Wait()
 
-	// Assemble and return the combined context from all stages.
-	fullContext := r.assembleContext(archContext, impactContext, descriptionContext, definitionsContext, hydeResults, indices, changedFiles, seenDocs, &seenDocsMu)
+	// ── Single-threaded deterministic dedup & formatting ──────────────────────
+	// Merge impact + description docs, deduplicate by key (sorted for determinism),
+	// then validate snippets against the PR description in one batch call.
+	allDocs := mergeAndDedup(append(impactDocs, descDocs...), r.getDocKey)
+
+	// Validate description-relevant docs in a single batch LLM call (Issue #6 fix
+	// is applied here via validateAndFormatSnippets which now uses batch validation).
+	var impactContext, descriptionContext string
+	if len(allDocs) > 0 {
+		var seenDocs sync.Map
+		impactContext, descriptionContext = r.splitAndFormatDocs(ctx, allDocs, impactDocs, descDocs, prDescription, &seenDocs)
+	}
+
+	// Assemble the final context string with token budget enforcement.
+	fullContext := r.assembleContext(archContext, impactContext, descriptionContext, definitionsContext, hydeResults, indices, changedFiles)
 	return fullContext, definitionsContext
 }
 
-// gatherDescriptionContext uses MultiQuery retrieval to find code related to the PR description.
-func (r *ragService) gatherDescriptionContext(ctx context.Context, collection, embedder, description string, seen map[string]struct{}, mu *sync.RWMutex) string {
+// mergeAndDedup merges document slices and deduplicates them by a key function.
+// The output order is deterministic: docs are sorted by key after dedup.
+func mergeAndDedup(docs []schema.Document, keyFn func(schema.Document) string) []schema.Document {
+	seen := make(map[string]schema.Document, len(docs))
+	for _, d := range docs {
+		key := keyFn(d)
+		if _, exists := seen[key]; !exists {
+			seen[key] = d
+		}
+	}
+	unique := make([]schema.Document, 0, len(seen))
+	for _, d := range seen {
+		unique = append(unique, d)
+	}
+	sort.Slice(unique, func(i, j int) bool {
+		si, _ := unique[i].Metadata["source"].(string)
+		sj, _ := unique[j].Metadata["source"].(string)
+		return si < sj
+	})
+	return unique
+}
+
+// splitAndFormatDocs splits merged docs back into impact/description buckets and formats them.
+func (r *ragService) splitAndFormatDocs(
+	ctx context.Context,
+	allDocs []schema.Document,
+	impactDocs, descDocs []schema.Document,
+	prDescription string,
+	seen *sync.Map,
+) (impactContext, descriptionContext string) {
+	// Build a quick lookup of which keys were originally in descDocs.
+	descKeys := make(map[string]struct{}, len(descDocs))
+	for _, d := range descDocs {
+		source, _ := d.Metadata["source"].(string)
+		descKeys[source] = struct{}{}
+	}
+
+	var impactBuilder, descBuilder strings.Builder
+
+	for _, doc := range allDocs {
+		source, _ := doc.Metadata["source"].(string)
+		if _, loaded := seen.LoadOrStore(source, struct{}{}); loaded {
+			continue
+		}
+		content := r.getDocContent(doc)
+		if _, inDesc := descKeys[source]; inDesc && prDescription != "" {
+			descBuilder.WriteString(fmt.Sprintf("File: %s\n```\n%s\n```\n\n", source, content))
+		} else {
+			_ = impactDocs // suppress unused warning
+			fmt.Fprintf(&impactBuilder, "**%s**:\n```\n%s\n```\n\n", source, content)
+		}
+	}
+
+	if descBuilder.Len() > 0 {
+		var h strings.Builder
+		h.WriteString("# Related to PR Description\n\n")
+		h.WriteString(descBuilder.String())
+		descriptionContext = h.String()
+	}
+
+	impactContext = impactBuilder.String()
+	return
+}
+
+// gatherDescriptionDocs uses MultiQuery retrieval to find documents related to the PR description.
+// Returns raw []schema.Document for deterministic dedup in the caller.
+func (r *ragService) gatherDescriptionDocs(ctx context.Context, collection, embedder, description string) []schema.Document {
 	r.logger.Info("stage started", "name", "DescriptionContext")
 
 	scopedStore := r.vectorStore.ForRepo(collection, embedder)
@@ -433,29 +620,16 @@ func (r *ragService) gatherDescriptionContext(ctx context.Context, collection, e
 	allDocs, err := retriever.GetRelevantDocuments(ctx, description)
 	if err != nil {
 		r.logger.Warn("multi-query retrieval failed", "error", err)
-		return ""
+		return nil
 	}
 
-	// Deduplicate by parent-aware key
-	uniqueDocs := make(map[string]schema.Document)
-	for _, d := range allDocs {
-		uniqueDocs[r.getDocKey(d)] = d
-	}
-
-	var builder strings.Builder
-	if len(uniqueDocs) > 0 {
-		builder.WriteString("# Related to PR Description\n\n")
-		builder.WriteString(r.validateAndFormatSnippets(ctx, description, uniqueDocs, seen, mu))
-	}
-
-	r.logger.Info("stage completed", "name", "DescriptionContext", "unique_snippets", len(uniqueDocs))
-	return builder.String()
+	r.logger.Info("stage completed", "name", "DescriptionContext", "retrieved", len(allDocs))
+	return allDocs
 }
 
 // validateSnippetRelevance uses a fast LLM to check if a retrieved snippet
 // is actually relevant to the given context. Fails open (returns true) if
 // the validator model is unavailable or returns an error.
-// Uses goframe's LLMChain pattern with structured JSON output parsing.
 func (r *ragService) validateSnippetRelevance(ctx context.Context, snippet, prContext string) bool {
 	validatorLLM, err := r.getOrCreateLLM(r.cfg.AI.FastModel)
 	if err != nil {
@@ -466,78 +640,79 @@ func (r *ragService) validateSnippetRelevance(ctx context.Context, snippet, prCo
 	return validator.validate(ctx, snippet, prContext)
 }
 
-func (r *ragService) gatherArchContext(ctx context.Context, store storage.ScopedVectorStore, files []internalgithub.ChangedFile) string {
+func (r *ragService) gatherArchContext(ctx context.Context, store storage.ScopedVectorStore, files []internalgithub.ChangedFile) string { //nolint:unused
 	r.logger.Info("stage started", "name", "ArchitecturalContext")
 	ac := r.getArchContext(ctx, store, files)
 	r.logger.Info("stage completed", "name", "ArchitecturalContext")
 	return ac
 }
 
-func (r *ragService) gatherImpactContext(ctx context.Context, store storage.ScopedVectorStore, repoPath string, files []internalgithub.ChangedFile, seen map[string]struct{}, mu *sync.RWMutex) string {
+// gatherImpactDocs returns raw impact docs without formatting or shared seenDocs.
+// Replaces gatherImpactContext: dedup now happens after wg.Wait() in the caller.
+func (r *ragService) gatherImpactDocs(ctx context.Context, store storage.ScopedVectorStore, repoPath string, files []internalgithub.ChangedFile) []schema.Document {
 	r.logger.Info("stage started", "name", "ImpactAnalysis")
-	ic := r.getImpactContext(ctx, store, repoPath, files, seen, mu)
-	r.logger.Info("stage completed", "name", "ImpactAnalysis")
-	return ic
+	docs := r.getImpactDocs(ctx, store, repoPath, files)
+	r.logger.Info("stage completed", "name", "ImpactAnalysis", "docs", len(docs))
+	return docs
 }
 
-func (r *ragService) assembleContext(arch, impact, description, definitions string, hyde [][]schema.Document, indices []int, files []internalgithub.ChangedFile, seen map[string]struct{}, mu *sync.RWMutex) string {
-	var contextBuilder strings.Builder
+// assembleContext assembles the final prompt context from all gathered sections,
+// applying a token budget to prevent context window overflow (Issue #3).
+// Priority order (high → low): definitions → description → impact → arch → hyde.
+func (r *ragService) assembleContext(
+	arch, impact, description, definitions string,
+	hyde [][]schema.Document, indices []int,
+	files []internalgithub.ChangedFile,
+) string {
+	const tokenBudget = 6000
+	packer := newTokenContextPacker(tokenBudget)
 
-	if arch != "" {
-		contextBuilder.WriteString("# Architectural Context\n\n")
-		contextBuilder.WriteString("The following describes the purpose of the affected modules:\n\n")
-		contextBuilder.WriteString(arch)
-		contextBuilder.WriteString("\n---\n\n")
-	}
-
-	if description != "" {
-		contextBuilder.WriteString(description) // Already formatted in gatherDescriptionContext
-		contextBuilder.WriteString("\n---\n\n")
-	}
-
+	// Priority 1: Definitions (type context is most critical for accuracy)
 	if definitions != "" {
-		contextBuilder.WriteString(definitions) // Already formatted in gatherDefinitionsContext
-		contextBuilder.WriteString("\n---\n\n")
+		packer.add("Definitions", definitions)
 	}
-
+	// Priority 2: Description-related snippets
+	if description != "" {
+		packer.add("Description", description)
+	}
+	// Priority 3: Impact analysis
 	if impact != "" {
-		r.logger.Info("impact analysis identified potential ripple effects", "context_length", len(impact))
-		contextBuilder.WriteString("# Potential Impacted Callers & Usages\n\n")
-		contextBuilder.WriteString("The following code snippets may be affected by the changes in modified symbols:\n\n")
-		contextBuilder.WriteString(impact)
-		contextBuilder.WriteString("\n---\n\n")
+		packer.add("Impact", fmt.Sprintf("# Potential Impacted Callers & Usages\n\nThe following code snippets may be affected by the changes in modified symbols:\n\n%s", impact))
 	}
-
+	// Priority 4: Architectural context
+	if arch != "" {
+		packer.add("Arch", fmt.Sprintf("# Architectural Context\n\nThe following describes the purpose of the affected modules:\n\n%s", arch))
+	}
+	// Priority 5: HyDE snippets (may be redundant if impact/description already covered)
 	if len(hyde) > 0 {
-		contextBuilder.WriteString("# Related Code Snippets\n\n")
-		contextBuilder.WriteString("The following code snippets might be relevant to the changes being reviewed:\n\n")
-
+		var hydeBuilder strings.Builder
+		hydeBuilder.WriteString("# Related Code Snippets\n\nThe following code snippets might be relevant to the changes being reviewed:\n\n")
+		hydeSeenKeys := make(map[string]struct{})
 		for i, docs := range hyde {
-			if i >= len(indices) { // Safety check
+			if i >= len(indices) {
 				continue
 			}
 			originalIdx := indices[i]
-			if originalIdx >= len(files) { // Safety check
+			if originalIdx >= len(files) {
 				continue
 			}
 			filePath := files[originalIdx].Filename
 			for _, doc := range docs {
-				docKey := r.getDocKey(doc)
-				mu.Lock()
-				if _, exists := seen[docKey]; exists {
-					mu.Unlock()
+				key := r.getDocKey(doc)
+				if _, exists := hydeSeenKeys[key]; exists {
 					continue
 				}
-				seen[docKey] = struct{}{}
-				mu.Unlock()
-
-				contextBuilder.WriteString(fmt.Sprintf("## Related to: %s\n", filePath))
-				contextBuilder.WriteString("```\n")
-				contextBuilder.WriteString(r.getDocContent(doc))
-				contextBuilder.WriteString("\n```\n\n")
+				hydeSeenKeys[key] = struct{}{}
+				hydeBuilder.WriteString(fmt.Sprintf("## Related to: %s\n", filePath))
+				hydeBuilder.WriteString("```\n")
+				hydeBuilder.WriteString(r.getDocContent(doc))
+				hydeBuilder.WriteString("\n```\n\n")
 			}
 		}
+		packer.add("HyDE", hydeBuilder.String())
 	}
+
+	result := packer.build()
 
 	r.logger.Info("relevant context built",
 		"changed_files", len(files),
@@ -545,9 +720,71 @@ func (r *ragService) assembleContext(arch, impact, description, definitions stri
 		"impact_len", len(impact),
 		"definitions_len", len(definitions),
 		"hyde_results_count", len(hyde),
+		"packed_len", len(result),
 	)
 
-	return contextBuilder.String()
+	return result
+}
+
+// tokenContextSection represents a named section in the context packer.
+type tokenContextSection struct {
+	name    string
+	content string
+}
+
+// tokenContextPacker packs context sections into a token budget, truncating
+// lower-priority sections first. It uses a simple character-based estimate
+// (1 token ≈ 3 characters) for speed — no extra LLM calls needed.
+type tokenContextPacker struct {
+	budget   int
+	sections []tokenContextSection
+}
+
+func newTokenContextPacker(tokenBudget int) *tokenContextPacker {
+	return &tokenContextPacker{budget: tokenBudget}
+}
+
+// add appends a named section. Sections are packed in the order they are added
+// (first added = highest priority).
+func (p *tokenContextPacker) add(name, content string) {
+	if content != "" {
+		p.sections = append(p.sections, tokenContextSection{name: name, content: content})
+	}
+}
+
+// estimateTokens returns a fast character-based token estimate (1 token ≈ 3 chars).
+func estimateTokens(s string) int { return len(s) / 3 }
+
+// build assembles sections into a single string, truncating lower-priority
+// sections when the total would exceed the token budget.
+func (p *tokenContextPacker) build() string {
+	var out strings.Builder
+	remaining := p.budget
+
+	for _, sec := range p.sections {
+		tokens := estimateTokens(sec.content)
+		if tokens <= remaining {
+			out.WriteString(sec.content)
+			out.WriteString("\n---\n\n")
+			remaining -= tokens
+		} else if remaining > 50 { // Only truncate if there's meaningful space left
+			// Truncate to remaining budget
+			maxChars := remaining * 3
+			truncated := sec.content[:maxChars]
+			// Try to cut at a newline boundary
+			if idx := strings.LastIndex(truncated, "\n"); idx > maxChars/2 {
+				truncated = truncated[:idx]
+			}
+			out.WriteString(truncated)
+			out.WriteString(fmt.Sprintf("\n[%s context truncated due to length]\n\n---\n\n", sec.name))
+			remaining = 0
+		} else {
+			// Budget exhausted
+			out.WriteString(fmt.Sprintf("[%s context omitted — token budget exhausted]\n\n---\n\n", sec.name))
+		}
+	}
+
+	return out.String()
 }
 
 func (r *ragService) processRelatedSnippet(doc schema.Document, originalFile internalgithub.ChangedFile, rank int, seenDocs map[string]struct{}, seenMu *sync.RWMutex, topFiles []string, builder *strings.Builder) []string {
@@ -736,64 +973,66 @@ func (r *ragService) getDocContent(doc schema.Document) string {
 	return doc.PageContent
 }
 
+// validateAndFormatSnippets remains for internal use by the snippet_validator.
+// Note: the primary description-docs path now uses gatherDescriptionDocs + batch
+// validation in snippet_validator.go instead of per-snippet LLM calls.
 func (r *ragService) validateAndFormatSnippets(ctx context.Context, description string, uniqueDocs map[string]schema.Document, seen map[string]struct{}, mu *sync.RWMutex) string {
-	const maxConcurrentValidations = 10
-	sem := make(chan struct{}, maxConcurrentValidations)
-	var validated []string
-	var validMu sync.Mutex
-	var valWg sync.WaitGroup
-
-	for _, d := range uniqueDocs {
-		valWg.Add(1)
-		go func(doc schema.Document) {
-			defer valWg.Done()
-
-			// Concurrency control
-			select {
-			case sem <- struct{}{}:
-				defer func() { <-sem }()
-			case <-ctx.Done():
-				return
-			}
-
-			content := r.getDocContent(doc)
-			docKey := r.getDocKey(doc)
-
-			if ctx.Err() != nil {
-				return
-			}
-
-			// First check: fast path with read lock
-			mu.RLock()
-			_, exists := seen[docKey]
-			mu.RUnlock()
-			if exists {
-				return
-			}
-
-			// Perform expensive validation only if potentially new
-			if !r.validateSnippetRelevance(ctx, content, description) {
-				return
-			}
-
-			// Second check: verify still absent under write lock before adding
-			mu.Lock()
-			if _, exists := seen[docKey]; !exists {
-				seen[docKey] = struct{}{}
-				source, _ := doc.Metadata["source"].(string)
-				snip := fmt.Sprintf("File: %s\n```\n%s\n```\n\n", source, content)
-				validMu.Lock()
-				validated = append(validated, snip)
-				validMu.Unlock()
-			}
-			mu.Unlock()
-		}(d)
+	if len(uniqueDocs) == 0 {
+		return ""
 	}
-	valWg.Wait()
+
+	// Build ordered list of (key, doc, content) for batch validation
+	type entry struct {
+		key     string
+		doc     schema.Document
+		content string
+	}
+	entries := make([]entry, 0, len(uniqueDocs))
+	for key, doc := range uniqueDocs {
+		mu.RLock()
+		_, exists := seen[key]
+		mu.RUnlock()
+		if exists {
+			continue
+		}
+		entries = append(entries, entry{key: key, doc: doc, content: r.getDocContent(doc)})
+	}
+	if len(entries) == 0 {
+		return ""
+	}
+
+	// Build snippet slice for batch validation
+	snippets := make([]string, len(entries))
+	for i, e := range entries {
+		snippets[i] = e.content
+	}
+
+	// Single batch LLM call to validate all snippets at once (Issue #6 fix)
+	validatorLLM, err := r.getOrCreateLLM(r.cfg.AI.FastModel)
+	var relevanceMap map[int]bool
+	if err == nil {
+		v := newSnippetValidator(validatorLLM, r.promptMgr)
+		relevanceMap = v.validateBatch(ctx, snippets, description)
+	} else {
+		// Fail open: include all snippets if validator unavailable
+		relevanceMap = make(map[int]bool, len(entries))
+		for i := range entries {
+			relevanceMap[i] = true
+		}
+	}
 
 	var builder strings.Builder
-	for _, v := range validated {
-		builder.WriteString(v)
+	for i, e := range entries {
+		if !relevanceMap[i] {
+			continue
+		}
+		mu.Lock()
+		if _, exists := seen[e.key]; !exists {
+			seen[e.key] = struct{}{}
+			source, _ := e.doc.Metadata["source"].(string)
+			builder.WriteString(fmt.Sprintf("File: %s\n```\n%s\n```\n\n", source, e.content))
+		}
+		mu.Unlock()
 	}
 	return builder.String()
 }

--- a/internal/rag/rag_context.go
+++ b/internal/rag/rag_context.go
@@ -135,7 +135,7 @@ func filterAddedLines(patch string) string {
 	lines := strings.Split(patch, "\n")
 	var added []string
 	for _, line := range lines {
-		if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "++") {
+		if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++") {
 			added = append(added, line[1:]) // Strip the leading '+'
 		}
 	}

--- a/internal/rag/rag_context.go
+++ b/internal/rag/rag_context.go
@@ -423,17 +423,11 @@ func (r *ragService) resolveSymbolDefinition(ctx context.Context, symbol string,
 // buildRelevantContext performs similarity searches using file diffs to find related
 // code snippets from the repository. These results provide context to help the LLM
 // better understand the scope and impact of the changes.
-//
-// Design note (Issue #4 fix): gatherers now return []schema.Document instead of
-// pre-formatted strings. Deduplication and formatting happen in a single-threaded
-// pass after wg.Wait(), making the output fully deterministic regardless of which
-// goroutine wins a race to a shared doc.
 func (r *ragService) buildRelevantContext(ctx context.Context, collectionName, embedderModelName, repoPath string, changedFiles []internalgithub.ChangedFile, prDescription string) (string, string) {
 	if len(changedFiles) == 0 {
 		return "", ""
 	}
 
-	// Bound the number of files processed to prevent OOM/DoS
 	const defaultMaxContextFiles = 20
 	if len(changedFiles) > defaultMaxContextFiles {
 		r.logger.Warn("truncating context files", "total", len(changedFiles), "limit", defaultMaxContextFiles)
@@ -442,35 +436,42 @@ func (r *ragService) buildRelevantContext(ctx context.Context, collectionName, e
 
 	scopedStore := r.vectorStore.ForRepo(collectionName, embedderModelName)
 
-	// Run context gathering concurrently. Each gatherer returns raw docs or a
-	// self-contained string (for arch and definitions which have their own
-	// dedup/formatting logic that doesn't share state with other stages).
+	archContext, definitionsContext, impactDocs, descDocs, hydeResults, indices := r.buildContextConcurrently(
+		ctx, collectionName, embedderModelName, repoPath, prDescription, changedFiles, scopedStore)
+
+	allDocs := mergeAndDedup(append(impactDocs, descDocs...), r.getDocKey)
+
+	var impactContext, descriptionContext string
+	if len(allDocs) > 0 {
+		var seenDocs sync.Map
+		impactContext, descriptionContext = r.splitAndFormatDocs(allDocs, descDocs, prDescription, &seenDocs)
+	}
+
+	fullContext := r.assembleContext(archContext, impactContext, descriptionContext, definitionsContext, hydeResults, indices, changedFiles)
+	return fullContext, definitionsContext
+}
+
+func (r *ragService) buildContextConcurrently(
+	ctx context.Context, collectionName, embedderModelName, repoPath, prDescription string,
+	changedFiles []internalgithub.ChangedFile, scopedStore storage.ScopedVectorStore,
+) (archContext, definitionsContext string, impactDocs, descDocs []schema.Document, hydeResults [][]schema.Document, indices []int) {
 	var wg sync.WaitGroup
-	var archContext, definitionsContext string
-	var impactDocs, descDocs []schema.Document
-	var hydeResults [][]schema.Document
-	var indices []int
 	var impactMu, descMu sync.Mutex
 
-	// 1. Architectural Context (returns formatted string — no shared state)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		archContext = r.gatherArchContext(ctx, scopedStore, changedFiles)
+		archContext = r.gatherArchContextSafe(ctx, scopedStore, changedFiles)
 	}()
 
-	// 2. HyDE Snippets
 	if r.cfg.AI.EnableHyDE {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			hydeResults, indices = r.gatherHyDEContext(ctx, collectionName, embedderModelName, changedFiles)
 		}()
-	} else {
-		r.logger.Info("stage skipped", "name", "HyDE", "reason", "disabled_in_config")
 	}
 
-	// 3. Impact Context — returns []schema.Document (no shared seenDocs)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -480,7 +481,6 @@ func (r *ragService) buildRelevantContext(ctx context.Context, collectionName, e
 		impactMu.Unlock()
 	}()
 
-	// 4. Description Context — returns []schema.Document (no shared seenDocs)
 	if prDescription != "" {
 		wg.Add(1)
 		go func() {
@@ -492,34 +492,23 @@ func (r *ragService) buildRelevantContext(ctx context.Context, collectionName, e
 		}()
 	}
 
-	// 5. Symbol Resolution — returns formatted string (its own internal dedup)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		// gatherDefinitionsContext owns its seenDocs internally
 		seenDocs := make(map[string]struct{})
 		var mu sync.RWMutex
 		definitionsContext = r.gatherDefinitionsContext(ctx, scopedStore, changedFiles, seenDocs, &mu)
 	}()
 
 	wg.Wait()
+	return
+}
 
-	// ── Single-threaded deterministic dedup & formatting ──────────────────────
-	// Merge impact + description docs, deduplicate by key (sorted for determinism),
-	// then validate snippets against the PR description in one batch call.
-	allDocs := mergeAndDedup(append(impactDocs, descDocs...), r.getDocKey)
-
-	// Validate description-relevant docs in a single batch LLM call (Issue #6 fix
-	// is applied here via validateAndFormatSnippets which now uses batch validation).
-	var impactContext, descriptionContext string
-	if len(allDocs) > 0 {
-		var seenDocs sync.Map
-		impactContext, descriptionContext = r.splitAndFormatDocs(ctx, allDocs, impactDocs, descDocs, prDescription, &seenDocs)
-	}
-
-	// Assemble the final context string with token budget enforcement.
-	fullContext := r.assembleContext(archContext, impactContext, descriptionContext, definitionsContext, hydeResults, indices, changedFiles)
-	return fullContext, definitionsContext
+func (r *ragService) gatherArchContextSafe(ctx context.Context, store storage.ScopedVectorStore, files []internalgithub.ChangedFile) string {
+	r.logger.Info("stage started", "name", "ArchitecturalContext")
+	ac := r.getArchContext(ctx, store, files)
+	r.logger.Info("stage completed", "name", "ArchitecturalContext")
+	return ac
 }
 
 // mergeAndDedup merges document slices and deduplicates them by a key function.
@@ -546,44 +535,88 @@ func mergeAndDedup(docs []schema.Document, keyFn func(schema.Document) string) [
 
 // splitAndFormatDocs splits merged docs back into impact/description buckets and formats them.
 func (r *ragService) splitAndFormatDocs(
-	ctx context.Context,
 	allDocs []schema.Document,
-	impactDocs, descDocs []schema.Document,
+	descDocs []schema.Document,
 	prDescription string,
 	seen *sync.Map,
 ) (impactContext, descriptionContext string) {
-	// Build a quick lookup of which keys were originally in descDocs.
-	descKeys := make(map[string]struct{}, len(descDocs))
+	descKeys := make(map[string]schema.Document, len(descDocs))
 	for _, d := range descDocs {
 		source, _ := d.Metadata["source"].(string)
-		descKeys[source] = struct{}{}
+		descKeys[source] = d
 	}
 
-	var impactBuilder, descBuilder strings.Builder
+	validDescSources := r.filterValidDescriptionDocs(descKeys, seen, prDescription)
+	return r.formatSplitDocs(allDocs, descKeys, validDescSources, seen, prDescription)
+}
 
+func (r *ragService) filterValidDescriptionDocs(descKeys map[string]schema.Document, seen *sync.Map, prDescription string) map[string]bool {
+	var toValidate []schema.Document
+	var snippets []string
+	for source, d := range descKeys {
+		if _, loaded := seen.Load(source); !loaded {
+			toValidate = append(toValidate, d)
+			snippets = append(snippets, r.getDocContent(d))
+		}
+	}
+
+	relevanceMap := make(map[int]bool, len(toValidate))
+	if len(snippets) > 0 && prDescription != "" {
+		validatorLLM, err := r.getOrCreateLLM(r.cfg.AI.FastModel)
+		if err == nil {
+			v := newSnippetValidator(validatorLLM, r.promptMgr)
+			relevanceMap = v.validateBatch(context.Background(), snippets, prDescription)
+		} else {
+			for i := range snippets {
+				relevanceMap[i] = true
+			}
+		}
+	}
+
+	validSources := make(map[string]bool, len(toValidate))
+	for i, doc := range toValidate {
+		if relevanceMap[i] {
+			source, _ := doc.Metadata["source"].(string)
+			validSources[source] = true
+		}
+	}
+	return validSources
+}
+
+func (r *ragService) formatSplitDocs(
+	allDocs []schema.Document,
+	descKeys map[string]schema.Document,
+	validDescSources map[string]bool,
+	seen *sync.Map,
+	prDescription string,
+) (string, string) {
+	var impactBuilder, descBuilder strings.Builder
 	for _, doc := range allDocs {
 		source, _ := doc.Metadata["source"].(string)
+
+		if _, isDesc := descKeys[source]; isDesc && prDescription != "" {
+			if !validDescSources[source] {
+				continue
+			}
+		}
+
 		if _, loaded := seen.LoadOrStore(source, struct{}{}); loaded {
 			continue
 		}
+
 		content := r.getDocContent(doc)
-		if _, inDesc := descKeys[source]; inDesc && prDescription != "" {
+		if _, isDesc := descKeys[source]; isDesc && prDescription != "" {
 			descBuilder.WriteString(fmt.Sprintf("File: %s\n```\n%s\n```\n\n", source, content))
 		} else {
-			_ = impactDocs // suppress unused warning
 			fmt.Fprintf(&impactBuilder, "**%s**:\n```\n%s\n```\n\n", source, content)
 		}
 	}
 
+	var descCtx string
 	if descBuilder.Len() > 0 {
-		var h strings.Builder
-		h.WriteString("# Related to PR Description\n\n")
-		h.WriteString(descBuilder.String())
-		descriptionContext = h.String()
+		descCtx = "# Related to PR Description\n\n" + descBuilder.String()
 	}
-
-	impactContext = impactBuilder.String()
-	return
+	return impactBuilder.String(), descCtx
 }
 
 // gatherDescriptionDocs uses MultiQuery retrieval to find documents related to the PR description.
@@ -625,26 +658,6 @@ func (r *ragService) gatherDescriptionDocs(ctx context.Context, collection, embe
 
 	r.logger.Info("stage completed", "name", "DescriptionContext", "retrieved", len(allDocs))
 	return allDocs
-}
-
-// validateSnippetRelevance uses a fast LLM to check if a retrieved snippet
-// is actually relevant to the given context. Fails open (returns true) if
-// the validator model is unavailable or returns an error.
-func (r *ragService) validateSnippetRelevance(ctx context.Context, snippet, prContext string) bool {
-	validatorLLM, err := r.getOrCreateLLM(r.cfg.AI.FastModel)
-	if err != nil {
-		return true // Fail open: if no validator available, include the snippet
-	}
-
-	validator := newSnippetValidator(validatorLLM, r.promptMgr)
-	return validator.validate(ctx, snippet, prContext)
-}
-
-func (r *ragService) gatherArchContext(ctx context.Context, store storage.ScopedVectorStore, files []internalgithub.ChangedFile) string { //nolint:unused
-	r.logger.Info("stage started", "name", "ArchitecturalContext")
-	ac := r.getArchContext(ctx, store, files)
-	r.logger.Info("stage completed", "name", "ArchitecturalContext")
-	return ac
 }
 
 // gatherImpactDocs returns raw impact docs without formatting or shared seenDocs.
@@ -763,11 +776,14 @@ func (p *tokenContextPacker) build() string {
 
 	for _, sec := range p.sections {
 		tokens := estimateTokens(sec.content)
-		if tokens <= remaining {
+
+		switch {
+		case tokens <= remaining:
 			out.WriteString(sec.content)
 			out.WriteString("\n---\n\n")
 			remaining -= tokens
-		} else if remaining > 50 { // Only truncate if there's meaningful space left
+
+		case remaining > 50: // Only truncate if there's meaningful space left
 			// Truncate to remaining budget
 			maxChars := remaining * 3
 			truncated := sec.content[:maxChars]
@@ -778,8 +794,8 @@ func (p *tokenContextPacker) build() string {
 			out.WriteString(truncated)
 			out.WriteString(fmt.Sprintf("\n[%s context truncated due to length]\n\n---\n\n", sec.name))
 			remaining = 0
-		} else {
-			// Budget exhausted
+
+		default: // Budget exhausted
 			out.WriteString(fmt.Sprintf("[%s context omitted — token budget exhausted]\n\n---\n\n", sec.name))
 		}
 	}
@@ -971,68 +987,4 @@ func (r *ragService) getDocContent(doc schema.Document) string {
 		r.logger.Debug("parent_id present but full_parent_text missing", "parent_id", parentID, "source", doc.Metadata["source"])
 	}
 	return doc.PageContent
-}
-
-// validateAndFormatSnippets remains for internal use by the snippet_validator.
-// Note: the primary description-docs path now uses gatherDescriptionDocs + batch
-// validation in snippet_validator.go instead of per-snippet LLM calls.
-func (r *ragService) validateAndFormatSnippets(ctx context.Context, description string, uniqueDocs map[string]schema.Document, seen map[string]struct{}, mu *sync.RWMutex) string {
-	if len(uniqueDocs) == 0 {
-		return ""
-	}
-
-	// Build ordered list of (key, doc, content) for batch validation
-	type entry struct {
-		key     string
-		doc     schema.Document
-		content string
-	}
-	entries := make([]entry, 0, len(uniqueDocs))
-	for key, doc := range uniqueDocs {
-		mu.RLock()
-		_, exists := seen[key]
-		mu.RUnlock()
-		if exists {
-			continue
-		}
-		entries = append(entries, entry{key: key, doc: doc, content: r.getDocContent(doc)})
-	}
-	if len(entries) == 0 {
-		return ""
-	}
-
-	// Build snippet slice for batch validation
-	snippets := make([]string, len(entries))
-	for i, e := range entries {
-		snippets[i] = e.content
-	}
-
-	// Single batch LLM call to validate all snippets at once (Issue #6 fix)
-	validatorLLM, err := r.getOrCreateLLM(r.cfg.AI.FastModel)
-	var relevanceMap map[int]bool
-	if err == nil {
-		v := newSnippetValidator(validatorLLM, r.promptMgr)
-		relevanceMap = v.validateBatch(ctx, snippets, description)
-	} else {
-		// Fail open: include all snippets if validator unavailable
-		relevanceMap = make(map[int]bool, len(entries))
-		for i := range entries {
-			relevanceMap[i] = true
-		}
-	}
-
-	var builder strings.Builder
-	for i, e := range entries {
-		if !relevanceMap[i] {
-			continue
-		}
-		mu.Lock()
-		if _, exists := seen[e.key]; !exists {
-			seen[e.key] = struct{}{}
-			source, _ := e.doc.Metadata["source"].(string)
-			builder.WriteString(fmt.Sprintf("File: %s\n```\n%s\n```\n\n", source, e.content))
-		}
-		mu.Unlock()
-	}
-	return builder.String()
 }

--- a/internal/rag/rag_impact.go
+++ b/internal/rag/rag_impact.go
@@ -2,9 +2,7 @@ package rag
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"strings"
 	"sync"
 
 	"github.com/sevigo/goframe/schema"
@@ -18,14 +16,6 @@ type depRequest struct {
 	Pkg     string
 	Imports []string
 	File    internalgithub.ChangedFile
-}
-
-func (r *ragService) getImpactContext(ctx context.Context, store storage.ScopedVectorStore, repoPath string, files []internalgithub.ChangedFile, seen map[string]struct{}, mu *sync.RWMutex) string {
-	retriever := vectorstores.NewDependencyRetriever(store)
-
-	reqs := r.buildImpactRequests(repoPath, files)
-	depResults := r.fetchImpactResults(ctx, retriever, reqs)
-	return r.processImpactResults(depResults, seen, mu)
 }
 
 // getImpactDocs returns raw impact documents without formatting or deduplication.
@@ -111,38 +101,4 @@ func (r *ragService) fetchImpactResults(ctx context.Context, retriever *vectorst
 	}
 	wg.Wait()
 	return depResults
-}
-
-func (r *ragService) processImpactResults(depResults map[string][]schema.Document, seen map[string]struct{}, mu *sync.RWMutex) string {
-	var impactBuilder strings.Builder
-	const maxImpactSnippets = 10
-	totalSnippets := 0
-
-	for filename, dependents := range depResults {
-		for _, doc := range dependents {
-			if totalSnippets >= maxImpactSnippets {
-				return impactBuilder.String()
-			}
-
-			docKey := r.getDocKey(doc)
-			source, ok := doc.Metadata["source"].(string)
-			if !ok || source == "" {
-				r.logger.Debug("skipping impact doc with missing source", "docKey", docKey)
-				continue
-			}
-
-			mu.Lock()
-			if _, exists := seen[docKey]; exists {
-				mu.Unlock()
-				continue
-			}
-			seen[docKey] = struct{}{}
-			mu.Unlock()
-
-			_, _ = impactBuilder.WriteString(fmt.Sprintf("File: %s (potential ripple effect from %s)\n---\n%s\n\n",
-				source, filename, r.getDocContent(doc)))
-			totalSnippets++
-		}
-	}
-	return impactBuilder.String()
 }

--- a/internal/rag/rag_impact.go
+++ b/internal/rag/rag_impact.go
@@ -28,6 +28,31 @@ func (r *ragService) getImpactContext(ctx context.Context, store storage.ScopedV
 	return r.processImpactResults(depResults, seen, mu)
 }
 
+// getImpactDocs returns raw impact documents without formatting or deduplication.
+// Deduplication is handled by the caller (buildRelevantContext) after all goroutines
+// complete, ensuring deterministic output.
+func (r *ragService) getImpactDocs(ctx context.Context, store storage.ScopedVectorStore, repoPath string, files []internalgithub.ChangedFile) []schema.Document {
+	retriever := vectorstores.NewDependencyRetriever(store)
+	reqs := r.buildImpactRequests(repoPath, files)
+	depResults := r.fetchImpactResults(ctx, retriever, reqs)
+
+	const maxImpactSnippets = 10
+	var docs []schema.Document
+	for _, dependents := range depResults {
+		for _, doc := range dependents {
+			source, ok := doc.Metadata["source"].(string)
+			if !ok || source == "" {
+				continue
+			}
+			docs = append(docs, doc)
+			if len(docs) >= maxImpactSnippets {
+				return docs
+			}
+		}
+	}
+	return docs
+}
+
 func (r *ragService) buildImpactRequests(repoPath string, files []internalgithub.ChangedFile) []depRequest {
 	reqs := make([]depRequest, 0, len(files))
 	for _, f := range files {

--- a/internal/rag/rag_retrievers_test.go
+++ b/internal/rag/rag_retrievers_test.go
@@ -126,14 +126,15 @@ func TestBuildContextForPrompt_Deduplication(t *testing.T) {
 
 	context := service.buildContextForPrompt(docs)
 
-	// Should contain 3 unique entries, not 4
+	// Should contain all 3 unique functions
 	assert.Contains(t, context, "func A()")
 	assert.Contains(t, context, "func B()")
 	assert.Contains(t, context, "func C()")
 
-	// Count file occurrences - should be exactly 3 files mentioned
+	// All 3 unique docs share the same source file, so they are grouped into
+	// one file block (chunk splicing). File: file.go should appear exactly once.
 	fileCount := strings.Count(context, "File: file.go")
-	assert.Equal(t, 3, fileCount, "Expected 3 unique file entries")
+	assert.Equal(t, 1, fileCount, "Expected docs from the same source to be grouped into 1 file block")
 }
 
 // TestBuildContextForPrompt_WithParentText tests that full_parent_text is preferred

--- a/internal/rag/rag_test.go
+++ b/internal/rag/rag_test.go
@@ -329,9 +329,9 @@ func TestExtractSymbolsFromPatch(t *testing.T) {
 		},
 		{
 			name: "method definition",
-			patch: `func (c *Config) GetTimeout() int {
-	return c.Timeout
-}`,
+			patch: `+func (c *Config) GetTimeout() int {
++	return c.Timeout
++}`,
 			expected: []string{"GetTimeout"}, // The receiver type Config is not captured by current regex
 		},
 		{

--- a/internal/rag/snippet_validator.go
+++ b/internal/rag/snippet_validator.go
@@ -3,54 +3,22 @@ package rag
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 
-	"github.com/sevigo/goframe/chains"
 	"github.com/sevigo/goframe/llms"
-	"github.com/sevigo/goframe/prompts"
 
 	"github.com/sevigo/code-warden/internal/llm"
 )
 
-// snippetValidator uses goframe's LLMChain pattern to validate
-// if a code snippet is relevant to a given context/query.
+// snippetValidator uses a fast LLM to validate whether code snippets are
+// relevant to a PR description. All validation is done in a single batch call.
 type snippetValidator struct {
 	validatorLLM llms.Model
 	promptMgr    *llm.PromptManager
 }
 
-// validateSnippetResult is the parsed result from the validation LLM.
-type validateSnippetResult struct {
-	Relevant bool   `json:"relevant"`
-	Reason   string `json:"reason"`
-}
-
-// snippetOutputParser implements output parsing for validation results.
-type snippetOutputParser struct{}
-
-func (p *snippetOutputParser) Parse(_ context.Context, output string) (*validateSnippetResult, error) {
-	// Try to extract JSON from the response
-	start := strings.Index(output, "{")
-	end := strings.LastIndex(output, "}")
-	if start == -1 || end == -1 || end < start {
-		// Fallback: check for YES/NO pattern
-		if strings.Contains(strings.ToUpper(output), "YES") {
-			return &validateSnippetResult{Relevant: true, Reason: "positive response detected"}, nil
-		}
-		return &validateSnippetResult{Relevant: false, Reason: "no valid response"}, nil
-	}
-
-	jsonStr := output[start : end+1]
-	var result validateSnippetResult
-	if err := json.Unmarshal([]byte(jsonStr), &result); err != nil {
-		// Log parse error but return result with reason (intentional fail-open behavior)
-		//nolint:nilerr // Intentional: fail-open design, error is captured in Reason field
-		return &validateSnippetResult{Relevant: false, Reason: "parse error: " + err.Error()}, nil
-	}
-	return &result, nil
-}
-
-// newSnippetValidator creates a new snippet validator using the provided LLM.
+// newSnippetValidator creates a validator backed by the provided LLM.
 func newSnippetValidator(validatorLLM llms.Model, promptMgr *llm.PromptManager) *snippetValidator {
 	return &snippetValidator{
 		validatorLLM: validatorLLM,
@@ -58,124 +26,93 @@ func newSnippetValidator(validatorLLM llms.Model, promptMgr *llm.PromptManager) 
 	}
 }
 
-// validate checks if a snippet is relevant to the given context.
-// Returns true if relevant, false otherwise. Fails open (returns true) on errors.
-func (v *snippetValidator) validate(ctx context.Context, snippet, context string) bool {
-	if v.validatorLLM == nil {
-		return true // Fail open: if no validator available, include the snippet
-	}
-
-	promptData := map[string]string{
-		"context": context,
-		"snippet": snippet,
-	}
-
-	prompt, err := v.promptMgr.Render(llm.ValidateSnippetPrompt, promptData)
-	if err != nil {
-		// Fail open on prompt rendering errors
-		return true
-	}
-
-	parser := &snippetOutputParser{}
-	chain := chains.NewLLMChain(
-		v.validatorLLM,
-		prompts.NewPromptTemplate(prompt),
-		chains.WithOutputParser(parser),
-	)
-
-	result, err := chain.Call(ctx, nil)
-	if err != nil {
-		// Fail open on LLM errors
-		return true
-	}
-
-	return result.Relevant
-}
-
-// batchValidationResult is the parsed JSON result from a batch validation call.
-// The LLM returns a map of string-index to bool relevance, e.g. {"0": true, "1": false}.
+// batchValidationResult is the parsed JSON result from a batch validation call:
+// {"0": true, "1": false, ...}
 type batchValidationResult map[string]bool
 
-// validateBatch sends all snippets to the LLM in a single call and returns a map
-// of snippet index → relevant. Fails open (all true) on any error.
-// This is Issue #6's fix: replaces N sequential LLM calls with one batched call.
+// validateBatch sends all snippets to the LLM in a single call and returns a
+// map of snippet-index → relevant. Fails open (all true) on any error.
+// This is Issue #6's fix: replaces N sequential per-snippet LLM calls with one
+// batched call.
 func (v *snippetValidator) validateBatch(ctx context.Context, snippets []string, prContext string) map[int]bool {
 	result := make(map[int]bool, len(snippets))
-	// Default: fail open — include all snippets
 	for i := range snippets {
-		result[i] = true
+		result[i] = true // fail-open default
 	}
 
 	if v.validatorLLM == nil || len(snippets) == 0 {
 		return result
 	}
 
-	// Build a numbered list of snippets for the LLM
+	prompt, err := v.buildBatchPrompt(snippets, prContext)
+	if err != nil {
+		return result
+	}
+
+	raw, llmErr := llms.GenerateFromSinglePrompt(ctx, v.validatorLLM, prompt)
+	if llmErr != nil {
+		return result
+	}
+
+	parsed, parseErr := parseBatchResponse(raw)
+	if parseErr != nil {
+		return result
+	}
+
+	applyParsedResults(parsed, len(snippets), result)
+	return result
+}
+
+// buildBatchPrompt constructs the numbered-snippet prompt for batch validation.
+func (v *snippetValidator) buildBatchPrompt(snippets []string, prContext string) (string, error) {
 	var snippetList strings.Builder
 	for i, s := range snippets {
-		// Truncate long snippets to keep the prompt manageable
 		preview := s
 		if len(preview) > 500 {
 			preview = preview[:500] + "..."
 		}
 		snippetList.WriteString("--- Snippet ")
-		snippetList.WriteString(strings.TrimSpace(strings.Repeat(" ", 0)))
 		snippetList.WriteString(itoa(i))
 		snippetList.WriteString(" ---\n")
 		snippetList.WriteString(preview)
 		snippetList.WriteString("\n\n")
 	}
 
-	promptData := map[string]string{
+	return v.promptMgr.Render(llm.ValidateSnippetsBatchPrompt, map[string]string{
 		"context":  prContext,
 		"snippets": snippetList.String(),
 		"count":    itoa(len(snippets)),
-	}
+	})
+}
 
-	prompt, err := v.promptMgr.Render(llm.ValidateSnippetsBatchPrompt, promptData)
-	if err != nil {
-		// Fail open: prompt template not found or render error
-		return result
-	}
-
-	// Use GenerateFromSinglePrompt to get a raw text response — no output parser needed,
-	// we parse the JSON ourselves. This also avoids the generic type inference issue with
-	// chains.NewLLMChain when no typed output parser is provided.
-	raw, llmErr := llms.GenerateFromSinglePrompt(ctx, v.validatorLLM, prompt)
-	if llmErr != nil {
-		return result // Fail open
-	}
-
-	// Parse JSON response: expects {"0": true, "1": false, ...}
+// parseBatchResponse extracts JSON from the LLM's raw response.
+func parseBatchResponse(raw string) (batchValidationResult, error) {
 	start := strings.Index(raw, "{")
 	end := strings.LastIndex(raw, "}")
 	if start == -1 || end == -1 || end < start {
-		return result // Fail open: malformed response
+		return nil, errNoJSON
 	}
-
 	var parsed batchValidationResult
 	if err := json.Unmarshal([]byte(raw[start:end+1]), &parsed); err != nil {
-		return result // Fail open: JSON parse error
+		return nil, err
 	}
-
-	// Apply parsed results — only override where we got a definitive answer
-	for k, v := range parsed {
-		idx := 0
-		fmt := strings.TrimSpace(k)
-		for _, c := range fmt {
-			if c >= '0' && c <= '9' {
-				idx = idx*10 + int(c-'0')
-			}
-		}
-		if idx >= 0 && idx < len(snippets) {
-			result[idx] = v
-		}
-	}
-
-	return result
+	return parsed, nil
 }
 
-// itoa converts an int to string without importing strconv.
+// applyParsedResults writes the LLM's relevance decisions onto the result map.
+func applyParsedResults(parsed batchValidationResult, snippetCount int, result map[int]bool) {
+	for k, relevant := range parsed {
+		idx := atoiSafe(k)
+		if idx >= 0 && idx < snippetCount {
+			result[idx] = relevant
+		}
+	}
+}
+
+// errNoJSON is returned when the LLM response contains no JSON object.
+var errNoJSON = errors.New("no JSON object found in response")
+
+// itoa converts a non-negative int to string without importing strconv.
 func itoa(n int) string {
 	if n == 0 {
 		return "0"
@@ -188,4 +125,20 @@ func itoa(n int) string {
 		n /= 10
 	}
 	return string(buf[pos:])
+}
+
+// atoiSafe converts a decimal string to int, returning -1 on any invalid input.
+func atoiSafe(s string) int {
+	s = strings.TrimSpace(s)
+	if len(s) == 0 {
+		return -1
+	}
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return -1
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
 }

--- a/internal/rag/snippet_validator.go
+++ b/internal/rag/snippet_validator.go
@@ -91,3 +91,101 @@ func (v *snippetValidator) validate(ctx context.Context, snippet, context string
 
 	return result.Relevant
 }
+
+// batchValidationResult is the parsed JSON result from a batch validation call.
+// The LLM returns a map of string-index to bool relevance, e.g. {"0": true, "1": false}.
+type batchValidationResult map[string]bool
+
+// validateBatch sends all snippets to the LLM in a single call and returns a map
+// of snippet index → relevant. Fails open (all true) on any error.
+// This is Issue #6's fix: replaces N sequential LLM calls with one batched call.
+func (v *snippetValidator) validateBatch(ctx context.Context, snippets []string, prContext string) map[int]bool {
+	result := make(map[int]bool, len(snippets))
+	// Default: fail open — include all snippets
+	for i := range snippets {
+		result[i] = true
+	}
+
+	if v.validatorLLM == nil || len(snippets) == 0 {
+		return result
+	}
+
+	// Build a numbered list of snippets for the LLM
+	var snippetList strings.Builder
+	for i, s := range snippets {
+		// Truncate long snippets to keep the prompt manageable
+		preview := s
+		if len(preview) > 500 {
+			preview = preview[:500] + "..."
+		}
+		snippetList.WriteString("--- Snippet ")
+		snippetList.WriteString(strings.TrimSpace(strings.Repeat(" ", 0)))
+		snippetList.WriteString(itoa(i))
+		snippetList.WriteString(" ---\n")
+		snippetList.WriteString(preview)
+		snippetList.WriteString("\n\n")
+	}
+
+	promptData := map[string]string{
+		"context":  prContext,
+		"snippets": snippetList.String(),
+		"count":    itoa(len(snippets)),
+	}
+
+	prompt, err := v.promptMgr.Render(llm.ValidateSnippetsBatchPrompt, promptData)
+	if err != nil {
+		// Fail open: prompt template not found or render error
+		return result
+	}
+
+	// Use GenerateFromSinglePrompt to get a raw text response — no output parser needed,
+	// we parse the JSON ourselves. This also avoids the generic type inference issue with
+	// chains.NewLLMChain when no typed output parser is provided.
+	raw, llmErr := llms.GenerateFromSinglePrompt(ctx, v.validatorLLM, prompt)
+	if llmErr != nil {
+		return result // Fail open
+	}
+
+	// Parse JSON response: expects {"0": true, "1": false, ...}
+	start := strings.Index(raw, "{")
+	end := strings.LastIndex(raw, "}")
+	if start == -1 || end == -1 || end < start {
+		return result // Fail open: malformed response
+	}
+
+	var parsed batchValidationResult
+	if err := json.Unmarshal([]byte(raw[start:end+1]), &parsed); err != nil {
+		return result // Fail open: JSON parse error
+	}
+
+	// Apply parsed results — only override where we got a definitive answer
+	for k, v := range parsed {
+		idx := 0
+		fmt := strings.TrimSpace(k)
+		for _, c := range fmt {
+			if c >= '0' && c <= '9' {
+				idx = idx*10 + int(c-'0')
+			}
+		}
+		if idx >= 0 && idx < len(snippets) {
+			result[idx] = v
+		}
+	}
+
+	return result
+}
+
+// itoa converts an int to string without importing strconv.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for n > 0 {
+		pos--
+		buf[pos] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[pos:])
+}

--- a/internal/repomanager/sync.go
+++ b/internal/repomanager/sync.go
@@ -226,27 +226,37 @@ func (m *manager) cleanupRepoDir(path string) {
 	}
 }
 
-// ensureDefaultBranch fetches origin and checks out the default branch ref (HEAD).
+// ensureDefaultBranch fetches origin and resets the local branch to match the remote upstream.
 // It does NOT check out the PR's HeadSHA — that is intentional.
 func (m *manager) ensureDefaultBranch(ctx context.Context, ev *core.GitHubEvent, token, clonePath string) error {
 	currentSHA, err := m.gitClient.GetHeadSHA(ctx, clonePath)
-	if err != nil {
+	needsFullFetch := currentSHA == "" || err != nil
+
+	if needsFullFetch {
 		m.logger.Warn("failed to get current HEAD SHA, forcing fetch", "repo", ev.RepoFullName, "err", err)
 	}
 
-	// Only fetch if we don't have a valid HEAD yet (handles edge cases like a wiped working tree).
-	if currentSHA == "" || err != nil {
-		if fetchErr := m.gitClient.Fetch(ctx, clonePath, token); fetchErr != nil {
-			return fmt.Errorf("git fetch default branch: %w", fetchErr)
-		}
-	} else {
-		// Always fetch to pick up any new commits on the default branch.
-		if fetchErr := m.gitClient.Fetch(ctx, clonePath, token); fetchErr != nil {
-			// Non-fatal: we may still have a usable local state.
-			m.logger.Warn("git fetch failed, using existing local state", "repo", ev.RepoFullName, "err", fetchErr)
-		}
+	fetchErr := m.gitClient.Fetch(ctx, clonePath, token)
+
+	// If we don't have a valid working tree yet, fetch is mandatory.
+	if needsFullFetch && fetchErr != nil {
+		return fmt.Errorf("git fetch default branch: %w", fetchErr)
 	}
 
-	// We don't call Checkout(HeadSHA) here — the working tree stays on the default branch.
+	// If fetch failed but we already had a valid working tree, we can limp along with a warning.
+	if fetchErr != nil {
+		m.logger.Warn("git fetch failed, using existing local state", "repo", ev.RepoFullName, "err", fetchErr)
+		return nil
+	}
+
+	// Fetch succeeded. Ensure the working tree is advanced to the newly fetched upstream commit.
+	resetErr := m.gitClient.ResetToUpstream(ctx, clonePath)
+	if resetErr != nil {
+		if needsFullFetch {
+			return fmt.Errorf("git reset upstream: %w", resetErr)
+		}
+		m.logger.Warn("git reset upstream failed, index might be slightly stale", "repo", ev.RepoFullName, "err", resetErr)
+	}
+
 	return nil
 }

--- a/internal/repomanager/sync.go
+++ b/internal/repomanager/sync.go
@@ -17,6 +17,9 @@ import (
 const cloneTimeout = 5 * time.Minute
 
 // syncRepo decides whether we need a fresh clone or an incremental update.
+// IMPORTANT: This function only ever syncs the repository's *default branch* (main/master).
+// PR head SHAs are never checked out here; they are used only for logging and DB records.
+// This prevents the "linear indexing" corruption where parallel PR webhooks thrash Qdrant.
 func (m *manager) syncRepo(ctx context.Context, ev *core.GitHubEvent, token string) (*core.UpdateResult, error) {
 	repoRec, err := m.store.GetRepositoryByFullName(ctx, ev.RepoFullName)
 	if err != nil && !errors.Is(err, storage.ErrNotFound) {
@@ -61,7 +64,7 @@ func (m *manager) cloneAndIndex(
 	ev *core.GitHubEvent,
 	token, clonePath string,
 ) (*core.UpdateResult, error) {
-	m.logger.Info("initial clone", "repo", ev.RepoFullName)
+	m.logger.Info("initial clone of default branch", "repo", ev.RepoFullName)
 	if err := os.MkdirAll(filepath.Dir(clonePath), 0o750); err != nil {
 		return nil, fmt.Errorf("create parent dir: %w", err)
 	}
@@ -70,24 +73,19 @@ func (m *manager) cloneAndIndex(
 	cloneCtx, cancel := context.WithTimeout(ctx, cloneTimeout)
 	defer cancel()
 
+	// Clone the default branch only — never the PR head.
+	// The PR diff is fetched separately via the GitHub API and passed in-memory to the LLM.
 	_, err := m.gitClient.Clone(cloneCtx, ev.RepoCloneURL, clonePath, token)
 	if err != nil {
 		m.cleanupRepoDir(clonePath)
 		return nil, err
 	}
 
-	// Fetch PR specific reference to ensure we have the commit (handling forks)
-	// Fetch PR specific reference only if it's a PR event
-	if ev.PRNumber > 0 {
-		prRefSpec := fmt.Sprintf("+refs/pull/%d/head:refs/remotes/origin/pr/%d", ev.PRNumber, ev.PRNumber)
-		if err := m.gitClient.Fetch(cloneCtx, clonePath, token, prRefSpec); err != nil {
-			m.cleanupRepoDir(clonePath)
-			return nil, fmt.Errorf("git fetch pr: %w", err)
-		}
-	}
-	if err = m.gitClient.Checkout(cloneCtx, clonePath, ev.HeadSHA); err != nil {
+	// Read what HEAD resolved to (the default branch tip).
+	defaultBranchSHA, err := m.gitClient.GetHeadSHA(cloneCtx, clonePath)
+	if err != nil {
 		m.cleanupRepoDir(clonePath)
-		return nil, err
+		return nil, fmt.Errorf("get default branch SHA after clone: %w", err)
 	}
 
 	files, err := m.listRepoFiles(clonePath)
@@ -108,6 +106,7 @@ func (m *manager) cloneAndIndex(
 		ClonePath:            clonePath,
 		QdrantCollectionName: GenerateCollectionName(ev.RepoFullName, m.cfg.AI.EmbedderModel),
 		EmbedderModelName:    m.cfg.AI.EmbedderModel,
+		// LastIndexedSHA is zeroed here; it is set by the job once Qdrant indexing succeeds.
 	}
 
 	if existing != nil {
@@ -126,10 +125,12 @@ func (m *manager) cloneAndIndex(
 	}
 
 	return &core.UpdateResult{
-		FilesToAddOrUpdate: files,
-		RepoPath:           clonePath,
-		HeadSHA:            ev.HeadSHA,
-		IsInitialClone:     true,
+		FilesToAddOrUpdate:   files,
+		RepoPath:             clonePath,
+		HeadSHA:              ev.HeadSHA,       // PR head — for logging/DB only
+		DefaultBranchSHA:     defaultBranchSHA, // Default branch tip — persisted to LastIndexedSHA
+		DefaultBranchChanged: true,             // Always need a full index on initial clone
+		IsInitialClone:       true,
 	}, nil
 }
 
@@ -148,32 +149,56 @@ func (m *manager) incrementalUpdate(
 		return nil, err
 	}
 
-	// 1. Check if we are already at the target SHA (Bottleneck #3: Excessive Fetching)
-	if err := m.ensureTargetSHA(ctx, ev, token, rec.ClonePath); err != nil {
+	// Fetch and checkout the DEFAULT BRANCH ONLY — not the PR's HeadSHA.
+	// This keeps the on-disk working tree and the Qdrant index in sync with main.
+	if err := m.ensureDefaultBranch(ctx, ev, token, rec.ClonePath); err != nil {
 		return nil, err
+	}
+
+	// Get the current default branch SHA after fetch.
+	defaultBranchSHA, err := m.gitClient.GetHeadSHA(ctx, rec.ClonePath)
+	if err != nil {
+		return nil, fmt.Errorf("get default branch SHA: %w", err)
 	}
 
 	// If no previous SHA recorded, treat as full re-index
 	if rec.LastIndexedSHA == "" {
-		m.logger.Info("no previous index SHA, listing all files", "repo", ev.RepoFullName)
+		m.logger.Info("no previous index SHA, listing all files for full re-index", "repo", ev.RepoFullName)
 		files, err := m.listRepoFiles(rec.ClonePath)
 		if err != nil {
 			return nil, fmt.Errorf("list files: %w", err)
 		}
 		return &core.UpdateResult{
-			FilesToAddOrUpdate: files,
-			RepoPath:           rec.ClonePath,
-			HeadSHA:            ev.HeadSHA,
-			IsInitialClone:     true, // Force full re-index
+			FilesToAddOrUpdate:   files,
+			RepoPath:             rec.ClonePath,
+			HeadSHA:              ev.HeadSHA,
+			DefaultBranchSHA:     defaultBranchSHA,
+			DefaultBranchChanged: true, // Force full re-index
+			IsInitialClone:       true,
 		}, nil
 	}
 
-	added, modified, deleted, err := m.gitClient.Diff(gitRepo, rec.LastIndexedSHA, ev.HeadSHA)
+	// Check if the default branch has actually moved since our last index.
+	if rec.LastIndexedSHA == defaultBranchSHA {
+		m.logger.Info("default branch unchanged, no Qdrant update needed",
+			"repo", ev.RepoFullName,
+			"sha", defaultBranchSHA,
+		)
+		return &core.UpdateResult{
+			RepoPath:             rec.ClonePath,
+			HeadSHA:              ev.HeadSHA,
+			DefaultBranchSHA:     defaultBranchSHA,
+			DefaultBranchChanged: false, // No vector update needed
+		}, nil
+	}
+
+	// Default branch moved: compute the incremental diff (LastIndexedSHA → defaultBranchSHA).
+	added, modified, deleted, err := m.gitClient.Diff(gitRepo, rec.LastIndexedSHA, defaultBranchSHA)
 	if err != nil {
 		m.logger.Warn("git diff failed, falling back to full re-index",
 			"repo", ev.RepoFullName,
 			"last_indexed_sha", rec.LastIndexedSHA,
-			"head_sha", ev.HeadSHA,
+			"default_branch_sha", defaultBranchSHA,
 			"error", err,
 		)
 		// Cleanup corrupted state before re-cloning
@@ -185,11 +210,13 @@ func (m *manager) incrementalUpdate(
 	}
 
 	return &core.UpdateResult{
-		FilesToAddOrUpdate: append(added, modified...),
-		FilesToDelete:      deleted,
-		RepoPath:           rec.ClonePath,
-		HeadSHA:            ev.HeadSHA,
-		IsInitialClone:     false,
+		FilesToAddOrUpdate:   append(added, modified...),
+		FilesToDelete:        deleted,
+		RepoPath:             rec.ClonePath,
+		HeadSHA:              ev.HeadSHA,
+		DefaultBranchSHA:     defaultBranchSHA,
+		DefaultBranchChanged: true,
+		IsInitialClone:       false,
 	}, nil
 }
 
@@ -199,26 +226,27 @@ func (m *manager) cleanupRepoDir(path string) {
 	}
 }
 
-func (m *manager) ensureTargetSHA(ctx context.Context, ev *core.GitHubEvent, token, clonePath string) error {
+// ensureDefaultBranch fetches origin and checks out the default branch ref (HEAD).
+// It does NOT check out the PR's HeadSHA — that is intentional.
+func (m *manager) ensureDefaultBranch(ctx context.Context, ev *core.GitHubEvent, token, clonePath string) error {
 	currentSHA, err := m.gitClient.GetHeadSHA(ctx, clonePath)
-	if err == nil && currentSHA == ev.HeadSHA {
-		m.logger.Info("repository already at target SHA, skipping git fetch", "repo", ev.RepoFullName, "sha", ev.HeadSHA)
-		return nil
+	if err != nil {
+		m.logger.Warn("failed to get current HEAD SHA, forcing fetch", "repo", ev.RepoFullName, "err", err)
 	}
 
-	if ev.PRNumber > 0 {
-		prRefSpec := fmt.Sprintf("+refs/pull/%d/head:refs/remotes/origin/pr/%d", ev.PRNumber, ev.PRNumber)
-		if err = m.gitClient.Fetch(ctx, clonePath, token, prRefSpec); err != nil {
-			return fmt.Errorf("git fetch pr: %w", err)
+	// Only fetch if we don't have a valid HEAD yet (handles edge cases like a wiped working tree).
+	if currentSHA == "" || err != nil {
+		if fetchErr := m.gitClient.Fetch(ctx, clonePath, token); fetchErr != nil {
+			return fmt.Errorf("git fetch default branch: %w", fetchErr)
 		}
 	} else {
-		if err = m.gitClient.Fetch(ctx, clonePath, token); err != nil {
-			return fmt.Errorf("git fetch: %w", err)
+		// Always fetch to pick up any new commits on the default branch.
+		if fetchErr := m.gitClient.Fetch(ctx, clonePath, token); fetchErr != nil {
+			// Non-fatal: we may still have a usable local state.
+			m.logger.Warn("git fetch failed, using existing local state", "repo", ev.RepoFullName, "err", fetchErr)
 		}
 	}
 
-	if err = m.gitClient.Checkout(ctx, clonePath, ev.HeadSHA); err != nil {
-		return err
-	}
+	// We don't call Checkout(HeadSHA) here — the working tree stays on the default branch.
 	return nil
 }


### PR DESCRIPTION
## Summary

Addresses all 7 issues from the review. Two critical fixes that prevent correctness bugs in production, plus 5 RAG quality/performance improvements.

---

## 🔴 Critical Fixes

### Issue #1 — Ephemeral PR Overlays (default-branch-only indexing)
**Problem:** `sync.go` was diffing `LastIndexedSHA → PR's HeadSHA` and writing results to Qdrant. With parallel PRs, the vector DB continuously thrashed — each PR deleted the previous PR's code from the index.

**Fix:** `sync.go` now always syncs the **default branch (main)** only. The on-disk checkout and Qdrant diffs are computed against `main`'s HEAD, never a PR branch. PR diffs are fetched in-memory via the GitHub API and passed directly to the LLM.

Key changes:
- New `ensureDefaultBranch` replaces `ensureTargetSHA` — no PR HEAD checkout
- `UpdateResult` gains `DefaultBranchSHA` and `DefaultBranchChanged` fields
- `updateVectorStoreAndSHA` persists `DefaultBranchSHA` (not `HeadSHA`) to DB
- Vector store update skipped entirely when default branch hasn't moved

### Issue #2 — Narrow Mutex Scope
**Problem:** The repo mutex in `ReviewJob.Run` wrapped the entire pipeline including LLM calls (which can take minutes), blocking all other PRs for the same repo.

**Fix:** Mutex is now acquired/released inside `setupReviewEnvironment` — only protecting git sync + Qdrant update. `GenerateReview` (the expensive LLM call) runs fully concurrently for all PRs on the same repo.

---

## 🟡 RAG Improvements

### Issue #3 — Token-Aware Context Packer
Added `tokenContextPacker` in `assembleContext`. Enforces a 6,000-token budget with priority order: definitions → description → impact → arch → hyde. Overflowing sections are truncated with `[X context truncated due to length]`.

### Issue #4 — Deterministic Deduplication (no more race)
Context gatherers now return `[]schema.Document` instead of pre-formatted strings with a shared mutable `seenDocs` map. Dedup and formatting happen single-threaded after `wg.Wait()` via `mergeAndDedup()` (sorted by source for determinism).

### Issue #5 — Contiguous Chunk Splicing
`buildContextForPrompt` groups docs by source file and merges adjacent chunks using overlap detection (`findOverlapStart`). Eliminates redundant overlap text and disjointed code blocks.

### Issue #6 — Batch Snippet Validation
`validateBatch()` replaces N sequential `chains.NewLLMChain` calls with a single LLM call containing all snippets. Returns JSON `{"0": true, "1": false, ...}`. Added `validate_snippets_batch.prompt` template.

### Issue #7a — extractSymbolsFromPatch (added lines only)
New `filterAddedLines()` helper strips diff metadata and only processes `+` lines (not `---`/`+++` headers), preventing regex from matching deleted symbol names.

---

## Testing
- `go build ./...` ✅
- `go test ./internal/... -race` ✅ (all modified packages pass)
- Pre-existing flaky test `TestDoS_PreambleResilience` in `internal/llm` confirmed independent of these changes (passes on `main` and passes when re-run)
- Updated 2 tests to reflect new behavior: chunk grouping in `buildContextForPrompt` and `+`-prefix test inputs for `extractSymbolsFromPatch`