### PR TITLE
feat(review): add citation enforcement for anti-hallucination grounding

### DIFF
--- a/internal/core/structured_review.go
+++ b/internal/core/structured_review.go
@@ -29,6 +29,9 @@ type Suggestion struct {
 	Reproducibility string `json:"reproducibility,omitempty"`
 	// CodeSuggestion is the raw code fix proposed by the LLM.
 	CodeSuggestion string `json:"code_suggestion,omitempty"`
+	// Source is the citation for where this finding originated (anti-hallucination grounding).
+	// Format: "diff:L{line}", "context:{file}:{line}", "inference:{type}", or "external:{description}"
+	Source string `json:"source,omitempty"`
 }
 
 // StructuredReview represents the complete output from the LLM in a structured,

--- a/internal/github/status.go
+++ b/internal/github/status.go
@@ -197,6 +197,12 @@ func formatInlineComment(ctx context.Context, sug core.Suggestion) string {
 		sb.WriteString("\n```")
 	}
 
+	// 5. Add Source Citation (anti-hallucination grounding)
+	if sug.Source != "" {
+		sb.WriteString("\n\n")
+		fmt.Fprintf(&sb, "*📍 Source: `%s`*", sug.Source)
+	}
+
 	return sb.String()
 }
 

--- a/internal/llm/parser.go
+++ b/internal/llm/parser.go
@@ -85,6 +85,7 @@ type xmlSuggestion struct {
 	Confidence       int            `xml:"confidence"`
 	EstimatedFixTime string         `xml:"estimated_fix_time"`
 	Reproducibility  string         `xml:"reproducibility"`
+	Source           string         `xml:"source"`
 	Comment          innerXMLString `xml:"comment"`
 	CodeSuggestion   innerXMLString `xml:"code_suggestion"`
 	FixCode          innerXMLString `xml:"fix_code"` // Legacy syntax fallback
@@ -225,6 +226,7 @@ func parseXMLSuggestion(xs *xmlSuggestion, logger *slog.Logger) *core.Suggestion
 	s.Confidence = xs.Confidence
 	s.EstimatedFixTime = strings.TrimSpace(xs.EstimatedFixTime)
 	s.Reproducibility = strings.TrimSpace(xs.Reproducibility)
+	s.Source = strings.TrimSpace(xs.Source)
 
 	if xs.Comment.Content != "" {
 		// Clean up the comment by removing any embedded <fix_code> or <code_suggestion> tags

--- a/internal/llm/prompts/code_review.prompt
+++ b/internal/llm/prompts/code_review.prompt
@@ -122,11 +122,26 @@ You have been provided with pre-computed context in the "ARCHITECTURAL OVERVIEW"
 - **Validation**: Ensure suggested fixes are syntactically correct and don't introduce new bugs (e.g., race conditions).
 - **Tone**: Be constructive. Distinguish between BLOCKING errors (bugs/security) and NON-BLOCKING suggestions (style/perf).
 
-### CITATION REQUIREMENTS (Anti-Hallucination)
-- **Cite Retrieved Context**: When flagging an issue based on external code (not in diff), you MUST reference the specific section from ARCHITECTURAL OVERVIEW or RESOLVED TYPE DEFINITIONS that supports your finding.
-- **Quote Pattern Evidence**: When suggesting changes contradict existing patterns, quote the relevant snippet from "Related Code Snippets" that should be followed.
-- **Acknowledge Blind Spots**: If you cannot verify a concern due to missing context, explicitly state: "Cannot verify - requires context from [module/file] not available in retrieved data."
-- **No Fabricated References**: Never invent file paths, function names, or type definitions not present in the diff OR retrieved context.
+### CITATION REQUIREMENTS (Anti-Hallucination) - MANDATORY
+Every suggestion MUST include a `<source>` tag that grounds the finding in evidence:
+
+**Required Source Types:**
+1. `diff:L{line}` - Issue visible directly in the diff at line {line}
+2. `context:{filename}:{line}` - Issue based on retrieved context (must match actual context section)
+3. `inference` - Logical deduction from visible code patterns (use sparingly, only for obvious issues)
+4. `external:{description}` - When you cannot verify (acknowledge blind spot)
+
+**Examples:**
+- `<source>diff:L45</source>` - Bug found at line 45 in the diff
+- `<source>context:auth.go:102</source>` - Found via architectural context in auth.go line 102
+- `<source>context:definitions:UserService</source>` - Based on resolved type definition
+- `<source>inference:nil-check-missing</source>` - Logical inference from pattern
+
+**Anti-Hallucination Rules:**
+- **NEVER** cite files/lines that don't exist in the diff or provided context
+- **NEVER** fabricate function names, types, or variables not shown
+- **ALWAYS** verify the cited source actually supports your claim
+- If you cannot find evidence in context, use `external:` and describe the gap
 
 ### SEVERITY GUIDELINES
 - **Critical**: Security vulnerabilities, data loss/corruption, guaranteed crashes, path traversal, injection flaws
@@ -184,6 +199,7 @@ If your stack shows `[comment]` and you are about to write code, you **MUST** po
       <confidence>100</confidence>
       <estimated_fix_time>5m</estimated_fix_time>
       <reproducibility>Always</reproducibility>
+      <source>diff:L123</source>
       <comment>
         **Observation:** [Detail]
         **Rationale:** [Impact]
@@ -198,6 +214,6 @@ If your stack shows `[comment]` and you are about to write code, you **MUST** po
 </review>
 ```
 
-If no suggestions are found, the `<suggestions>` tag should be empty or omitted.
+**The `<source>` tag is MANDATORY for every suggestion.** This grounds your findings in verifiable evidence and prevents hallucinations.
 
 Now analyze the PR:


### PR DESCRIPTION
## Summary
This PR adds mandatory citation enforcement to reduce hallucinations in code reviews.

### Prompt Changes
- Every suggestion now requires a `<source>` tag citing evidence
- Defined source types:
  - `diff:L{line}` - Issue visible directly in the diff
  - `context:{file}:{line}` - Based on retrieved architectural context
  - `inference:{type}` - Logical deduction from visible patterns
  - `external:{description}` - Acknowledged blind spot
- Added anti-hallucination rules to prevent fabricated references

### Code Changes
- Added `Source` field to `Suggestion` struct
- Updated XML parser to extract the `<source>` tag
- Display source citation in GitHub comments with 📍 emoji

## Example Output
```
**🔴 Critical — Security**

> [!CAUTION]
> Missing input validation on file path...

```suggestion
// code fix
```

*📍 Source: `diff:L45`*
```

## Test plan
- [x] All tests pass (`go test ./...`)
- [x] Linter passes (`make lint`)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)