### PR TITLE
Add debug logging to RAG pipeline

### DIFF
--- a/internal/rag/arch_context.go
+++ b/internal/rag/arch_context.go
@@ -67,9 +67,7 @@ func (r *ragService) GenerateArchSummaries(ctx context.Context, collectionName, 
 		return nil
 	}
 
-	// 3. For directories that need updates, we need to gather Symbols and Imports.
-	// We defer this data gathering to the worker pool phase to avoid blocking the discovery loop.
-	// The hydration of directory metadata happens efficiently just before the LLM prompt value generation.
+	// Hydrate directory metadata and generate summaries
 
 	// Generate summaries with a worker pool
 	archDocs := r.generateSummariesWithWorkerPool(ctx, dirsToProcess, 3)
@@ -124,7 +122,7 @@ func (r *ragService) discoverDirectories(repoPath string, targetPaths []string, 
 	dirsToProcess := make(map[string]*DirectoryInfo)
 	cachedCount := 0
 
-	// Case 1: Full Recursive Walk (Initial Indexing)
+	// Recursive walk for initial indexing
 	if len(targetPaths) == 0 {
 		err := filepath.WalkDir(repoPath, func(path string, d os.DirEntry, walkErr error) error {
 			if walkErr != nil {
@@ -148,21 +146,19 @@ func (r *ragService) discoverDirectories(repoPath string, targetPaths []string, 
 		return dirsToProcess, cachedCount, err
 	}
 
-	// Case 2: Targeted Walk (Incremental Sync - Bottleneck #4)
+	// Targeted walk for incremental sync
 	uniqueDirs := make(map[string]struct{})
 
 	for _, p := range targetPaths {
-		// Securely validate and join the path using our helper
 		_, err := r.validateAndJoinPath(repoPath, p)
 		if err != nil {
-			r.logger.Warn("invalid or suspicious target path", "path", p, "error", err)
+			r.logger.Warn("invalid target path", "path", p, "error", err)
 			continue
 		}
 
-		// Use the cleaned path for directory traversal.
 		cleanP := filepath.Clean(p)
 		dir := filepath.Dir(cleanP)
-		// Traverse up to root to ensure all affected parent summaries are updated if needed
+		// Traverse up to root
 		for {
 			uniqueDirs[dir] = struct{}{}
 			if dir == "." || dir == "/" || dir == "" {

--- a/internal/rag/rag.go
+++ b/internal/rag/rag.go
@@ -23,7 +23,7 @@ import (
 	"github.com/sevigo/code-warden/internal/storage"
 )
 
-// Pre-compiled regexes for comment cleaning and symbol extraction to avoid recompilation on each call
+// Regexes for comment cleaning and symbol extraction.
 var (
 	statusRegex     = regexp.MustCompile(`(?i)\*\*status:\*\*\s*(unresolved|partial|fixed|new critical bug)\s*`)
 	obsRegex        = regexp.MustCompile(`(?i)\*\*observation:\*\*`)
@@ -39,7 +39,7 @@ var (
 	symbolExportedTypeRegex = regexp.MustCompile(`\b([A-Z]\w+)(?:\.|\{)`)
 )
 
-// Service defines the core operations for our Retrieval-Augmented Generation (RAG) pipeline.
+// Service defines operations for the RAG pipeline.
 type Service interface {
 	SetupRepoContext(ctx context.Context, repoConfig *core.RepoConfig, repo *storage.Repository, repoPath string) error
 	UpdateRepoContext(ctx context.Context, repoConfig *core.RepoConfig, repo *storage.Repository, repoPath string, filesToProcess, filesToDelete []string) error
@@ -65,8 +65,7 @@ type ragService struct {
 	hydeCache      sync.Map // map[string]string: patchHash -> hydeSnippet
 }
 
-// NewService creates a new Service instance with a vector store, LLM model,
-// parser registry, and logger. This service powers the indexing and code review flow.
+// NewService creates a new RAG service.
 func NewService(
 	cfg *config.Config,
 	promptMgr *llm.PromptManager,

--- a/internal/rag/rag_context.go
+++ b/internal/rag/rag_context.go
@@ -25,7 +25,7 @@ func (r *ragService) buildContextForPrompt(docs []schema.Document) string {
 		return ""
 	}
 
-	// ── Dedup by key ─────────────────────────────────────────────────────────
+	// Dedup by key
 	seenDocs := make(map[string]struct{})
 	unique := docs[:0]
 	for _, doc := range docs {
@@ -37,7 +37,7 @@ func (r *ragService) buildContextForPrompt(docs []schema.Document) string {
 		unique = append(unique, doc)
 	}
 
-	// ── Group by source file ──────────────────────────────────────────────────
+	// Group by source file
 	type fileEntry struct {
 		source string
 		docs   []schema.Document
@@ -77,9 +77,7 @@ func (r *ragService) buildContextForPrompt(docs []schema.Document) string {
 	return contextBuilder.String()
 }
 
-// mergeChunksForFile merges consecutive chunks from the same source file,
-// removing overlapping text to produce a single continuous code block.
-// This prevents token waste and confusing duplicate snippets for the LLM.
+// mergeChunksForFile merges consecutive chunks from the same source file.
 func mergeChunksForFile(docs []schema.Document, r *ragService) string {
 	if len(docs) == 1 {
 		return r.getDocContent(docs[0])
@@ -105,8 +103,7 @@ func mergeChunksForFile(docs []schema.Document, r *ragService) string {
 	return merged.String()
 }
 
-// findOverlapStart returns the length of the longest suffix of prev that is
-// also a prefix of curr. Checks overlaps of up to 300 characters.
+// findOverlapStart returns the length of the longest suffix of prev that is also a prefix of curr.
 func findOverlapStart(prev, curr string) int {
 	const maxOverlap = 300
 	overlap := len(prev)
@@ -127,10 +124,7 @@ func findOverlapStart(prev, curr string) int {
 	return 0
 }
 
-// filterAddedLines extracts only the added ('+') lines from a git patch string,
-// stripping the leading '+' character. Lines starting with '+++' (file header) are excluded.
-// This prevents regex symbol extraction from matching deleted ('-') lines, which could
-// produce stale or incorrect symbol names.
+// filterAddedLines extracts only the added ('+') lines from a git patch.
 func filterAddedLines(patch string) string {
 	lines := strings.Split(patch, "\n")
 	var added []string
@@ -143,8 +137,6 @@ func filterAddedLines(patch string) string {
 }
 
 // extractSymbolsFromPatch extracts potential type/function names from a git patch.
-// IMPORTANT: Only added lines ('+') are processed to avoid matching deleted symbols.
-// Uses pre-compiled regexes for performance.
 func extractSymbolsFromPatch(patch string) []string {
 	symbols := make(map[string]struct{})
 
@@ -195,27 +187,20 @@ const maxDepth2Symbols = 15
 // maxSymbolWorkers limits concurrent DefinitionRetriever lookups at each depth.
 const maxSymbolWorkers = 10
 
-// gatherDefinitionsContext extracts symbols from the changed files and retrieves their definitions
-// using a two-depth recursive resolution strategy:
-//
-//	Depth 0: Extract symbols from git diff patches (regex-based).
-//	Depth 1: Concurrently retrieve definitions for those symbols from the vector store.
-//	Depth 2: Parse retrieved definitions for transitive symbol references (via ExtractUsedSymbols)
-//	          and concurrently retrieve those as well.
-//
-// This ensures the LLM has complete type dependency context (e.g., User → Address → Address.Validate).
+// gatherDefinitionsContext extracts symbols from changed files and retrieves their definitions.
 func (r *ragService) gatherDefinitionsContext(ctx context.Context, scopedStore storage.ScopedVectorStore, changedFiles []internalgithub.ChangedFile, seenDocs map[string]struct{}, mu *sync.RWMutex) string {
 	if len(changedFiles) == 0 {
 		return ""
 	}
 
-	// ── Depth 0: Extract symbols from diff ──────────────────────────────
+	// Symbol extraction
 	symbolList := r.extractDepth0Symbols(changedFiles)
 	if len(symbolList) == 0 {
 		r.logger.Info("stage skipped", "name", "SymbolResolution", "reason", "no_symbols_found")
 		return ""
 	}
 
+	r.logger.Debug("extracted symbols from diff", "symbols", symbolList)
 	r.logger.Info("stage started", "name", "SymbolResolution", "depth0_symbols", len(symbolList))
 
 	seenSymbols := make(map[string]struct{})
@@ -223,14 +208,14 @@ func (r *ragService) gatherDefinitionsContext(ctx context.Context, scopedStore s
 		seenSymbols[s] = struct{}{}
 	}
 
-	// ── Depth 1: Concurrently resolve Depth-0 symbols ───────────────────
+	// Resolve direct symbols
 	depth1Defs := r.resolveSymbolsConcurrently(ctx, symbolList, scopedStore, seenDocs, mu)
 	r.logger.Info("depth-1 resolution complete", "resolved", len(depth1Defs))
 
-	// ── Depth 2: Resolve transitive symbols found inside Depth-1 definitions ──
+	// Resolve transitive symbols
 	depth2Defs := r.resolveDepth2Symbols(ctx, depth1Defs, seenSymbols, scopedStore, seenDocs, mu)
 
-	// ── Format output ───────────────────────────────────────────────────
+	// Format output
 	return r.formatResolvedDefinitions(depth1Defs, depth2Defs)
 }
 
@@ -248,8 +233,7 @@ func (r *ragService) extractDepth0Symbols(changedFiles []internalgithub.ChangedF
 	return mapKeysToSlice(depth0Symbols, maxDepth0Symbols)
 }
 
-// resolveDepth2Symbols extracts transitive symbols from Depth-1 definitions,
-// deduplicates them, and resolves the new ones concurrently.
+// resolveDepth2Symbols extracts transitive symbols from Depth-1 definitions.
 func (r *ragService) resolveDepth2Symbols(
 	ctx context.Context,
 	depth1Defs []resolvedDefinition,
@@ -310,8 +294,7 @@ func (r *ragService) formatResolvedDefinitions(depth1Defs, depth2Defs []resolved
 	return builder.String()
 }
 
-// resolveSymbolsConcurrently resolves a list of symbols in parallel using errgroup.
-// Returns the successfully resolved definitions.
+// resolveSymbolsConcurrently resolves symbols in parallel.
 func (r *ragService) resolveSymbolsConcurrently(
 	ctx context.Context, symbols []string,
 	scopedStore storage.ScopedVectorStore,
@@ -345,10 +328,7 @@ func (r *ragService) resolveSymbolsConcurrently(
 	return results
 }
 
-// extractTransitiveSymbols parses a resolved definition's content to find
-// additional symbols referenced within it (e.g., field types, method parameters).
-// Uses the language-aware parser from the registry when available, falling back
-// to the regex-based extractor.
+// extractTransitiveSymbols parses a definition to find referenced symbols.
 func (r *ragService) extractTransitiveSymbols(source, content string) []string {
 	if r.parserRegistry == nil {
 		return extractSymbolsFromPatch(content) // Fallback to regex
@@ -424,9 +404,7 @@ func (r *ragService) resolveSymbolDefinition(ctx context.Context, symbol string,
 	return source, content, true
 }
 
-// buildRelevantContext performs similarity searches using file diffs to find related
-// code snippets from the repository. These results provide context to help the LLM
-// better understand the scope and impact of the changes.
+// buildRelevantContext performs similarity searches to find related code snippets.
 func (r *ragService) buildRelevantContext(ctx context.Context, collectionName, embedderModelName, repoPath string, changedFiles []internalgithub.ChangedFile, prDescription string) (string, string) {
 	if len(changedFiles) == 0 {
 		return "", ""
@@ -442,6 +420,14 @@ func (r *ragService) buildRelevantContext(ctx context.Context, collectionName, e
 
 	archContext, definitionsContext, impactDocs, descDocs, hydeResults, indices := r.buildContextConcurrently(
 		ctx, collectionName, embedderModelName, repoPath, prDescription, changedFiles, scopedStore)
+
+	r.logger.Debug("raw context gathered",
+		"arch_found", archContext != "",
+		"definitions_found", definitionsContext != "",
+		"impact_docs_count", len(impactDocs),
+		"description_docs_count", len(descDocs),
+		"hyde_results_count", len(hydeResults),
+	)
 
 	allDocs := mergeAndDedup(append(impactDocs, descDocs...), r.getDocKey)
 
@@ -585,6 +571,11 @@ func (r *ragService) filterValidDescriptionDocs(ctx context.Context, descKeys ma
 			validSources[source] = true
 		}
 	}
+
+	r.logger.Debug("description snippets validated",
+		"total_candidates", len(toValidate),
+		"valid_count", len(validSources),
+	)
 	return validSources
 }
 
@@ -624,8 +615,7 @@ func (r *ragService) formatSplitDocs(
 	return impactBuilder.String(), descCtx
 }
 
-// gatherDescriptionDocs uses MultiQuery retrieval to find documents related to the PR description.
-// Returns raw []schema.Document for deterministic dedup in the caller.
+// gatherDescriptionDocs finds documents related to the PR description.
 func (r *ragService) gatherDescriptionDocs(ctx context.Context, collection, embedder, description string) []schema.Document {
 	r.logger.Info("stage started", "name", "DescriptionContext")
 
@@ -665,8 +655,7 @@ func (r *ragService) gatherDescriptionDocs(ctx context.Context, collection, embe
 	return allDocs
 }
 
-// gatherImpactDocs returns raw impact docs without formatting or shared seenDocs.
-// Replaces gatherImpactContext: dedup now happens after wg.Wait() in the caller.
+// gatherImpactDocs returns raw impact docs without formatting.
 func (r *ragService) gatherImpactDocs(ctx context.Context, store storage.ScopedVectorStore, repoPath string, files []internalgithub.ChangedFile) []schema.Document {
 	r.logger.Info("stage started", "name", "ImpactAnalysis")
 	docs := r.getImpactDocs(ctx, store, repoPath, files)
@@ -674,9 +663,7 @@ func (r *ragService) gatherImpactDocs(ctx context.Context, store storage.ScopedV
 	return docs
 }
 
-// assembleContext assembles the final prompt context from all gathered sections,
-// applying a token budget to prevent context window overflow (Issue #3).
-// Priority order (high → low): definitions → description → impact → arch → hyde.
+// assembleContext assembles the final prompt context.
 func (r *ragService) assembleContext(
 	arch, impact, description, definitions string,
 	hyde [][]schema.Document, indices []int,
@@ -739,6 +726,7 @@ func (r *ragService) assembleContext(
 		"definitions_len", len(definitions),
 		"hyde_results_count", len(hyde),
 		"packed_len", len(result),
+		"is_truncated", packer.isTruncated,
 	)
 
 	return result
@@ -750,12 +738,11 @@ type tokenContextSection struct {
 	content string
 }
 
-// tokenContextPacker packs context sections into a token budget, truncating
-// lower-priority sections first. It uses a simple character-based estimate
-// (1 token ≈ 3 characters) for speed — no extra LLM calls needed.
+// tokenContextPacker packs context sections into a token budget.
 type tokenContextPacker struct {
-	budget   int
-	sections []tokenContextSection
+	budget      int
+	sections    []tokenContextSection
+	isTruncated bool
 }
 
 func newTokenContextPacker(tokenBudget int) *tokenContextPacker {
@@ -789,6 +776,7 @@ func (p *tokenContextPacker) build() string {
 			remaining -= tokens
 
 		case remaining > 50: // Only truncate if there's meaningful space left
+			p.isTruncated = true
 			// Truncate to remaining budget
 			maxChars := remaining * 3
 			truncated := sec.content[:maxChars]
@@ -801,6 +789,7 @@ func (p *tokenContextPacker) build() string {
 			remaining = 0
 
 		default: // Budget exhausted
+			p.isTruncated = true
 			out.WriteString(fmt.Sprintf("[%s context omitted — token budget exhausted]\n\n---\n\n", sec.name))
 		}
 	}

--- a/internal/rag/rag_hyde.go
+++ b/internal/rag/rag_hyde.go
@@ -20,6 +20,7 @@ type HyDEData struct {
 
 const hydeBaseQueryPrompt = "To understand the impact of changes in the file '%s', find relevant code that interacts with or is related to the following diff:\n%s"
 
+// dynamicSparseRetriever retrieves documents using sparse vectors if available.
 type dynamicSparseRetriever struct {
 	store   storage.ScopedVectorStore
 	numDocs int
@@ -95,8 +96,11 @@ func (r *ragService) gatherHyDEContext(ctx context.Context, collection, embedder
 		}
 
 		if len(docs) > 0 {
+			r.logger.Debug("HyDE docs found", "file", file.Filename, "count", len(docs))
 			finalResults = append(finalResults, docs)
 			finalIndices = append(finalIndices, i)
+		} else {
+			r.logger.Debug("no HyDE docs found", "file", file.Filename)
 		}
 	}
 
@@ -104,6 +108,7 @@ func (r *ragService) gatherHyDEContext(ctx context.Context, collection, embedder
 	return finalResults, finalIndices
 }
 
+// generateHyDESnippet generates a HyDE snippet.
 func (r *ragService) generateHyDESnippet(ctx context.Context, q string) (string, error) {
 	patchHash := r.hashPatch(q)
 	if cached, ok := r.hydeCache.Load(patchHash); ok {

--- a/internal/rag/rag_impact.go
+++ b/internal/rag/rag_impact.go
@@ -18,9 +18,7 @@ type depRequest struct {
 	File    internalgithub.ChangedFile
 }
 
-// getImpactDocs returns raw impact documents without formatting or deduplication.
-// Deduplication is handled by the caller (buildRelevantContext) after all goroutines
-// complete, ensuring deterministic output.
+// getImpactDocs returns related documents for impact analysis.
 func (r *ragService) getImpactDocs(ctx context.Context, store storage.ScopedVectorStore, repoPath string, files []internalgithub.ChangedFile) []schema.Document {
 	retriever, err := vectorstores.NewDependencyRetriever(store)
 	if err != nil {
@@ -88,18 +86,19 @@ func (r *ragService) fetchImpactResults(ctx context.Context, retriever *vectorst
 	var wg sync.WaitGroup
 	for _, req := range reqs {
 		wg.Add(1)
-		go func(r depRequest) {
+		go func(dr depRequest) {
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			network, err := retriever.GetContextNetwork(ctx, r.Pkg, r.Imports)
+			network, err := retriever.GetContextNetwork(ctx, dr.Pkg, dr.Imports)
 			if err != nil {
 				return
 			}
 
 			depMu.Lock()
-			depResults[r.File.Filename] = network.Dependents
+			depResults[dr.File.Filename] = network.Dependents
+			r.logger.Debug("impact graph fetched", "file", dr.File.Filename, "dependents", len(network.Dependents))
 			depMu.Unlock()
 		}(req)
 	}

--- a/internal/rag/rag_question.go
+++ b/internal/rag/rag_question.go
@@ -19,7 +19,7 @@ type QuestionPromptData struct {
 }
 
 func (r *ragService) AnswerQuestion(ctx context.Context, collectionName, embedderModelName, question string, history []string) (string, error) {
-	r.logger.Info("Answering question with RAG context", "collection", collectionName)
+	r.logger.Info("answering question", "collection", collectionName)
 
 	var retriever schema.Retriever
 	scopedStore := r.vectorStore.ForRepo(collectionName, embedderModelName)
@@ -34,8 +34,7 @@ func (r *ragService) AnswerQuestion(ctx context.Context, collectionName, embedde
 		retriever = vectorstores.ToRetriever(scopedStore, 5, vectorstores.WithSparseQuery(sparseQuery))
 	}
 
-	// Try to use ValidatingRetrievalQA if a fast model is configured for validation
-	// This validates the retrieved context before generating an answer
+	// Use ValidatingRetrievalQA if a fast model is configured.
 	if r.cfg.AI.FastModel != "" {
 		validatorLLM, err := r.getOrCreateLLM(ctx, r.cfg.AI.FastModel)
 		if err == nil {
@@ -49,7 +48,6 @@ func (r *ragService) AnswerQuestion(ctx context.Context, collectionName, embedde
 }
 
 // answerWithValidation uses ValidatingRetrievalQA to validate context before answering.
-// If the retrieved context is not relevant, it generates an answer without context.
 func (r *ragService) answerWithValidation(ctx context.Context, retriever schema.Retriever, validatorLLM llms.Model, question string, history []string) (string, error) {
 	chain, err := chains.NewValidatingRetrievalQA(
 		retriever,
@@ -66,8 +64,7 @@ func (r *ragService) answerWithValidation(ctx context.Context, retriever schema.
 		return "", fmt.Errorf("validating QA chain failed: %w", err)
 	}
 
-	// If there's conversation history, we need to incorporate it
-	// ValidatingRetrievalQA doesn't support history natively, so we append it
+	// If there's conversation history, we need to incorporate it.
 	if len(history) > 0 {
 		answer = r.enrichAnswerWithContext(answer, history)
 	}
@@ -82,10 +79,10 @@ func (r *ragService) answerWithoutValidation(ctx context.Context, retriever sche
 		retriever,
 		r.generatorLLM,
 		chains.WithPromptBuilder(func(q string, docs []schema.Document) (string, error) {
-			for _, doc := range docs {
-				r.logger.Debug("got a document after similarity search:", "document", doc)
+			r.logger.Debug("retrieved docs for question", "count", len(docs))
+			for i, doc := range docs {
+				r.logger.Debug("retrieved doc metadata", "idx", i, "source", doc.Metadata["source"])
 			}
-			r.logger.Debug("Retrieved relevant documents for question", "count", len(docs))
 
 			contextString := r.buildContextForPrompt(docs)
 			promptData := QuestionPromptData{

--- a/internal/rag/rag_rereview.go
+++ b/internal/rag/rag_rereview.go
@@ -16,8 +16,7 @@ import (
 	"github.com/sevigo/code-warden/internal/storage"
 )
 
-// GenerateReReview performs feedback-driven retrieval to find relevant context
-// for verifying fixes to previously identified issues.
+// GenerateReReview performs feedback-driven retrieval for verifying fixes.
 func (r *ragService) GenerateReReview(ctx context.Context, repo *storage.Repository, event *core.GitHubEvent, originalReview *core.Review, ghClient internalgithub.Client, changedFiles []internalgithub.ChangedFile) (*core.StructuredReview, string, error) {
 	r.logger.Info("preparing data for a re-review", "repo", event.RepoFullName, "pr", event.PRNumber)
 
@@ -32,17 +31,17 @@ func (r *ragService) GenerateReReview(ctx context.Context, repo *storage.Reposit
 		}, "This pull request contains no new code changes to re-review.", nil
 	}
 
-	// Step 1: Build standard context (Arch + Impact + HyDE + Definitions) for the changed files
+	// Build standard context
 	standardContext, definitionsContext := r.buildRelevantContext(ctx, repo.QdrantCollectionName, repo.EmbedderModelName, repo.ClonePath, changedFiles, event.PRTitle+"\n"+event.PRBody)
 
-	// Step 2: Extract feedback-driven search queries from original review
+	// Extract search queries from original review
 	feedbackQueries := r.extractCommentsFromReview(ctx, originalReview.ReviewContent)
 	r.logger.Info("extracted feedback-driven search queries", "count", len(feedbackQueries))
 
-	// Step 3: Perform feedback-driven vector searches
+	// Feedback-driven searches
 	feedbackContext := r.buildFeedbackDrivenContext(ctx, repo.QdrantCollectionName, repo.EmbedderModelName, feedbackQueries, event.UserInstructions)
 
-	// Step 4: Combine contexts with feedback-driven results prioritized
+	// Combine contexts
 	combinedContext := r.combineReReviewContext(standardContext, feedbackContext)
 
 	promptData := core.ReReviewData{
@@ -75,8 +74,7 @@ func (r *ragService) GenerateReReview(ctx context.Context, repo *storage.Reposit
 	return structuredReview, rawReview, nil
 }
 
-// buildFeedbackDrivenContext performs vector searches using the extracted feedback
-// comments as queries to find relevant code definitions and dependencies.
+// buildFeedbackDrivenContext performs vector searches based on feedback.
 func (r *ragService) buildFeedbackDrivenContext(ctx context.Context, collectionName, embedderModelName string, feedbackQueries []string, userInstructions string) string {
 	if len(feedbackQueries) == 0 && userInstructions == "" {
 		return ""
@@ -87,43 +85,37 @@ func (r *ragService) buildFeedbackDrivenContext(ctx context.Context, collectionN
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 
-	// Channel to collect results from goroutines
 	resultChan := make(chan string, len(feedbackQueries)+1)
 
-	// Limit concurrent searches to prevent resource exhaustion
 	const maxConcurrentSearches = 10
 	semaphore := make(chan struct{}, maxConcurrentSearches)
 
-	// Search for each feedback query
 	for _, query := range feedbackQueries {
 		if strings.TrimSpace(query) == "" {
 			continue
 		}
 		wg.Add(1)
-		semaphore <- struct{}{} // Acquire slot
+		semaphore <- struct{}{}
 		go func(q string) {
-			defer func() { <-semaphore }() // Release slot
+			defer func() { <-semaphore }()
 			r.performReReviewSearch(ctx, scopedStore, q, "feedback query", "Relevant to", resultChan, seenDocs, &mu, &wg)
 		}(query)
 	}
 
-	// If user provided specific instructions, search for those too
 	if userInstructions != "" {
 		wg.Add(1)
-		semaphore <- struct{}{} // Acquire slot
+		semaphore <- struct{}{}
 		go func() {
-			defer func() { <-semaphore }() // Release slot
+			defer func() { <-semaphore }()
 			r.performReReviewSearch(ctx, scopedStore, userInstructions, "user instructions", "Relevant to user focus", resultChan, seenDocs, &mu, &wg)
 		}()
 	}
 
-	// Wait for all searches to complete, then close the channel
 	go func() {
 		wg.Wait()
 		close(resultChan)
 	}()
 
-	// Collect all results into the builder (single goroutine - no race condition)
 	var contextBuilder strings.Builder
 	contextBuilder.WriteString("# Feedback-Driven Context\n\n")
 	contextBuilder.WriteString("The following code definitions and dependencies are relevant to the issues raised in the original review:\n\n")
@@ -141,12 +133,10 @@ func (r *ragService) buildFeedbackDrivenContext(ctx context.Context, collectionN
 	return contextBuilder.String()
 }
 
-// performReReviewSearch executes a single search query (either from feedback or user instructions)
-// and handles deduplication and result formatting for the re-review context.
+// performReReviewSearch executes a search query for re-review context.
 func (r *ragService) performReReviewSearch(ctx context.Context, scopedStore storage.ScopedVectorStore, query, queryType, headerPrefix string, resultChan chan<- string, seenDocs map[string]struct{}, mu *sync.Mutex, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	// Check for cancellation before starting work
 	select {
 	case <-ctx.Done():
 		return
@@ -166,7 +156,6 @@ func (r *ragService) performReReviewSearch(ctx context.Context, scopedStore stor
 	var builder strings.Builder
 
 	for _, doc := range docs {
-		// Check for cancellation during processing
 		select {
 		case <-ctx.Done():
 			return
@@ -209,15 +198,13 @@ func (r *ragService) performSearch(ctx context.Context, scopedStore storage.Scop
 
 	docs, err := scopedStore.SimilaritySearch(ctx, query, 5, searchOpts...)
 	if err != nil {
-		r.logger.Warn("search failed", "queryType", queryType, "query", query[:min(50, len(query))], "error", err)
-		return nil
+		r.logger.Warn("re-review search failed", "queryType", queryType, "error", err)
 	}
-
+	r.logger.Debug("re-review search complete", "queryType", queryType, "docs_found", len(docs))
 	return docs
 }
 
-// combineReReviewContext merges standard context with feedback-driven context,
-// prioritizing feedback-driven results at the beginning.
+// combineReReviewContext merges standard context with feedback-driven context.
 func (r *ragService) combineReReviewContext(standardContext, feedbackContext string) string {
 	if feedbackContext == "" {
 		return standardContext
@@ -231,12 +218,10 @@ func (r *ragService) combineReReviewContext(standardContext, feedbackContext str
 	return result.String()
 }
 
-// extractCommentsFromReview parses the original review content and extracts
-// all comment contents to use as feedback-driven search queries.
+// extractCommentsFromReview parses the review content to extract search queries.
 func (r *ragService) extractCommentsFromReview(ctx context.Context, reviewContent string) []string {
 	var queries []string
 
-	// Use the new parser to properly unmarshal the LLM review
 	parsedReview, err := llm.ParseMarkdownReview(ctx, reviewContent, r.logger)
 	if err != nil {
 		r.logger.Warn("extractCommentsFromReview: failed to parse review content", "error", err)
@@ -245,7 +230,6 @@ func (r *ragService) extractCommentsFromReview(ctx context.Context, reviewConten
 
 	for _, s := range parsedReview.Suggestions {
 		if strings.TrimSpace(s.Comment) != "" {
-			// Clean up the comment for use as a search query
 			cleaned := r.cleanCommentForQuery(s.Comment)
 			if cleaned != "" {
 				queries = append(queries, cleaned)
@@ -256,26 +240,19 @@ func (r *ragService) extractCommentsFromReview(ctx context.Context, reviewConten
 	return queries
 }
 
-// cleanCommentForQuery prepares a comment for use as a vector search query.
-// It normalizes markdown artifacts and structural headers while preserving semantic context.
+// cleanCommentForQuery prepares a comment for use as a search query.
 func (r *ragService) cleanCommentForQuery(comment string) string {
-	// Remove markdown formatting (backticks)
 	comment = strings.ReplaceAll(comment, "```", " ")
 	comment = strings.ReplaceAll(comment, "`", " ")
 
-	// Normalize structural headers to separators for semantic retention
-	// This preserves the semantic meaning (e.g., "Observation:", "Fix:") while reducing noise.
-	// Status markers are removed as they don't contribute to code retrieval.
 	comment = statusRegex.ReplaceAllString(comment, " ")
 	comment = obsRegex.ReplaceAllString(comment, " | Observation: ")
 	comment = rootCauseRegex.ReplaceAllString(comment, " | Root Cause: ")
 	comment = fixRegex.ReplaceAllString(comment, " | Fix: ")
 
-	// Collapse multiple spaces and trim
 	comment = whitespaceRegex.ReplaceAllString(comment, " ")
 	comment = strings.TrimSpace(comment)
 
-	// Limit query length to avoid overly long searches
 	const maxQueryLen = 500
 	if len(comment) > maxQueryLen {
 		if idx := strings.LastIndex(comment[:maxQueryLen], " "); idx > 400 {

--- a/internal/rag/rag_review.go
+++ b/internal/rag/rag_review.go
@@ -61,7 +61,7 @@ func (r *ragService) GenerateReview(ctx context.Context, repoConfig *core.RepoCo
 
 	contextString, definitionsContext := r.buildRelevantContext(ctx, repo.QdrantCollectionName, repo.EmbedderModelName, repo.ClonePath, changedFiles, event.PRTitle+"\n"+event.PRBody)
 
-	// HIGH PRIORITY: Check for empty context to warn about hallucination risk
+	// Check for empty context to warn about hallucination risk
 	contextIsEmpty := contextIsEmpty(contextString, definitionsContext)
 	if contextIsEmpty {
 		r.logger.Warn("HIGH HALLUCINATION RISK: no context retrieved from vector store - review will be based solely on diff without repository context",
@@ -121,8 +121,8 @@ func (r *ragService) buildReviewPromptData(event *core.GitHubEvent, repoConfig *
 	}
 }
 
-// contextIsEmpty checks if both context strings are empty, indicating no repository context was retrieved.
-// This is used to detect high hallucination risk scenarios.
+// contextIsEmpty checks if both context strings are empty.
+// This helps detect high hallucination risk.
 func contextIsEmpty(contextString, definitionsContext string) bool {
 	return contextString == "" && definitionsContext == ""
 }
@@ -141,7 +141,13 @@ func (r *ragService) GenerateConsensusReview(ctx context.Context, repoConfig *co
 
 	contextString, definitionsContext := r.buildRelevantContext(ctx, repo.QdrantCollectionName, repo.EmbedderModelName, repo.ClonePath, changedFiles, event.PRTitle+"\n"+event.PRBody)
 
-	// HIGH PRIORITY: Check for empty context to warn about hallucination risk
+	r.logger.Info("stage started", "name", "ConsensusGathering", "models_count", len(models))
+	r.logger.Debug("consensus context gathered",
+		"context_len", len(contextString),
+		"definitions_len", len(definitionsContext),
+	)
+
+	// Warn if no context was retrieved
 	contextWasEmpty := contextIsEmpty(contextString, definitionsContext)
 	if contextWasEmpty {
 		r.logger.Warn("HIGH HALLUCINATION RISK: no context retrieved from vector store - consensus review will be based solely on diff",
@@ -169,6 +175,7 @@ func (r *ragService) GenerateConsensusReview(ctx context.Context, repoConfig *co
 			defer cancel()
 
 			resp, err := llmModel.Call(tCtx, prompt)
+			r.logger.Debug("model review finished", "model", modelName, "error", err, "review_len", len(resp))
 			return ComparisonResult{Model: modelName, Review: resp, Error: err}, nil
 		},
 		func(ctx context.Context, results []ComparisonResult) (string, error) {
@@ -206,7 +213,7 @@ func (r *ragService) GenerateConsensusReview(ctx context.Context, repoConfig *co
 }
 
 func (r *ragService) validateStructuredReview(ctx context.Context, event *core.GitHubEvent, review *core.StructuredReview) error {
-	// Verify integrity of consensus review
+	// check review integrity
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
@@ -242,7 +249,7 @@ func (r *ragService) synthesizeConsensus(ctx context.Context, repoConfig *core.R
 	timestamp := time.Now().Format("20060102_150405_000000000")
 	reviewsDir := "reviews"
 
-	// Resolve artifacts directory safely
+	// Ensure reviews directory exists
 	if err := r.ensureReviewsDir(reviewsDir); err != nil {
 		return "", nil, err
 	}
@@ -278,6 +285,7 @@ func (r *ragService) synthesizeConsensus(ctx context.Context, repoConfig *core.R
 		return "", nil, fmt.Errorf("failed to generate consensus: %w", err)
 	}
 
+	r.logger.Debug("consensus synthesis complete", "valid_reviews", len(validReviews))
 	r.saveConsensusArtifact(reviewsDir, rawConsensus, timestamp)
 	return rawConsensus, validReviews, nil
 }
@@ -349,13 +357,12 @@ func SanitizeModelForFilename(modelName string) string {
 		sanitized = "model"
 	}
 
-	// Security: Prevent collisions by adding a short deterministic hash
+	// Add a short hash to prevent name collisions
 	h := sha256.New()
 	h.Write([]byte(modelName))
 	hashStr := hex.EncodeToString(h.Sum(nil))[:16]
 
-	// Windows reserved names check (case-insensitive)
-	// Ref: Deepseek review - handle extension-like suffixes (e.g., COM1.txt)
+	// Handle Windows reserved names
 	reserved := map[string]bool{
 		"CON": true, "PRN": true, "AUX": true, "NUL": true,
 		"COM1": true, "COM2": true, "COM3": true, "COM4": true, "COM5": true, "COM6": true, "COM7": true, "COM8": true, "COM9": true,
@@ -380,8 +387,7 @@ func SanitizeModelForFilename(modelName string) string {
 	return fullName
 }
 
-// formatChangedFiles returns a markdown-formatted list of changed file paths
-// to include in the LLM prompt.
+// formatChangedFiles returns a markdown-formatted list of changed file paths.
 func (r *ragService) formatChangedFiles(files []internalgithub.ChangedFile) string {
 	var builder strings.Builder
 	for _, file := range files {

--- a/internal/rag/reuse_detector.go
+++ b/internal/rag/reuse_detector.go
@@ -140,7 +140,7 @@ func (d *ReuseDetector) DetectRedundancies(
 					"file", fn.FilePath,
 					"error", err,
 				)
-				return nil // Continue processing other functions
+				return nil
 			}
 
 			if suggestion != nil {
@@ -328,7 +328,7 @@ func (d *ReuseDetector) retrieveSimilarCode(
 	results, err := scopedStore.SimilaritySearch(
 		ctx,
 		query,
-		3, // Top 3 matches
+		3,
 		vectorstores.WithFilter("source", excludeFile),
 	)
 	if err != nil {

--- a/internal/rag/snippet_validator.go
+++ b/internal/rag/snippet_validator.go
@@ -11,14 +11,13 @@ import (
 	"github.com/sevigo/code-warden/internal/llm"
 )
 
-// snippetValidator uses a fast LLM to validate whether code snippets are
-// relevant to a PR description. All validation is done in a single batch call.
+// snippetValidator validates whether code snippets are relevant to a PR description.
 type snippetValidator struct {
 	validatorLLM llms.Model
 	promptMgr    *llm.PromptManager
 }
 
-// newSnippetValidator creates a validator backed by the provided LLM.
+// newSnippetValidator creates a new validator.
 func newSnippetValidator(validatorLLM llms.Model, promptMgr *llm.PromptManager) *snippetValidator {
 	return &snippetValidator{
 		validatorLLM: validatorLLM,
@@ -30,10 +29,7 @@ func newSnippetValidator(validatorLLM llms.Model, promptMgr *llm.PromptManager) 
 // {"0": true, "1": false, ...}
 type batchValidationResult map[string]bool
 
-// validateBatch sends all snippets to the LLM in a single call and returns a
-// map of snippet-index → relevant. Fails open (all true) on any error.
-// This is Issue #6's fix: replaces N sequential per-snippet LLM calls with one
-// batched call.
+// validateBatch validates all snippets in a single call.
 func (v *snippetValidator) validateBatch(ctx context.Context, snippets []string, prContext string) map[int]bool {
 	result := make(map[int]bool, len(snippets))
 	for i := range snippets {
@@ -63,7 +59,7 @@ func (v *snippetValidator) validateBatch(ctx context.Context, snippets []string,
 	return result
 }
 
-// buildBatchPrompt constructs the numbered-snippet prompt for batch validation.
+// buildBatchPrompt constructs the prompt for batch validation.
 func (v *snippetValidator) buildBatchPrompt(snippets []string, prContext string) (string, error) {
 	var snippetList strings.Builder
 	for i, s := range snippets {
@@ -99,7 +95,7 @@ func parseBatchResponse(raw string) (batchValidationResult, error) {
 	return parsed, nil
 }
 
-// applyParsedResults writes the LLM's relevance decisions onto the result map.
+// applyParsedResults applies the relevance decisions to the result map.
 func applyParsedResults(parsed batchValidationResult, snippetCount int, result map[int]bool) {
 	for k, relevant := range parsed {
 		idx := atoiSafe(k)

--- a/internal/wire/wire_gen.go
+++ b/internal/wire/wire_gen.go
@@ -9,6 +9,13 @@ package wire
 import (
 	"context"
 	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
 	"github.com/jmoiron/sqlx"
 	"github.com/sevigo/code-warden/internal/app"
 	"github.com/sevigo/code-warden/internal/config"
@@ -29,12 +36,6 @@ import (
 	"github.com/sevigo/goframe/schema"
 	"github.com/sevigo/goframe/textsplitter"
 	"github.com/sevigo/goframe/vectorstores/qdrant"
-	"io"
-	"log/slog"
-	"net"
-	"net/http"
-	"os"
-	"time"
 )
 
 // Injectors from wire.go:


### PR DESCRIPTION
This PR adds detailed debug logging to the RAG pipeline to improve visibility into context gathering and assembly. It also cleans up several comments that sounded too much like they were generated by an LLM.