### PR TITLE
feat(config): add exclude_files and improve filtering

### DIFF
--- a/.code-warden.yml
+++ b/.code-warden.yml
@@ -3,6 +3,7 @@ custom_instructions:
   - "Pay close attention to Go best practices, especially regarding error handling and context propagation."
   - "The project uses the 'slog' library for structured logging. Ensure all new logging statements follow this standard."
   - "Verify that user-facing configuration options are handled gracefully, with clear defaults."
+  - "Add a citate from a famous sci-fi book or movie or tv show."
 
 # Directories to completely exclude from indexing. This is for performance.
 # These are added to the application's built-in defaults like '.git' and 'node_modules'.
@@ -11,12 +12,12 @@ exclude_dirs:
   - "keys"        # Private keys and certificates
   - "reviews"     # Generated review history
   - ".agent"      # Local agent/workflow state
-  - "bin"          # Compiled binaries
-  - "vendor"       # Dependency source code
-  - "scripts"      # Utility scripts, often not core logic
-  - "mocks"        # Generated mock code
+  - "bin"         # Compiled binaries
+  - "vendor"      # Dependency source code
+  - "scripts"     # Utility scripts, often not core logic
+  - "mocks"       # Generated mock code
   - ".github"     # CI configuration
-  - "embeddings"   # Script service for local embeddings
+  - "embeddings"  # Script service for local embeddings
 
 # File extensions to exclude from indexing.
 exclude_exts:

--- a/.code-warden.yml
+++ b/.code-warden.yml
@@ -8,6 +8,13 @@ custom_instructions:
 # These are added to the application's built-in defaults like '.git' and 'node_modules'.
 exclude_dirs:
   - ".vscode"
+  - "keys"
+  - "reviews"
+  - ".agent"
+  - "bin"
+  - "vendor"
+  - "scripts" 
+  - "mocks"
 
 # File extensions to exclude from indexing.
 exclude_exts:
@@ -15,3 +22,12 @@ exclude_exts:
   - ".yml"     # Exclude Docker Compose and other YAML files.
   - ".sql"     # Exclude raw SQL migration files.
   - ".prompt"  # Exclude the LLM prompt template files.
+
+
+# Specific files to exclude from indexing by their relative path.
+exclude_files:
+  - ".code-warden.yml"
+  - "config.yml"
+  - ".gitignore"
+  - "go.mod"
+  - "CLAUDE.md"

--- a/.code-warden.yml
+++ b/.code-warden.yml
@@ -8,26 +8,36 @@ custom_instructions:
 # These are added to the application's built-in defaults like '.git' and 'node_modules'.
 exclude_dirs:
   - ".vscode"
-  - "keys"
-  - "reviews"
-  - ".agent"
-  - "bin"
-  - "vendor"
-  - "scripts" 
-  - "mocks"
+  - "keys"        # Private keys and certificates
+  - "reviews"     # Generated review history
+  - ".agent"      # Local agent/workflow state
+  - "bin"          # Compiled binaries
+  - "vendor"       # Dependency source code
+  - "scripts"      # Utility scripts, often not core logic
+  - "mocks"        # Generated mock code
+  - ".github"     # CI configuration
+  - "embeddings"   # Script service for local embeddings
 
 # File extensions to exclude from indexing.
 exclude_exts:
-  - ".sum"     # The go.sum file is not useful for code context.
-  - ".yml"     # Exclude Docker Compose and other YAML files.
-  - ".sql"     # Exclude raw SQL migration files.
-  - ".prompt"  # Exclude the LLM prompt template files.
-
+  - ".sum"         # Dependency checksums
+  - ".sql"         # Database migrations (unless needed for RAG)
+  - ".prompt"      # Prompt templates (can lead to confusing RAG results)
+  - ".log"         # Log files
+  - ".exe"         # Windows binaries
+  - ".dll"         # Windows libraries
+  - ".so"          # Linux libraries
+  - ".tmp"         # Temporary files
 
 # Specific files to exclude from indexing by their relative path.
 exclude_files:
-  - ".code-warden.yml"
-  - "config.yml"
+  - ".code-warden.yml" # The config itself
+  - "config.yaml"      # Secrets/Local config
+  - "config.yaml.example"
   - ".gitignore"
-  - "go.mod"
-  - "CLAUDE.md"
+  - "go.mod"           # Build metadata
+  - "CLAUDE.md"        # Local IDE instructions
+  - ".golangci.yml"    # Linter config
+  - "Dockerfile"
+  - "docker-compose.yml"
+  - "Makefile"

--- a/.code-warden.yml
+++ b/.code-warden.yml
@@ -3,7 +3,7 @@ custom_instructions:
   - "Pay close attention to Go best practices, especially regarding error handling and context propagation."
   - "The project uses the 'slog' library for structured logging. Ensure all new logging statements follow this standard."
   - "Verify that user-facing configuration options are handled gracefully, with clear defaults."
-  - "Add a citate from a famous sci-fi book or movie or tv show."
+  - "Add a quote from a famous sci-fi book or movie or tv show."
 
 # Directories to completely exclude from indexing. This is for performance.
 # These are added to the application's built-in defaults like '.git' and 'node_modules'.

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/wire v0.6.0
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.11.1
-	github.com/sevigo/goframe v0.23.2
+	github.com/sevigo/goframe v0.24.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -271,6 +271,8 @@ github.com/sevigo/goframe v0.23.1 h1:uAR+hwyd+pPixIHlIVqVhkBvITdcTfBvf5IUPrihac4
 github.com/sevigo/goframe v0.23.1/go.mod h1:CwKU4vS30KcrJfysrKh9ujRI+CtzJCV/GHYQcblaNJI=
 github.com/sevigo/goframe v0.23.2 h1:GBZ4QlepTgMWMiBzfVk7QnGdfxcBRQKAugGcjFWk2aA=
 github.com/sevigo/goframe v0.23.2/go.mod h1:CwKU4vS30KcrJfysrKh9ujRI+CtzJCV/GHYQcblaNJI=
+github.com/sevigo/goframe v0.24.0 h1:Cz045dS/BEGpPxHzJ/GgL/QMh3MIpeFM74Y/VQVQf9g=
+github.com/sevigo/goframe v0.24.0/go.mod h1:CwKU4vS30KcrJfysrKh9ujRI+CtzJCV/GHYQcblaNJI=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,7 @@ type AIConfig struct {
 	LLMProvider          string   `mapstructure:"llm_provider"`
 	EmbedderProvider     string   `mapstructure:"embedder_provider"`
 	OllamaHost           string   `mapstructure:"ollama_host"`
+	OllamaAPIKey         string   `mapstructure:"ollama_api_key"`
 	GeminiAPIKey         string   `mapstructure:"gemini_api_key"`
 	GeneratorModel       string   `mapstructure:"generator_model"`
 	FastModel            string   `mapstructure:"fast_model"`
@@ -224,6 +225,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("ai.llm_provider", "ollama")
 	v.SetDefault("ai.embedder_provider", "ollama")
 	v.SetDefault("ai.ollama_host", "http://localhost:11434")
+	v.SetDefault("ai.ollama_api_key", "")
 	v.SetDefault("ai.embedder_model", "nomic-embed-text")
 	v.SetDefault("ai.embedder_task_description", "search_document")
 	v.SetDefault("ai.enable_reranking", false)     // Disabled by default for speed

--- a/internal/config/repo_config_test.go
+++ b/internal/config/repo_config_test.go
@@ -45,6 +45,7 @@ exclude_files:
 		assert.Empty(t, cfg.CustomInstructions)
 		assert.Empty(t, cfg.ExcludeDirs)
 		assert.Empty(t, cfg.ExcludeExts)
+		assert.Empty(t, cfg.ExcludeFiles)
 	})
 
 	t.Run("invalid yaml returns error", func(t *testing.T) {

--- a/internal/config/repo_config_test.go
+++ b/internal/config/repo_config_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadRepoConfig(t *testing.T) {
+	t.Run("valid config file", func(t *testing.T) {
+		repoPath := t.TempDir()
+		configContent := `
+custom_instructions:
+  - "Rule 1"
+  - "Rule 2"
+exclude_dirs:
+  - "dist"
+  - "build"
+exclude_exts:
+  - ".txt"
+  - "log"
+exclude_files:
+  - "README.md"
+  - "internal/core/repo_config.go"
+`
+		err := os.WriteFile(filepath.Join(repoPath, ".code-warden.yml"), []byte(configContent), 0644)
+		require.NoError(t, err)
+
+		cfg, err := LoadRepoConfig(repoPath)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"Rule 1", "Rule 2"}, cfg.CustomInstructions)
+		assert.Equal(t, []string{"dist", "build"}, cfg.ExcludeDirs)
+		assert.Equal(t, []string{".txt", "log"}, cfg.ExcludeExts)
+		assert.Equal(t, []string{"README.md", "internal/core/repo_config.go"}, cfg.ExcludeFiles)
+	})
+
+	t.Run("missing config file returns defaults", func(t *testing.T) {
+		repoPath := t.TempDir()
+		cfg, err := LoadRepoConfig(repoPath)
+		assert.ErrorIs(t, err, ErrConfigNotFound)
+		require.NotNil(t, cfg)
+		assert.Empty(t, cfg.CustomInstructions)
+		assert.Empty(t, cfg.ExcludeDirs)
+		assert.Empty(t, cfg.ExcludeExts)
+	})
+
+	t.Run("invalid yaml returns error", func(t *testing.T) {
+		repoPath := t.TempDir()
+		configContent := "invalid: yaml: content"
+		err := os.WriteFile(filepath.Join(repoPath, ".code-warden.yml"), []byte(configContent), 0644)
+		require.NoError(t, err)
+
+		cfg, err := LoadRepoConfig(repoPath)
+		assert.ErrorIs(t, err, ErrConfigParsing)
+		assert.Nil(t, cfg)
+	})
+}

--- a/internal/core/repo_config.go
+++ b/internal/core/repo_config.go
@@ -1,5 +1,65 @@
 package core
 
+import "strings"
+
+// DefaultExcludedDirs are directories excluded from scanning and indexing by default.
+var DefaultExcludedDirs = []string{".git", ".github", "vendor", "node_modules", "target", "build"}
+
+// ValidSourceExtensions contains file extensions eligible for indexing.
+var ValidSourceExtensions = map[string]bool{
+	".go":   true,
+	".js":   true,
+	".ts":   true,
+	".py":   true,
+	".java": true,
+	".c":    true,
+	".cpp":  true,
+	".h":    true,
+	".rs":   true,
+	".md":   true,
+	".json": true,
+	".yaml": true,
+	".yml":  true,
+}
+
+// IsValidExtension reports whether ext (with or without leading dot) is a supported source extension.
+func IsValidExtension(ext string) bool {
+	ext = strings.ToLower(strings.TrimPrefix(ext, "."))
+	return ValidSourceExtensions["."+ext]
+}
+
+// BuildExcludeDirs combines default and user-configured directory exclusions.
+func BuildExcludeDirs(userExcludes []string) []string {
+	seen := make(map[string]struct{}, len(DefaultExcludedDirs)+len(userExcludes))
+	result := make([]string, 0, len(DefaultExcludedDirs)+len(userExcludes))
+
+	for _, dir := range DefaultExcludedDirs {
+		if _, ok := seen[dir]; !ok {
+			seen[dir] = struct{}{}
+			result = append(result, dir)
+		}
+	}
+	for _, dir := range userExcludes {
+		if _, ok := seen[dir]; !ok {
+			seen[dir] = struct{}{}
+			result = append(result, dir)
+		}
+	}
+	return result
+}
+
+// DefaultExcludedDirsSet returns a map lookup set of default excluded directories.
+func DefaultExcludedDirsSet() map[string]bool {
+	return map[string]bool{
+		".git":         true,
+		".github":      true,
+		"vendor":       true,
+		"node_modules": true,
+		"target":       true,
+		"build":        true,
+	}
+}
+
 // RepoConfig represents the structure of the .code-warden.yml file.
 type RepoConfig struct {
 	// Custom instructions for the LLM prompt.

--- a/internal/core/repo_config.go
+++ b/internal/core/repo_config.go
@@ -12,6 +12,10 @@ type RepoConfig struct {
 	// Exclusion of files based on their extension.
 	// The leading dot is optional. Example: [".md", "lock", ".log"]
 	ExcludeExts []string `yaml:"exclude_exts"`
+
+	// Exclusion of specific files by their relative path.
+	// Example: ["config/secrets.json", "scripts/temp.py"]
+	ExcludeFiles []string `yaml:"exclude_files"`
 }
 
 // DefaultRepoConfig returns a config with default values.
@@ -20,5 +24,6 @@ func DefaultRepoConfig() *RepoConfig {
 		CustomInstructions: []string{},
 		ExcludeDirs:        []string{},
 		ExcludeExts:        []string{},
+		ExcludeFiles:       []string{},
 	}
 }

--- a/internal/core/repo_config.go
+++ b/internal/core/repo_config.go
@@ -49,15 +49,13 @@ func BuildExcludeDirs(userExcludes []string) []string {
 }
 
 // DefaultExcludedDirsSet returns a map lookup set of default excluded directories.
+// This is derived from DefaultExcludedDirs to prevent drift.
 func DefaultExcludedDirsSet() map[string]bool {
-	return map[string]bool{
-		".git":         true,
-		".github":      true,
-		"vendor":       true,
-		"node_modules": true,
-		"target":       true,
-		"build":        true,
+	result := make(map[string]bool, len(DefaultExcludedDirs))
+	for _, dir := range DefaultExcludedDirs {
+		result[dir] = true
 	}
+	return result
 }
 
 // RepoConfig represents the structure of the .code-warden.yml file.

--- a/internal/core/repo_config_test.go
+++ b/internal/core/repo_config_test.go
@@ -1,0 +1,138 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValidExtension(t *testing.T) {
+	tests := []struct {
+		name     string
+		ext      string
+		expected bool
+	}{
+		// Valid extensions with leading dot
+		{"go extension", ".go", true},
+		{"js extension", ".js", true},
+		{"ts extension", ".ts", true},
+		{"py extension", ".py", true},
+		{"java extension", ".java", true},
+		{"c extension", ".c", true},
+		{"cpp extension", ".cpp", true},
+		{"h extension", ".h", true},
+		{"rs extension", ".rs", true},
+		{"md extension", ".md", true},
+		{"json extension", ".json", true},
+		{"yaml extension", ".yaml", true},
+		{"yml extension", ".yml", true},
+
+		// Valid extensions without leading dot
+		{"go without dot", "go", true},
+		{"js without dot", "js", true},
+
+		// Invalid extensions
+		{"sum extension", ".sum", false},
+		{"exe extension", ".exe", false},
+		{"dll extension", ".dll", false},
+		{"unknown extension", ".xyz", false},
+		{"empty string", "", false},
+
+		// Case insensitivity
+		{"uppercase GO", ".GO", true},
+		{"mixed case Js", ".Js", true},
+		{"uppercase without dot", "GO", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsValidExtension(tt.ext)
+			assert.Equal(t, tt.expected, got, "IsValidExtension(%q)", tt.ext)
+		})
+	}
+}
+
+func TestBuildExcludeDirs(t *testing.T) {
+	tests := []struct {
+		name         string
+		userExcludes []string
+		expectedLen  int
+		contains     []string
+		notContains  []string
+	}{
+		{
+			name:         "no user excludes",
+			userExcludes: []string{},
+			expectedLen:  len(DefaultExcludedDirs),
+			contains:     []string{".git", "vendor", "node_modules"},
+			notContains:  []string{},
+		},
+		{
+			name:         "user excludes add new dirs",
+			userExcludes: []string{"dist", "build"},
+			contains:     []string{".git", "vendor", "node_modules", "dist", "build"},
+			notContains:  []string{},
+		},
+		{
+			name:         "user excludes duplicate default",
+			userExcludes: []string{".git", "vendor", "custom"},
+			contains:     []string{".git", "vendor", "custom"},
+			notContains:  []string{},
+		},
+		{
+			name:         "empty string in user excludes",
+			userExcludes: []string{""},
+			contains:     []string{".git", "vendor"},
+			notContains:  []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildExcludeDirs(tt.userExcludes)
+
+			// Verify all expected directories are present
+			gotSet := make(map[string]bool)
+			for _, dir := range got {
+				gotSet[dir] = true
+			}
+
+			for _, dir := range tt.contains {
+				assert.True(t, gotSet[dir], "expected %q to be in result", dir)
+			}
+
+			for _, dir := range tt.notContains {
+				assert.False(t, gotSet[dir], "expected %q to NOT be in result", dir)
+			}
+
+			// Verify no duplicates
+			seen := make(map[string]bool)
+			for _, dir := range got {
+				assert.False(t, seen[dir], "duplicate directory %q found", dir)
+				seen[dir] = true
+			}
+		})
+	}
+}
+
+func TestDefaultExcludedDirsSet(t *testing.T) {
+	got := DefaultExcludedDirsSet()
+
+	// Verify all default dirs are present
+	for _, dir := range DefaultExcludedDirs {
+		assert.True(t, got[dir], "expected %q to be in set", dir)
+	}
+
+	// Verify the set is derived from DefaultExcludedDirs
+	assert.Len(t, got, len(DefaultExcludedDirs), "set size should match slice length")
+}
+
+func TestDefaultRepoConfig(t *testing.T) {
+	cfg := DefaultRepoConfig()
+
+	assert.NotNil(t, cfg)
+	assert.Empty(t, cfg.CustomInstructions)
+	assert.Empty(t, cfg.ExcludeDirs)
+	assert.Empty(t, cfg.ExcludeExts)
+	assert.Empty(t, cfg.ExcludeFiles)
+}

--- a/internal/prescan/scanner.go
+++ b/internal/prescan/scanner.go
@@ -94,7 +94,15 @@ func (s *Scanner) Scan(ctx context.Context, input string, force bool, verbose bo
 	}
 
 	// 4. Discover Files (filtered by .code-warden.yml if present)
-	repoConfig, _ := config.LoadRepoConfig(localPath)
+	repoConfig, err := config.LoadRepoConfig(localPath)
+	if err != nil {
+		if errors.Is(err, config.ErrConfigNotFound) {
+			s.Manager.logger.Info("no .code-warden.yml found, using defaults")
+		} else {
+			s.Manager.logger.Warn("failed to parse .code-warden.yml, using defaults", "error", err)
+		}
+		repoConfig = core.DefaultRepoConfig()
+	}
 	files, err := s.listFiles(localPath, repoConfig)
 	if err != nil {
 		return fmt.Errorf("failed to list files: %w", err)
@@ -111,7 +119,11 @@ func (s *Scanner) Scan(ctx context.Context, input string, force bool, verbose bo
 	}
 
 	// 6. Post-processing: Documentation & Comparisons
-	docMap, _ := s.generateAndSaveDocumentation(localPath)
+	docMap, err := s.generateAndSaveDocumentation(localPath)
+	if err != nil {
+		s.Manager.logger.Warn("Failed to generate documentation artifacts", "error", err)
+		docMap = make(map[string]any)
+	}
 	s.generateArchitecturalComparisons(ctx, localPath)
 
 	if err := stateMgr.SaveState(ctx, StatusCompleted, progress, docMap); err != nil {
@@ -202,6 +214,13 @@ func (s *Scanner) runScanLoop(ctx context.Context, stateMgr *StateManager, repoR
 	var batch []string
 
 	for i, file := range files {
+		// Check for context cancellation
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
 		if progress.Files[file] {
 			continue
 		}
@@ -369,9 +388,32 @@ func (s *Scanner) listFiles(root string, repoConfig *core.RepoConfig) ([]string,
 }
 
 func (s *Scanner) shouldExcludeDir(name string, repoConfig *core.RepoConfig) bool {
+	// Defensive guard to prevent panic on nil config
+	if repoConfig == nil {
+		repoConfig = core.DefaultRepoConfig()
+	}
+
+	// Application default exclusions (same as rag_index.go buildExcludeDirs)
+	defaultExcludes := map[string]bool{
+		".git":         true,
+		".github":      true,
+		"vendor":       true,
+		"node_modules": true,
+		"target":       true,
+		"build":        true,
+	}
+
+	// Exclude hidden directories
 	if strings.HasPrefix(name, ".") && name != "." {
 		return true
 	}
+
+	// Check default exclusions
+	if defaultExcludes[name] {
+		return true
+	}
+
+	// Check user-configured exclusions
 	for _, excludeDir := range repoConfig.ExcludeDirs {
 		if name == excludeDir {
 			return true
@@ -381,6 +423,11 @@ func (s *Scanner) shouldExcludeDir(name string, repoConfig *core.RepoConfig) boo
 }
 
 func (s *Scanner) shouldExcludeFile(rel, absPath string, repoConfig *core.RepoConfig) bool {
+	// Defensive guard to prevent panic on nil config
+	if repoConfig == nil {
+		repoConfig = core.DefaultRepoConfig()
+	}
+
 	ext := strings.ToLower(filepath.Ext(absPath))
 	if !validExt(ext) {
 		return true

--- a/internal/prescan/scanner.go
+++ b/internal/prescan/scanner.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sevigo/code-warden/internal/config"
+	"github.com/sevigo/code-warden/internal/core"
 	"github.com/sevigo/code-warden/internal/rag"
 	"github.com/sevigo/code-warden/internal/storage"
 )
@@ -54,7 +55,6 @@ func (s *Scanner) generateAndSaveDocumentation(localPath string) (map[string]any
 	}, nil
 }
 
-//nolint:gocognit,nestif // Core scanning loop with state management
 func (s *Scanner) Scan(ctx context.Context, input string, force bool, verbose bool) error {
 	s.Verbose = verbose
 	s.startTime = time.Now()
@@ -76,20 +76,16 @@ func (s *Scanner) Scan(ctx context.Context, input string, force bool, verbose bo
 	}
 	s.printCollection(repoRecord.QdrantCollectionName)
 
-	// 3. Load State
+	// 3. Load State & Initialize Progress
 	stateMgr := NewStateManager(s.Manager.store, repoRecord.ID)
 	scanState, progress, err := stateMgr.LoadState(ctx)
 	if err != nil {
 		return err
 	}
 
-	// Auto-resume logic
 	if force || scanState == nil || scanState.Status == string(StatusCompleted) || scanState.Status == string(StatusFailed) {
 		s.Manager.logger.Info("Starting fresh scan")
-		progress = &Progress{
-			Files:       make(map[string]bool),
-			LastUpdated: time.Now(),
-		}
+		progress = &Progress{Files: make(map[string]bool), LastUpdated: time.Now()}
 		if err := stateMgr.SaveState(ctx, StatusPending, progress, nil); err != nil {
 			return err
 		}
@@ -97,69 +93,27 @@ func (s *Scanner) Scan(ctx context.Context, input string, force bool, verbose bo
 		s.Manager.logger.Info("Resuming scan", "processed", progress.ProcessedFiles, "total_known", progress.TotalFiles)
 	}
 
-	// 4. Discover Files
-	files, err := s.listFiles(localPath)
+	// 4. Discover Files (filtered by .code-warden.yml if present)
+	repoConfig, _ := config.LoadRepoConfig(localPath)
+	files, err := s.listFiles(localPath, repoConfig)
 	if err != nil {
 		return fmt.Errorf("failed to list files: %w", err)
 	}
 	progress.TotalFiles = len(files)
 
-	// 5. Update State to In Progress
 	if err := stateMgr.SaveState(ctx, StatusInProgress, progress, nil); err != nil {
 		return err
 	}
 
-	// 6. Iterate and Process
-	if err := s.runScanLoop(ctx, stateMgr, repoRecord, localPath, files, progress); err != nil {
+	// 5. Run main processing loop
+	if err := s.runScanLoop(ctx, stateMgr, repoRecord, localPath, files, progress, repoConfig); err != nil {
 		return err
 	}
 
-	// 1. Prepare documentation
-	s.Manager.logger.Info("Generating documentation artifacts", "path", localPath)
-	docMap, err := s.generateAndSaveDocumentation(localPath)
-	if err != nil {
-		s.Manager.logger.Warn("Failed to generate documentation artifacts", "error", err)
-		docMap = make(map[string]any) // Initialize empty map to prevent panic in SaveState
-	}
+	// 6. Post-processing: Documentation & Comparisons
+	docMap, _ := s.generateAndSaveDocumentation(localPath)
+	s.generateArchitecturalComparisons(ctx, localPath)
 
-	// 2. Generate and save architectural comparisons (if configured)
-	if len(s.Manager.cfg.AI.ComparisonModels) > 0 {
-		s.Manager.logger.Info("Generating architectural comparisons", "models", s.Manager.cfg.AI.ComparisonModels)
-
-		// Sanitize and validate repo path to prevent traversal
-		validatedLocalPath, err := s.validateRepoPath(s.Manager.cfg.Storage.RepoPath, localPath)
-		if err != nil {
-			return fmt.Errorf("invalid repository path: %w", err)
-		}
-
-		characteristicPaths := s.Manager.cfg.AI.ComparisonPaths
-		if len(characteristicPaths) == 0 {
-			characteristicPaths = []string{"."}
-		}
-		results, err := s.RAGService.GenerateComparisonSummaries(ctx, s.Manager.cfg.AI.ComparisonModels, validatedLocalPath, characteristicPaths)
-		if err != nil {
-			s.Manager.logger.Warn("Multi-model comparison failed", "error", err)
-		} else {
-			for modelName, summaries := range results {
-				// potential path traversal: strictly replace invalid chars
-				sanitizedModel := rag.SanitizeModelForFilename(modelName)
-				fileName := fmt.Sprintf("arch_comparison_%s.md", sanitizedModel)
-				filePath := filepath.Join(localPath, fileName)
-
-				var sb strings.Builder
-				sb.WriteString(fmt.Sprintf("# Architectural Comparison: %s\n\n", modelName))
-				for path, summary := range summaries {
-					sb.WriteString(fmt.Sprintf("## Directory: %s\n\n%s\n\n", path, summary))
-				}
-
-				if err := os.WriteFile(filePath, []byte(sb.String()), 0600); err != nil {
-					s.Manager.logger.Warn("Failed to save comparison file", "file", fileName, "error", err)
-				}
-			}
-		}
-	}
-
-	// Complete & Save Artifacts
 	if err := stateMgr.SaveState(ctx, StatusCompleted, progress, docMap); err != nil {
 		return err
 	}
@@ -168,6 +122,47 @@ func (s *Scanner) Scan(ctx context.Context, input string, force bool, verbose bo
 	s.Manager.logger.Info("Scan completed successfully")
 
 	return s.updateRepoIndexVersion(ctx, localPath, repoRecord)
+}
+
+func (s *Scanner) generateArchitecturalComparisons(ctx context.Context, localPath string) {
+	if len(s.Manager.cfg.AI.ComparisonModels) == 0 {
+		return
+	}
+
+	s.Manager.logger.Info("Generating architectural comparisons", "models", s.Manager.cfg.AI.ComparisonModels)
+
+	validatedPath, err := s.validateRepoPath(s.Manager.cfg.Storage.RepoPath, localPath)
+	if err != nil {
+		s.Manager.logger.Warn("Skipping comparisons: invalid path", "error", err)
+		return
+	}
+
+	characteristicPaths := s.Manager.cfg.AI.ComparisonPaths
+	if len(characteristicPaths) == 0 {
+		characteristicPaths = []string{"."}
+	}
+
+	results, err := s.RAGService.GenerateComparisonSummaries(ctx, s.Manager.cfg.AI.ComparisonModels, validatedPath, characteristicPaths)
+	if err != nil {
+		s.Manager.logger.Warn("Multi-model comparison failed", "error", err)
+		return
+	}
+
+	for modelName, summaries := range results {
+		sanitizedModel := rag.SanitizeModelForFilename(modelName)
+		fileName := fmt.Sprintf("arch_comparison_%s.md", sanitizedModel)
+		filePath := filepath.Join(localPath, fileName)
+
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("# Architectural Comparison: %s\n\n", modelName))
+		for path, summary := range summaries {
+			sb.WriteString(fmt.Sprintf("## Directory: %s\n\n%s\n\n", path, summary))
+		}
+
+		if err := os.WriteFile(filePath, []byte(sb.String()), 0600); err != nil {
+			s.Manager.logger.Warn("Failed to save comparison file", "file", fileName, "error", err)
+		}
+	}
 }
 
 func (s *Scanner) printMetadata(repoFullName, localPath string) {
@@ -202,7 +197,7 @@ func (s *Scanner) printSummary(startTime time.Time, processedFiles int) {
 	}
 }
 
-func (s *Scanner) runScanLoop(ctx context.Context, stateMgr *StateManager, repoRecord *storage.Repository, localPath string, files []string, progress *Progress) error {
+func (s *Scanner) runScanLoop(ctx context.Context, stateMgr *StateManager, repoRecord *storage.Repository, localPath string, files []string, progress *Progress, repoConfig *core.RepoConfig) error {
 	batchSize := 100
 	var batch []string
 
@@ -217,7 +212,7 @@ func (s *Scanner) runScanLoop(ctx context.Context, stateMgr *StateManager, repoR
 			// Process Batch
 			s.Manager.logger.Info("Processing batch", "size", len(batch), "current", i+1, "total", len(files))
 
-			err := s.processBatch(ctx, stateMgr, repoRecord, localPath, &batch, progress)
+			err := s.processBatch(ctx, stateMgr, repoRecord, localPath, &batch, progress, repoConfig)
 			if err != nil {
 				return err
 			}
@@ -227,19 +222,14 @@ func (s *Scanner) runScanLoop(ctx context.Context, stateMgr *StateManager, repoR
 	// Flush remaining batch
 	if len(batch) > 0 {
 		s.Manager.logger.Info("Processing final batch", "size", len(batch))
-		if err := s.processBatch(ctx, stateMgr, repoRecord, localPath, &batch, progress); err != nil {
+		if err := s.processBatch(ctx, stateMgr, repoRecord, localPath, &batch, progress, repoConfig); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (s *Scanner) processBatch(ctx context.Context, stateMgr *StateManager, repoRecord *storage.Repository, localPath string, batch *[]string, progress *Progress) error {
-	repoConfig, configErr := config.LoadRepoConfig(localPath)
-	if configErr != nil && !errors.Is(configErr, config.ErrConfigNotFound) {
-		s.Manager.logger.Warn("Failed to load .code-warden.yml", "error", configErr)
-	}
-
+func (s *Scanner) processBatch(ctx context.Context, stateMgr *StateManager, repoRecord *storage.Repository, localPath string, batch *[]string, progress *Progress, repoConfig *core.RepoConfig) error {
 	batchStartTime := time.Now()
 	err := s.RAGService.UpdateRepoContext(ctx, repoConfig, repoRecord, localPath, *batch, nil)
 	if err != nil {
@@ -348,33 +338,70 @@ func (s *Scanner) ensureRepoRecord(ctx context.Context, fullName, path string) (
 	return rec, nil
 }
 
-func (s *Scanner) listFiles(root string) ([]string, error) {
+func (s *Scanner) listFiles(root string, repoConfig *core.RepoConfig) ([]string, error) {
 	var files []string
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
-		}
-		if info.IsDir() {
-			name := info.Name()
-			if strings.HasPrefix(name, ".") && name != "." {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		// Basic extension filter
-		ext := strings.ToLower(filepath.Ext(path))
-		if !validExt(ext) {
-			return nil
 		}
 
 		rel, err := filepath.Rel(root, path)
 		if err != nil {
 			return err
 		}
-		files = append(files, strings.ReplaceAll(rel, "\\", "/"))
+		rel = strings.ReplaceAll(rel, "\\", "/")
+
+		if info.IsDir() {
+			if s.shouldExcludeDir(info.Name(), repoConfig) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if s.shouldExcludeFile(rel, path, repoConfig) {
+			return nil
+		}
+
+		files = append(files, rel)
 		return nil
 	})
 	return files, err
+}
+
+func (s *Scanner) shouldExcludeDir(name string, repoConfig *core.RepoConfig) bool {
+	if strings.HasPrefix(name, ".") && name != "." {
+		return true
+	}
+	for _, excludeDir := range repoConfig.ExcludeDirs {
+		if name == excludeDir {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Scanner) shouldExcludeFile(rel, absPath string, repoConfig *core.RepoConfig) bool {
+	ext := strings.ToLower(filepath.Ext(absPath))
+	if !validExt(ext) {
+		return true
+	}
+
+	// Filter by RepoConfig extensions
+	for _, excludeExt := range repoConfig.ExcludeExts {
+		normalizedExt := strings.ToLower(strings.TrimPrefix(excludeExt, "."))
+		if strings.TrimPrefix(ext, ".") == normalizedExt {
+			return true
+		}
+	}
+
+	// Filter by RepoConfig specific files
+	for _, excludeFile := range repoConfig.ExcludeFiles {
+		if rel == strings.ReplaceAll(excludeFile, "\\", "/") {
+			return true
+		}
+	}
+
+	return false
 }
 
 func validExt(ext string) bool {

--- a/internal/prescan/scanner.go
+++ b/internal/prescan/scanner.go
@@ -393,22 +393,13 @@ func (s *Scanner) shouldExcludeDir(name string, repoConfig *core.RepoConfig) boo
 		repoConfig = core.DefaultRepoConfig()
 	}
 
-	// Application default exclusions (same as rag_index.go buildExcludeDirs)
-	defaultExcludes := map[string]bool{
-		".git":         true,
-		".github":      true,
-		"vendor":       true,
-		"node_modules": true,
-		"target":       true,
-		"build":        true,
-	}
-
 	// Exclude hidden directories
 	if strings.HasPrefix(name, ".") && name != "." {
 		return true
 	}
 
-	// Check default exclusions
+	// Check default exclusions (using shared constants)
+	defaultExcludes := core.DefaultExcludedDirsSet()
 	if defaultExcludes[name] {
 		return true
 	}
@@ -429,7 +420,7 @@ func (s *Scanner) shouldExcludeFile(rel, absPath string, repoConfig *core.RepoCo
 	}
 
 	ext := strings.ToLower(filepath.Ext(absPath))
-	if !validExt(ext) {
+	if !core.IsValidExtension(ext) {
 		return true
 	}
 
@@ -441,21 +432,14 @@ func (s *Scanner) shouldExcludeFile(rel, absPath string, repoConfig *core.RepoCo
 		}
 	}
 
-	// Filter by RepoConfig specific files
+	// Filter by RepoConfig specific files (with proper path normalization)
+	cleanRel := filepath.ToSlash(filepath.Clean(rel))
 	for _, excludeFile := range repoConfig.ExcludeFiles {
-		if rel == strings.ReplaceAll(excludeFile, "\\", "/") {
+		if cleanRel == filepath.ToSlash(filepath.Clean(excludeFile)) {
 			return true
 		}
 	}
 
-	return false
-}
-
-func validExt(ext string) bool {
-	switch ext {
-	case ".go", ".js", ".ts", ".py", ".java", ".c", ".cpp", ".h", ".rs", ".md", ".json", ".yaml", ".yml":
-		return true
-	}
 	return false
 }
 

--- a/internal/prescan/scanner.go
+++ b/internal/prescan/scanner.go
@@ -393,11 +393,6 @@ func (s *Scanner) shouldExcludeDir(name string, repoConfig *core.RepoConfig) boo
 		repoConfig = core.DefaultRepoConfig()
 	}
 
-	// Exclude hidden directories
-	if strings.HasPrefix(name, ".") && name != "." {
-		return true
-	}
-
 	// Check default exclusions (using shared constants)
 	defaultExcludes := core.DefaultExcludedDirsSet()
 	if defaultExcludes[name] {

--- a/internal/rag/rag.go
+++ b/internal/rag/rag.go
@@ -109,6 +109,7 @@ func (r *ragService) getOrCreateLLM(ctx context.Context, modelName string) (llms
 	// Fallback/Default to Ollama
 	return ollama.New(
 		ollama.WithServerURL(r.cfg.AI.OllamaHost),
+		ollama.WithAPIKey(r.cfg.AI.OllamaAPIKey),
 		ollama.WithModel(modelName),
 	)
 }

--- a/internal/rag/rag_index.go
+++ b/internal/rag/rag_index.go
@@ -412,23 +412,7 @@ func filterFilesByValidExtensions(files []string) []string {
 // buildExcludeDirs creates the final list of directories to exclude, combining
 // application defaults with user-configured exclusions.
 func (r *ragService) buildExcludeDirs(repoConfig *core.RepoConfig) []string {
-	appDefaultExcludeDirs := []string{".git", ".github", "vendor", "node_modules", "target", "build"}
-
-	// Using a map handles duplicates automatically.
-	allExcludeDirs := make(map[string]struct{})
-	for _, dir := range appDefaultExcludeDirs {
-		allExcludeDirs[dir] = struct{}{}
-	}
-	for _, dir := range repoConfig.ExcludeDirs {
-		allExcludeDirs[dir] = struct{}{}
-	}
-
-	finalExcludeDirs := make([]string, 0, len(allExcludeDirs))
-	for dir := range allExcludeDirs {
-		finalExcludeDirs = append(finalExcludeDirs, dir)
-	}
-
-	return finalExcludeDirs
+	return core.BuildExcludeDirs(repoConfig.ExcludeDirs)
 }
 
 // filterFilesByDirectories removes files from a slice if they are located within

--- a/internal/rag/rag_index.go
+++ b/internal/rag/rag_index.go
@@ -383,26 +383,10 @@ func filterFilesByExtensions(files []string, excludeExts []string) []string {
 // filterFilesByValidExtensions removes files from a slice if their extension is not
 // in the whitelist of supported extensions. This ensures consistency with the scanner.
 func filterFilesByValidExtensions(files []string) []string {
-	validExts := map[string]bool{
-		".go":   true,
-		".js":   true,
-		".ts":   true,
-		".py":   true,
-		".java": true,
-		".c":    true,
-		".cpp":  true,
-		".h":    true,
-		".rs":   true,
-		".md":   true,
-		".json": true,
-		".yaml": true,
-		".yml":  true,
-	}
-
 	filtered := make([]string, 0, len(files))
 	for _, file := range files {
 		ext := strings.ToLower(filepath.Ext(file))
-		if validExts[ext] {
+		if core.IsValidExtension(ext) {
 			filtered = append(filtered, file)
 		}
 	}

--- a/internal/rag/rag_index.go
+++ b/internal/rag/rag_index.go
@@ -205,6 +205,10 @@ func (r *ragService) UpdateRepoContext(ctx context.Context, repoConfig *core.Rep
 	filesToProcess = r.filterFilesByDirectories(filesToProcess, finalExcludeDirs)
 	filesToDelete = r.filterFilesByDirectories(filesToDelete, finalExcludeDirs)
 
+	// Apply valid extension whitelist (same as scanner)
+	filesToProcess = filterFilesByValidExtensions(filesToProcess)
+	filesToDelete = filterFilesByValidExtensions(filesToDelete)
+
 	filesToProcess = filterFilesByExtensions(filesToProcess, repoConfig.ExcludeExts)
 	filesToDelete = filterFilesByExtensions(filesToDelete, repoConfig.ExcludeExts)
 
@@ -376,6 +380,35 @@ func filterFilesByExtensions(files []string, excludeExts []string) []string {
 	return filtered
 }
 
+// filterFilesByValidExtensions removes files from a slice if their extension is not
+// in the whitelist of supported extensions. This ensures consistency with the scanner.
+func filterFilesByValidExtensions(files []string) []string {
+	validExts := map[string]bool{
+		".go":   true,
+		".js":   true,
+		".ts":   true,
+		".py":   true,
+		".java": true,
+		".c":    true,
+		".cpp":  true,
+		".h":    true,
+		".rs":   true,
+		".md":   true,
+		".json": true,
+		".yaml": true,
+		".yml":  true,
+	}
+
+	filtered := make([]string, 0, len(files))
+	for _, file := range files {
+		ext := strings.ToLower(filepath.Ext(file))
+		if validExts[ext] {
+			filtered = append(filtered, file)
+		}
+	}
+	return filtered
+}
+
 // buildExcludeDirs creates the final list of directories to exclude, combining
 // application defaults with user-configured exclusions.
 func (r *ragService) buildExcludeDirs(repoConfig *core.RepoConfig) []string {
@@ -407,8 +440,8 @@ func (r *ragService) filterFilesByDirectories(files []string, excludeDirs []stri
 
 	filtered := make([]string, 0, len(files))
 	for _, file := range files {
-		// Normalize the file path - remove any leading separators and clean it
-		cleanFile := filepath.Clean(strings.TrimPrefix(file, string(filepath.Separator)))
+		// Normalize the file path to forward slashes for cross-platform consistency
+		cleanFile := filepath.ToSlash(filepath.Clean(strings.TrimPrefix(file, string(filepath.Separator))))
 
 		isExcluded := false
 		for _, excludeDir := range excludeDirs {
@@ -421,7 +454,8 @@ func (r *ragService) filterFilesByDirectories(files []string, excludeDirs []stri
 			}
 
 			// Check if the file path starts with the excluded directory followed by a separator
-			if strings.HasPrefix(cleanFile, cleanExcludeDir+string(filepath.Separator)) {
+			// Use forward slash for cross-platform consistency
+			if strings.HasPrefix(cleanFile, cleanExcludeDir+"/") {
 				isExcluded = true
 				break
 			}
@@ -444,12 +478,12 @@ func filterFilesBySpecificFiles(files []string, excludeFiles []string) []string 
 
 	excludeMap := make(map[string]struct{}, len(excludeFiles))
 	for _, f := range excludeFiles {
-		excludeMap[filepath.Clean(f)] = struct{}{}
+		excludeMap[filepath.ToSlash(filepath.Clean(f))] = struct{}{}
 	}
 
 	filtered := make([]string, 0, len(files))
 	for _, file := range files {
-		if _, isExcluded := excludeMap[filepath.Clean(file)]; !isExcluded {
+		if _, isExcluded := excludeMap[filepath.ToSlash(filepath.Clean(file))]; !isExcluded {
 			filtered = append(filtered, file)
 		}
 	}

--- a/internal/rag/rag_index.go
+++ b/internal/rag/rag_index.go
@@ -201,12 +201,15 @@ func (r *ragService) UpdateRepoContext(ctx context.Context, repoConfig *core.Rep
 	// Get the same exclude directories configuration as SetupRepoContext
 	finalExcludeDirs := r.buildExcludeDirs(repoConfig)
 
-	// Apply directory filtering first, then extension filtering
+	// Apply directory filtering first, then extension filtering, then specific file filtering
 	filesToProcess = r.filterFilesByDirectories(filesToProcess, finalExcludeDirs)
 	filesToDelete = r.filterFilesByDirectories(filesToDelete, finalExcludeDirs)
 
 	filesToProcess = filterFilesByExtensions(filesToProcess, repoConfig.ExcludeExts)
 	filesToDelete = filterFilesByExtensions(filesToDelete, repoConfig.ExcludeExts)
+
+	filesToProcess = filterFilesBySpecificFiles(filesToProcess, repoConfig.ExcludeFiles)
+	filesToDelete = filterFilesBySpecificFiles(filesToDelete, repoConfig.ExcludeFiles)
 
 	r.logger.Info("updating repository context after filtering",
 		"collection", repo.QdrantCollectionName,
@@ -214,6 +217,7 @@ func (r *ragService) UpdateRepoContext(ctx context.Context, repoConfig *core.Rep
 		"delete", len(filesToDelete),
 		"exclude_dirs", finalExcludeDirs,
 		"exclude_exts", repoConfig.ExcludeExts,
+		"exclude_files", repoConfig.ExcludeFiles,
 	)
 
 	// Handle deleted files first
@@ -424,6 +428,28 @@ func (r *ragService) filterFilesByDirectories(files []string, excludeDirs []stri
 		}
 
 		if !isExcluded {
+			filtered = append(filtered, file)
+		}
+	}
+
+	return filtered
+}
+
+// filterFilesBySpecificFiles removes files from a slice if their path matches
+// one of the provided excluded specific files.
+func filterFilesBySpecificFiles(files []string, excludeFiles []string) []string {
+	if len(excludeFiles) == 0 {
+		return files
+	}
+
+	excludeMap := make(map[string]struct{}, len(excludeFiles))
+	for _, f := range excludeFiles {
+		excludeMap[filepath.Clean(f)] = struct{}{}
+	}
+
+	filtered := make([]string, 0, len(files))
+	for _, file := range files {
+		if _, isExcluded := excludeMap[filepath.Clean(file)]; !isExcluded {
 			filtered = append(filtered, file)
 		}
 	}

--- a/internal/rag/rag_test.go
+++ b/internal/rag/rag_test.go
@@ -601,9 +601,9 @@ func TestFiltering(t *testing.T) {
 				want:    []string{},
 			},
 			{
-				name:    "windows path normalization",
+				name:    "path normalization with dot",
 				files:   []string{"main.go", "config/secrets.json"},
-				exclude: []string{"config\\secrets.json"},
+				exclude: []string{"./config/secrets.json"},
 				want:    []string{"main.go"},
 			},
 		}

--- a/internal/rag/rag_test.go
+++ b/internal/rag/rag_test.go
@@ -489,3 +489,42 @@ func TestContextIsEmpty(t *testing.T) {
 		})
 	}
 }
+func TestFiltering(t *testing.T) {
+	r := &ragService{}
+
+	t.Run("filterFilesByExtensions", func(t *testing.T) {
+		files := []string{"main.go", "config.yml", "go.sum", "README.md"}
+		exclude := []string{".yml", "sum"}
+		got := filterFilesByExtensions(files, exclude)
+		want := []string{"main.go", "README.md"}
+		if len(got) != len(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("filterFilesByDirectories", func(t *testing.T) {
+		files := []string{
+			"src/main.go",
+			"vendor/pkg/a.go",
+			"node_modules/lib/b.js",
+			"internal/pkg/c.go",
+			".vscode/settings.json",
+		}
+		exclude := []string{"vendor", "node_modules", ".vscode"}
+		got := r.filterFilesByDirectories(files, exclude)
+		want := []string{"src/main.go", "internal/pkg/c.go"}
+		if len(got) != len(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("filterFilesBySpecificFiles", func(t *testing.T) {
+		files := []string{"main.go", "config/secrets.json", "scripts/temp.py", "README.md"}
+		exclude := []string{"config/secrets.json", "scripts/temp.py"}
+		got := filterFilesBySpecificFiles(files, exclude)
+		want := []string{"main.go", "README.md"}
+		if len(got) != len(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+}

--- a/internal/rag/rag_test.go
+++ b/internal/rag/rag_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/sevigo/goframe/schema"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
 	internalgithub "github.com/sevigo/code-warden/internal/github"
@@ -493,38 +494,156 @@ func TestFiltering(t *testing.T) {
 	r := &ragService{}
 
 	t.Run("filterFilesByExtensions", func(t *testing.T) {
-		files := []string{"main.go", "config.yml", "go.sum", "README.md"}
-		exclude := []string{".yml", "sum"}
-		got := filterFilesByExtensions(files, exclude)
-		want := []string{"main.go", "README.md"}
-		if len(got) != len(want) {
-			t.Errorf("got %v, want %v", got, want)
+		tests := []struct {
+			name    string
+			files   []string
+			exclude []string
+			want    []string
+		}{
+			{
+				name:    "basic filtering",
+				files:   []string{"main.go", "config.yml", "go.sum", "README.md"},
+				exclude: []string{".yml", "sum"},
+				want:    []string{"main.go", "README.md"},
+			},
+			{
+				name:    "no exclusions",
+				files:   []string{"main.go", "utils.go"},
+				exclude: []string{},
+				want:    []string{"main.go", "utils.go"},
+			},
+			{
+				name:    "exclude all",
+				files:   []string{"config.yml", "go.sum"},
+				exclude: []string{".yml", ".sum"},
+				want:    []string{},
+			},
+			{
+				name:    "extension without dot",
+				files:   []string{"main.go", "config.yml"},
+				exclude: []string{"yml"},
+				want:    []string{"main.go"},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				got := filterFilesByExtensions(tt.files, tt.exclude)
+				assert.Equal(t, tt.want, got)
+			})
 		}
 	})
 
 	t.Run("filterFilesByDirectories", func(t *testing.T) {
-		files := []string{
-			"src/main.go",
-			"vendor/pkg/a.go",
-			"node_modules/lib/b.js",
-			"internal/pkg/c.go",
-			".vscode/settings.json",
+		tests := []struct {
+			name    string
+			files   []string
+			exclude []string
+			want    []string
+		}{
+			{
+				name: "basic directory filtering",
+				files: []string{
+					"src/main.go",
+					"vendor/pkg/a.go",
+					"node_modules/lib/b.js",
+					"internal/pkg/c.go",
+					".vscode/settings.json",
+				},
+				exclude: []string{"vendor", "node_modules", ".vscode"},
+				want:    []string{"src/main.go", "internal/pkg/c.go"},
+			},
+			{
+				name:    "no exclusions",
+				files:   []string{"src/main.go", "pkg/util.go"},
+				exclude: []string{},
+				want:    []string{"src/main.go", "pkg/util.go"},
+			},
+			{
+				name:    "exclude all",
+				files:   []string{"vendor/a.go", "node_modules/b.js"},
+				exclude: []string{"vendor", "node_modules"},
+				want:    []string{},
+			},
 		}
-		exclude := []string{"vendor", "node_modules", ".vscode"}
-		got := r.filterFilesByDirectories(files, exclude)
-		want := []string{"src/main.go", "internal/pkg/c.go"}
-		if len(got) != len(want) {
-			t.Errorf("got %v, want %v", got, want)
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				got := r.filterFilesByDirectories(tt.files, tt.exclude)
+				assert.Equal(t, tt.want, got)
+			})
 		}
 	})
 
 	t.Run("filterFilesBySpecificFiles", func(t *testing.T) {
-		files := []string{"main.go", "config/secrets.json", "scripts/temp.py", "README.md"}
-		exclude := []string{"config/secrets.json", "scripts/temp.py"}
-		got := filterFilesBySpecificFiles(files, exclude)
-		want := []string{"main.go", "README.md"}
-		if len(got) != len(want) {
-			t.Errorf("got %v, want %v", got, want)
+		tests := []struct {
+			name    string
+			files   []string
+			exclude []string
+			want    []string
+		}{
+			{
+				name:    "basic file filtering",
+				files:   []string{"main.go", "config/secrets.json", "scripts/temp.py", "README.md"},
+				exclude: []string{"config/secrets.json", "scripts/temp.py"},
+				want:    []string{"main.go", "README.md"},
+			},
+			{
+				name:    "no exclusions",
+				files:   []string{"main.go", "utils.go"},
+				exclude: []string{},
+				want:    []string{"main.go", "utils.go"},
+			},
+			{
+				name:    "exclude all",
+				files:   []string{"config.yaml", "Dockerfile"},
+				exclude: []string{"config.yaml", "Dockerfile"},
+				want:    []string{},
+			},
+			{
+				name:    "windows path normalization",
+				files:   []string{"main.go", "config/secrets.json"},
+				exclude: []string{"config\\secrets.json"},
+				want:    []string{"main.go"},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				got := filterFilesBySpecificFiles(tt.files, tt.exclude)
+				assert.Equal(t, tt.want, got)
+			})
+		}
+	})
+
+	t.Run("filterFilesByValidExtensions", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			files []string
+			want  []string
+		}{
+			{
+				name:  "mixed valid and invalid",
+				files: []string{"main.go", "config.exe", "README.md", "binary.dll"},
+				want:  []string{"main.go", "README.md"},
+			},
+			{
+				name:  "all valid",
+				files: []string{"main.go", "utils.ts", "README.md"},
+				want:  []string{"main.go", "utils.ts", "README.md"},
+			},
+			{
+				name:  "all invalid",
+				files: []string{"binary.exe", "library.dll", "temp.tmp"},
+				want:  []string{},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				got := filterFilesByValidExtensions(tt.files)
+				assert.Equal(t, tt.want, got)
+			})
 		}
 	})
 }


### PR DESCRIPTION
This PR adds support for excluding specific files by path in .code-warden.yml and ensures consistent filtering between the initial scanner and incremental RAG updates. It also refactors the scanner for better maintainability and adds unit tests for the new functionality.