### PR TITLE
perf(rag): improve performance and fix race conditions

### DIFF
--- a/internal/rag/arch_context.go
+++ b/internal/rag/arch_context.go
@@ -70,7 +70,9 @@ func (r *ragService) GenerateArchSummaries(ctx context.Context, collectionName, 
 	// Hydrate directory metadata and generate summaries
 
 	// Generate summaries with a worker pool
-	archDocs := r.generateSummariesWithWorkerPool(ctx, dirsToProcess, 3)
+	// Use 5 workers by default for better throughput with LLM API rate limits
+	const defaultArchSummaryWorkers = 5
+	archDocs := r.generateSummariesWithWorkerPool(ctx, dirsToProcess, defaultArchSummaryWorkers)
 
 	if len(archDocs) == 0 {
 		r.logger.Warn("no architectural summaries generated")

--- a/internal/rag/rag.go
+++ b/internal/rag/rag.go
@@ -66,6 +66,7 @@ type ragService struct {
 	splitter       textsplitter.TextSplitter
 	logger         *slog.Logger
 	hydeCache      sync.Map // map[string]string: patchHash -> hydeSnippet
+	llmCache       sync.Map // map[string]llms.Model: modelName -> LLM instance
 }
 
 // NewService creates a new RAG service.
@@ -101,26 +102,45 @@ func (r *ragService) GetTextSplitter() textsplitter.TextSplitter {
 }
 
 func (r *ragService) getOrCreateLLM(ctx context.Context, modelName string) (llms.Model, error) {
-	// For now, just return the initialized generator if model matches or if we don't support dynamic switching yet.
-	// This is a simplification to fix the build.
+	// Return the initialized generator if model matches
 	if modelName == r.cfg.AI.GeneratorModel {
 		return r.generatorLLM, nil
 	}
 
-	// Create new instance if needed (simplified fallback)
-	r.logger.Info("creating new LLM instance on the fly", "model", modelName)
-	if r.cfg.AI.LLMProvider == "gemini" {
-		return gemini.New(ctx, gemini.WithModel(modelName), gemini.WithAPIKey(r.cfg.AI.GeminiAPIKey))
+	// Check cache first (read-only lock-free lookup)
+	if cached, ok := r.llmCache.Load(modelName); ok {
+		if llmModel, valid := cached.(llms.Model); valid {
+			return llmModel, nil
+		}
 	}
-	// Fallback/Default to Ollama
-	return ollama.New(
-		ollama.WithServerURL(r.cfg.AI.OllamaHost),
-		ollama.WithAPIKey(r.cfg.AI.OllamaAPIKey),
-		ollama.WithModel(modelName),
-		ollama.WithHTTPClient(httpclient.DefaultClient),
-		ollama.WithRetryAttempts(3),
-		ollama.WithRetryDelay(2*time.Second),
-	)
+
+	// Create new instance (not in cache)
+	r.logger.Info("creating new LLM instance on the fly", "model", modelName)
+
+	var newLLM llms.Model
+	var err error
+
+	if r.cfg.AI.LLMProvider == "gemini" {
+		newLLM, err = gemini.New(ctx, gemini.WithModel(modelName), gemini.WithAPIKey(r.cfg.AI.GeminiAPIKey))
+	} else {
+		// Fallback/Default to Ollama
+		newLLM, err = ollama.New(
+			ollama.WithServerURL(r.cfg.AI.OllamaHost),
+			ollama.WithAPIKey(r.cfg.AI.OllamaAPIKey),
+			ollama.WithModel(modelName),
+			ollama.WithHTTPClient(httpclient.DefaultClient),
+			ollama.WithRetryAttempts(3),
+			ollama.WithRetryDelay(2*time.Second),
+		)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create LLM instance for model %s: %w", modelName, err)
+	}
+
+	// Store in cache for future use
+	r.llmCache.Store(modelName, newLLM)
+	return newLLM, nil
 }
 
 func (r *ragService) generateResponseWithPrompt(ctx context.Context, event *core.GitHubEvent, promptKey llm.PromptKey, promptData any) (string, error) {
@@ -152,7 +172,8 @@ func (r *ragService) generateResponseWithPrompt(ctx context.Context, event *core
 }
 
 // hashPatch computes a short hash of the patch content for caching.
+// Uses 16 bytes (128 bits) for collision resistance.
 func (r *ragService) hashPatch(patch string) string {
 	hash := sha256.Sum256([]byte(patch))
-	return hex.EncodeToString(hash[:8])
+	return hex.EncodeToString(hash[:16])
 }

--- a/internal/rag/rag_context.go
+++ b/internal/rag/rag_context.go
@@ -208,17 +208,24 @@ func (r *ragService) gatherDefinitionsContext(ctx context.Context, scopedStore s
 	r.logger.Debug("extracted symbols from diff", "symbols", symbolList)
 	r.logger.Info("stage started", "name", "SymbolResolution", "depth0_symbols", len(symbolList))
 
+	// Create DefinitionRetriever once and reuse for all symbol lookups
+	defRetriever, err := vectorstores.NewDefinitionRetriever(scopedStore)
+	if err != nil {
+		r.logger.Warn("failed to create definition retriever, skipping symbol resolution", "error", err)
+		return "", nil
+	}
+
 	seenSymbols := make(map[string]struct{})
 	for _, s := range symbolList {
 		seenSymbols[s] = struct{}{}
 	}
 
 	// Resolve direct symbols
-	depth1Defs := r.resolveSymbolsConcurrently(ctx, symbolList, scopedStore, seenDocs, mu)
+	depth1Defs := r.resolveSymbolsConcurrently(ctx, symbolList, defRetriever, seenDocs, mu)
 	r.logger.Info("depth-1 resolution complete", "resolved", len(depth1Defs))
 
 	// Resolve transitive symbols
-	depth2Defs := r.resolveDepth2Symbols(ctx, depth1Defs, seenSymbols, scopedStore, seenDocs, mu)
+	depth2Defs := r.resolveDepth2Symbols(ctx, depth1Defs, seenSymbols, defRetriever, seenDocs, mu)
 
 	// Format output
 	return r.formatResolvedDefinitions(depth1Defs, depth2Defs), nil
@@ -243,7 +250,7 @@ func (r *ragService) resolveDepth2Symbols(
 	ctx context.Context,
 	depth1Defs []resolvedDefinition,
 	seenSymbols map[string]struct{},
-	scopedStore storage.ScopedVectorStore,
+	defRetriever *vectorstores.DefinitionRetriever,
 	seenDocs map[string]struct{}, mu *sync.RWMutex,
 ) []resolvedDefinition {
 	var candidates []string
@@ -267,7 +274,7 @@ func (r *ragService) resolveDepth2Symbols(
 	}
 
 	r.logger.Info("depth-2 resolution started", "transitive_symbols", len(candidates))
-	results := r.resolveSymbolsConcurrently(ctx, candidates, scopedStore, seenDocs, mu)
+	results := r.resolveSymbolsConcurrently(ctx, candidates, defRetriever, seenDocs, mu)
 	r.logger.Info("depth-2 resolution complete", "resolved", len(results))
 	return results
 }
@@ -302,7 +309,7 @@ func (r *ragService) formatResolvedDefinitions(depth1Defs, depth2Defs []resolved
 // resolveSymbolsConcurrently resolves symbols in parallel.
 func (r *ragService) resolveSymbolsConcurrently(
 	ctx context.Context, symbols []string,
-	scopedStore storage.ScopedVectorStore,
+	defRetriever *vectorstores.DefinitionRetriever,
 	seenDocs map[string]struct{}, mu *sync.RWMutex,
 ) []resolvedDefinition {
 	var (
@@ -315,7 +322,7 @@ func (r *ragService) resolveSymbolsConcurrently(
 
 	for _, sym := range symbols {
 		g.Go(func() error {
-			source, content, ok := r.resolveSymbolDefinition(gCtx, sym, scopedStore, seenDocs, mu)
+			source, content, ok := r.resolveSymbolDefinition(gCtx, sym, defRetriever, seenDocs, mu)
 			if ok {
 				resultMu.Lock()
 				results = append(results, resolvedDefinition{
@@ -371,13 +378,7 @@ func mapKeysToSlice(m map[string]struct{}, maxLen int) []string {
 	return result
 }
 
-func (r *ragService) resolveSymbolDefinition(ctx context.Context, symbol string, scopedStore storage.ScopedVectorStore, seenDocs map[string]struct{}, mu *sync.RWMutex) (string, string, bool) {
-	defRetriever, err := vectorstores.NewDefinitionRetriever(scopedStore)
-	if err != nil {
-		r.logger.Debug("failed to create definition retriever", "symbol", symbol, "error", err)
-		return "", "", false
-	}
-
+func (r *ragService) resolveSymbolDefinition(ctx context.Context, symbol string, defRetriever *vectorstores.DefinitionRetriever, seenDocs map[string]struct{}, mu *sync.RWMutex) (string, string, bool) {
 	docs, err := defRetriever.GetDefinition(ctx, symbol)
 	if err != nil {
 		r.logger.Debug("failed to search for definition", "symbol", symbol, "error", err)
@@ -460,6 +461,11 @@ func (r *ragService) buildContextConcurrently(
 ) *contextResults {
 	results := &contextResults{}
 	g, ctx := errgroup.WithContext(ctx)
+
+	// Limit concurrency to prevent resource exhaustion when all stages run in parallel.
+	// With 5 potential stages (arch, hyde, impact, description, definitions),
+	// a limit of 3 ensures some parallelism while avoiding overwhelming the system.
+	g.SetLimit(3)
 
 	g.Go(func() error {
 		arch, err := r.gatherArchContextSafe(ctx, scopedStore, changedFiles)

--- a/internal/rag/rag_hyde.go
+++ b/internal/rag/rag_hyde.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
+	"sync"
 
 	"github.com/sevigo/goframe/embeddings/sparse"
 	"github.com/sevigo/goframe/schema"
 	"github.com/sevigo/goframe/vectorstores"
+	"golang.org/x/sync/errgroup"
 
 	internalgithub "github.com/sevigo/code-warden/internal/github"
 	"github.com/sevigo/code-warden/internal/llm"
@@ -65,46 +68,84 @@ func (r *ragService) gatherHyDEContext(ctx context.Context, collection, embedder
 		vectorstores.WithNumGenerations(2),
 	)
 
-	var finalResults [][]schema.Document
-	var finalIndices []int
+	// Parallel HyDE generation with concurrency limit
+	const maxHyDEConcurrency = 5
+	type hydeResult struct {
+		index int
+		docs  []schema.Document
+	}
+
+	var (
+		resultsMu sync.Mutex
+		results   []hydeResult
+	)
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxHyDEConcurrency)
 
 	for i, file := range files {
 		if file.Patch == "" {
 			continue
 		}
 
-		select {
-		case <-ctx.Done():
-			r.logger.Warn("HyDE collection cancelled", "error", ctx.Err())
-			return finalResults, finalIndices, ctx.Err()
-		default:
-		}
+		// Capture loop variables
+		idx := i
+		f := file
 
-		var docs []schema.Document
-		var err error
+		g.Go(func() error {
+			// Check context cancellation
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
 
-		if isLogicFile(file.Filename) {
-			docs, err = retriever.GetRelevantDocuments(ctx, file.Patch)
-		} else {
-			baseQuery := fmt.Sprintf(hydeBaseQueryPrompt, file.Filename, file.Patch)
-			docs, err = rerankingRetriever.GetRelevantDocuments(ctx, baseQuery)
-		}
+			var docs []schema.Document
+			var err error
 
-		if err != nil {
-			r.logger.Warn("HyDE generation/retrieval failed for file", "file", file.Filename, "error", err)
-			continue
-		}
+			if isLogicFile(f.Filename) {
+				docs, err = retriever.GetRelevantDocuments(ctx, f.Patch)
+			} else {
+				baseQuery := fmt.Sprintf(hydeBaseQueryPrompt, f.Filename, f.Patch)
+				docs, err = rerankingRetriever.GetRelevantDocuments(ctx, baseQuery)
+			}
 
-		if len(docs) > 0 {
-			r.logger.Debug("HyDE docs found", "file", file.Filename, "count", len(docs))
-			finalResults = append(finalResults, docs)
-			finalIndices = append(finalIndices, i)
-		} else {
-			r.logger.Debug("no HyDE docs found", "file", file.Filename)
-		}
+			if err != nil {
+				r.logger.Warn("HyDE generation/retrieval failed for file", "file", f.Filename, "error", err)
+				return nil // Non-fatal: continue processing other files
+			}
+
+			if len(docs) > 0 {
+				r.logger.Debug("HyDE docs found", "file", f.Filename, "count", len(docs))
+				resultsMu.Lock()
+				results = append(results, hydeResult{index: idx, docs: docs})
+				resultsMu.Unlock()
+			} else {
+				r.logger.Debug("no HyDE docs found", "file", f.Filename)
+			}
+			return nil
+		})
 	}
 
-	r.logger.Info("stage completed", "name", "HyDE")
+	if err := g.Wait(); err != nil {
+		r.logger.Warn("HyDE collection cancelled", "error", err)
+		return nil, nil, err
+	}
+
+	// Sort results by original index to maintain order
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].index < results[j].index
+	})
+
+	// Extract final results
+	finalResults := make([][]schema.Document, len(results))
+	finalIndices := make([]int, len(results))
+	for i, res := range results {
+		finalResults[i] = res.docs
+		finalIndices[i] = res.index
+	}
+
+	r.logger.Info("stage completed", "name", "HyDE", "files_processed", len(results))
 	return finalResults, finalIndices, nil
 }
 

--- a/internal/rag/rag_index.go
+++ b/internal/rag/rag_index.go
@@ -93,7 +93,6 @@ func (r *ragService) SetupRepoContext(ctx context.Context, repoConfig *core.Repo
 	// Batch accumulation for memory-bounded inserts
 	var batchDocs []schema.Document
 	var batchFiles []storage.FileRecord
-	var batchMu sync.Mutex
 
 	// Start worker pool
 	var wg sync.WaitGroup
@@ -226,16 +225,14 @@ func (r *ragService) SetupRepoContext(ctx context.Context, repoConfig *core.Repo
 	close(resultChan)
 	<-collectorDone // Wait for collector to finish
 
-	// Flush remaining batch
+	// Flush remaining batch (no mutex needed - collector goroutine has finished)
 	if len(batchDocs) > 0 {
-		batchMu.Lock()
 		if _, err := scopedStore.AddDocuments(ctx, batchDocs); err != nil {
 			r.logger.Error("failed to add vectors in final batch", "error", err)
 		}
 		if err := r.store.UpsertFiles(ctx, repo.ID, batchFiles); err != nil {
 			r.logger.Error("failed to update file state in final DB batch", "error", err)
 		}
-		batchMu.Unlock()
 	}
 
 	// Update counts

--- a/internal/rag/rag_retrievers_test.go
+++ b/internal/rag/rag_retrievers_test.go
@@ -378,8 +378,8 @@ func TestHashPatch(t *testing.T) {
 	// Different content should produce different hash
 	assert.NotEqual(t, hash1, hash2)
 
-	// Should be 16 hex chars (8 bytes)
-	assert.Len(t, hash1, 16)
+	// Should be 32 hex chars (16 bytes)
+	assert.Len(t, hash1, 32)
 }
 
 // TestStripPatchNoise_Comprehensive tests the patch cleaning function

--- a/internal/storage/vectorstore.go
+++ b/internal/storage/vectorstore.go
@@ -56,15 +56,17 @@ var _ VectorStore = (*qdrantVectorStore)(nil)
 
 // qdrantVectorStore implements VectorStore using Qdrant with client caching.
 type qdrantVectorStore struct {
-	qdrantHost  string
-	logger      *slog.Logger
-	mu          sync.Mutex
-	embedderMu  sync.RWMutex
-	clients     map[string]vectorstores.VectorStore
-	embedders   map[string]embeddings.Embedder
-	batchConfig *qdrant.BatchConfig
-	cfg         *config.Config
-	qdrantOpts  []qdrant.Option
+	qdrantHost   string
+	logger       *slog.Logger
+	mu           sync.Mutex
+	embedderMu   sync.RWMutex
+	clients      map[string]vectorstores.VectorStore
+	embedders    map[string]embeddings.Embedder
+	batchConfig  *qdrant.BatchConfig
+	cfg          *config.Config
+	qdrantOpts   []qdrant.Option
+	scopedMu     sync.RWMutex
+	scopedStores map[string]*scopedVectorStore // cache for scoped stores
 }
 
 // QdrantStoreOption defines a functional option for configuring the Qdrant vector store.
@@ -105,12 +107,13 @@ func NewQdrantVectorStore(cfg *config.Config, logger *slog.Logger, opts ...Qdran
 		MaxRetryDelay:           qdrant.DefaultMaxRetryDelay,
 	}
 	s := &qdrantVectorStore{
-		qdrantHost:  cfg.Storage.QdrantHost,
-		logger:      logger,
-		clients:     make(map[string]vectorstores.VectorStore),
-		embedders:   make(map[string]embeddings.Embedder),
-		batchConfig: defaultConfig,
-		cfg:         cfg,
+		qdrantHost:   cfg.Storage.QdrantHost,
+		logger:       logger,
+		clients:      make(map[string]vectorstores.VectorStore),
+		embedders:    make(map[string]embeddings.Embedder),
+		batchConfig:  defaultConfig,
+		cfg:          cfg,
+		scopedStores: make(map[string]*scopedVectorStore),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -469,12 +472,37 @@ func (q *qdrantVectorStore) SimilaritySearchBatch(ctx context.Context, queries [
 }
 
 // ForRepo returns a scoped store for a specific repository collection and embedder model.
+// Cached scoped stores are returned for better performance on hot paths.
 func (q *qdrantVectorStore) ForRepo(collectionName, embedderModel string) ScopedVectorStore {
-	return &scopedVectorStore{
+	// Create cache key
+	cacheKey := collectionName + "|" + embedderModel
+
+	// Try read lock first for fast path
+	q.scopedMu.RLock()
+	if cached, ok := q.scopedStores[cacheKey]; ok {
+		q.scopedMu.RUnlock()
+		return cached
+	}
+	q.scopedMu.RUnlock()
+
+	// Create new scoped store
+	scoped := &scopedVectorStore{
 		parent:         q,
 		collectionName: collectionName,
 		embedderModel:  embedderModel,
 	}
+
+	// Store in cache with write lock
+	q.scopedMu.Lock()
+	// Double-check pattern - another goroutine might have created it
+	if existing, ok := q.scopedStores[cacheKey]; ok {
+		q.scopedMu.Unlock()
+		return existing
+	}
+	q.scopedStores[cacheKey] = scoped
+	q.scopedMu.Unlock()
+
+	return scoped
 }
 
 // scopedVectorStore wraps qdrantVectorStore with pre-configured collection and embedder.


### PR DESCRIPTION
High Priority Fixes:
- Fix race condition in batch processing mutex (rag_index.go)
- Add LLM instance caching to prevent re-initialization (rag.go)
- Increase HyDE cache hash from 8 to 16 bytes for collision resistance

Performance Improvements:
- Parallelize HyDE generation with errgroup (limit: 5 workers)
- Add concurrency limit (3) to buildContextConcurrently
- Reuse DefinitionRetriever across symbol lookups
- Increase arch summary worker pool from 3 to 5
- Add ScopedVectorStore caching with double-check locking