### PR TITLE
fix: escape XML special characters in code suggestions

### DIFF
--- a/internal/llm/parser.go
+++ b/internal/llm/parser.go
@@ -5,6 +5,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"log/slog"
 	"path/filepath"
@@ -19,7 +20,36 @@ import (
 var (
 	reFixCodeCleanup = regexp.MustCompile(`(?is)<fix_code>.*?</fix_code>`)
 	reCodeSugCleanup = regexp.MustCompile(`(?is)<code_suggestion>.*?</code_suggestion>`)
+
+	// escapeCodeSuggestionXML regexes for escaping angle brackets in code blocks
+	reCodeSuggestion = regexp.MustCompile(`(?is)<code_suggestion>(.*?)</code_suggestion>`)
+	reFixCode        = regexp.MustCompile(`(?is)<fix_code>(.*?)</fix_code>`)
 )
+
+// escapeCodeSuggestionXML escapes XML special characters (< and >) within
+// <code_suggestion> and <fix_code> tags to prevent the XML parser from breaking
+// on generic types like <T> or template syntax.
+func escapeCodeSuggestionXML(markdown string) string {
+	// Escape <code_suggestion> blocks
+	markdown = reCodeSuggestion.ReplaceAllStringFunc(markdown, func(match string) string {
+		// Extract content between tags
+		content := match[len("<code_suggestion>") : len(match)-len("</code_suggestion>")]
+		// Escape only the angle brackets in the content (not in the tags)
+		escaped := strings.ReplaceAll(content, "<", "&lt;")
+		escaped = strings.ReplaceAll(escaped, ">", "&gt;")
+		return "<code_suggestion>" + escaped + "</code_suggestion>"
+	})
+
+	// Escape <fix_code> blocks
+	markdown = reFixCode.ReplaceAllStringFunc(markdown, func(match string) string {
+		content := match[len("<fix_code>") : len(match)-len("</fix_code>")]
+		escaped := strings.ReplaceAll(content, "<", "&lt;")
+		escaped = strings.ReplaceAll(escaped, ">", "&gt;")
+		return "<fix_code>" + escaped + "</fix_code>"
+	})
+
+	return markdown
+}
 
 // ParseMarkdownReview extracts structured review data from the LLM's XML-tagged output.
 // It handles preambles gracefully and maintains a fallback for legacy markdown formats.
@@ -64,6 +94,10 @@ type xmlSuggestion struct {
 func decodeXMLReview(ctx context.Context, markdown string, logger *slog.Logger) (*xmlReview, bool) {
 	// Pre-process markdown to fix common LLM XML hallucinations
 	markdown = strings.ReplaceAll(markdown, "</ ", "</")
+
+	// Escape angle brackets within code suggestion blocks to prevent XML parser errors
+	// when models output generic types like <T> or template syntax
+	markdown = escapeCodeSuggestionXML(markdown)
 
 	// Count open tags vs closed tags for standard elements to handle truncation robustly
 	if strings.Contains(markdown, "<review>") && !strings.Contains(markdown, "</review>") {
@@ -209,10 +243,12 @@ func parseXMLSuggestion(xs *xmlSuggestion, logger *slog.Logger) *core.Suggestion
 		if len(xs.CodeSuggestion.Content) > maxCodeBytes {
 			logger.Warn("code suggestion exceeds safe size", "size", len(xs.CodeSuggestion.Content))
 		}
-		s.CodeSuggestion = stripMarkdownFence(unindent(xs.CodeSuggestion.Content))
+		unescaped := html.UnescapeString(xs.CodeSuggestion.Content)
+		s.CodeSuggestion = stripMarkdownFence(unindent(unescaped))
 	} else if xs.FixCode.Content != "" {
 		logger.Warn("using deprecated <fix_code> tag")
-		s.CodeSuggestion = stripMarkdownFence(unindent(xs.FixCode.Content))
+		unescaped := html.UnescapeString(xs.FixCode.Content)
+		s.CodeSuggestion = stripMarkdownFence(unindent(unescaped))
 	}
 
 	return s

--- a/internal/llm/parser_test.go
+++ b/internal/llm/parser_test.go
@@ -471,3 +471,103 @@ func TestStripMarkdownFence(t *testing.T) {
 		})
 	}
 }
+
+func TestEscapeCodeSuggestionXML(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "Generic type with T",
+			input: `<code_suggestion>func foo<T>(x T) {}</code_suggestion>`,
+			want:  `<code_suggestion>func foo&lt;T&gt;(x T) {}</code_suggestion>`,
+		},
+		{
+			name:  "Generic type with multiple type params",
+			input: `<code_suggestion>func foo<K, V>(m map[K]V) V {}</code_suggestion>`,
+			want:  `<code_suggestion>func foo&lt;K, V&gt;(m map[K]V) V {}</code_suggestion>`,
+		},
+		{
+			name:  "Angle bracket comparison",
+			input: `<code_suggestion>if a < b && b > c {}</code_suggestion>`,
+			want:  `<code_suggestion>if a &lt; b && b &gt; c {}</code_suggestion>`,
+		},
+		{
+			name:  "Template syntax",
+			input: `<code_suggestion>for i := 0; i < n; i++ {}</code_suggestion>`,
+			want:  `<code_suggestion>for i := 0; i &lt; n; i++ {}</code_suggestion>`,
+		},
+		{
+			name:  "No special characters",
+			input: `<code_suggestion>func main() { fmt.Println("hello") }</code_suggestion>`,
+			want:  `<code_suggestion>func main() { fmt.Println("hello") }</code_suggestion>`,
+		},
+		{
+			name:  "Multiple code suggestions",
+			input: `<code_suggestion>func foo<T>(x T) {}</code_suggestion><code_suggestion>func bar(y int) {}</code_suggestion>`,
+			want:  `<code_suggestion>func foo&lt;T&gt;(x T) {}</code_suggestion><code_suggestion>func bar(y int) {}</code_suggestion>`,
+		},
+		{
+			name:  "Fix code tag",
+			input: `<fix_code>func foo<T>(x T) {}</fix_code>`,
+			want:  `<fix_code>func foo&lt;T&gt;(x T) {}</fix_code>`,
+		},
+		{
+			name:  "Mixed code suggestion and fix code",
+			input: `<code_suggestion>func foo<T>() {}</code_suggestion><fix_code>func bar() {}</fix_code>`,
+			want:  `<code_suggestion>func foo&lt;T&gt;() {}</code_suggestion><fix_code>func bar() {}</fix_code>`,
+		},
+		{
+			name:  "Preserves other XML tags in review",
+			input: `<review><summary>Test</summary><code_suggestion>func foo<T>() {}</code_suggestion></review>`,
+			want:  `<review><summary>Test</summary><code_suggestion>func foo&lt;T&gt;() {}</code_suggestion></review>`,
+		},
+		{
+			name:  "Lambda with generics",
+			input: `<code_suggestion>x := func<T>(t T) T { return t }</code_suggestion>`,
+			want:  `<code_suggestion>x := func&lt;T&gt;(t T) T { return t }</code_suggestion>`,
+		},
+		{
+			name:  "Empty code suggestion",
+			input: `<code_suggestion></code_suggestion>`,
+			want:  `<code_suggestion></code_suggestion>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := escapeCodeSuggestionXML(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseMarkdownReviewWithGenerics(t *testing.T) {
+	// Test that the full parsing flow handles generic types correctly
+	input := `
+<review>
+  <verdict>COMMENT</verdict>
+  <summary>Generic types test</summary>
+  <suggestions>
+    <suggestion>
+      <file>main.go</file>
+      <line>10</line>
+      <severity>Low</severity>
+      <category>Style</category>
+      <code_suggestion>
+func foo<T>(x T) T {
+	return x
+}
+      </code_suggestion>
+    </suggestion>
+  </suggestions>
+</review>`
+
+	got, err := ParseMarkdownReview(context.Background(), input, slog.Default())
+	require.NoError(t, err)
+	assert.Equal(t, "COMMENT", got.Verdict)
+	assert.Equal(t, 1, len(got.Suggestions))
+	// The code suggestion should contain the generic function (unescaped)
+	assert.Contains(t, got.Suggestions[0].CodeSuggestion, "func foo<T>(x T) T")
+}


### PR DESCRIPTION
When models generate code suggestions containing generic types (like <T>) or template syntax, the raw < and > characters break the XML parser.

This adds a preprocessing step that escapes < to &lt; and > to &gt; only within <code_suggestion> and <fix_code> tags before XML decoding, then unescapes after parsing to restore the original code.