### PR TITLE
feat: integrate goframe contextpacker for accurate token counting

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -114,7 +114,7 @@ ai:
   # Recommendation based on model context window:
   #   - 8K context models: 4000-6000
   #   - 32K context models: 12000-20000
-  #   - 128K context models: 30000-50000 (default)
+  #   - 128K context models: 16000-50000 (16000 is a conservative default)
   #   - 256K+ context models: 50000-100000
   # Note: Leave room for system prompt (~1K), diff (~4K), and response (~8K-16K)
   context_token_budget: 16000

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -102,11 +102,22 @@ ai:
   model_keep_alive: "10m"
 
   # HTTP Client Overrides
-  # Timeout for waiting for the first byte of an LLM response (headers). 
-  # Increase this if you see "timeout awaiting response headers" errors 
+  # Timeout for waiting for the first byte of an LLM response (headers).
+  # Increase this if you see "timeout awaiting response headers" errors
   # when using heavy cloud models via Ollama proxy.
   # default: "120s"
   http_response_header_timeout: "120s"
+
+  # Context Assembly
+  # Maximum tokens for RAG context (retrieved code snippets, definitions, etc.)
+  # This is NOT the full prompt - it's just the retrieved context portion.
+  # Recommendation based on model context window:
+  #   - 8K context models: 4000-6000
+  #   - 32K context models: 12000-20000
+  #   - 128K context models: 30000-50000 (default)
+  #   - 256K+ context models: 50000-100000
+  # Note: Leave room for system prompt (~1K), diff (~4K), and response (~8K-16K)
+  context_token_budget: 16000
 
 # ============================================================================
 # Storage Configuration

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/wire v0.6.0
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.11.1
-	github.com/sevigo/goframe v0.28.3
+	github.com/sevigo/goframe v0.29.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,8 @@ github.com/schollz/progressbar/v2 v2.15.0 h1:dVzHQ8fHRmtPjD3K10jT3Qgn/+H+92jhPrh
 github.com/schollz/progressbar/v2 v2.15.0/go.mod h1:UdPq3prGkfQ7MOzZKlDRpYKcFqEMczbD7YmbPgpzKMI=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
-github.com/sevigo/goframe v0.28.3 h1:MKy9tnqNqQaBn+5X8HLcf0CuOipT6dsFnugAzZuZwvU=
-github.com/sevigo/goframe v0.28.3/go.mod h1:KyFDiWUZOfKlxBMc1yVLXBra1elkrXacoig6sRxa6K4=
+github.com/sevigo/goframe v0.29.0 h1:Pq2+Oi4jxRBV4lFLCIV7Y3JKwbUeZV1J1vPsA8Mx64A=
+github.com/sevigo/goframe v0.29.0/go.mod h1:KyFDiWUZOfKlxBMc1yVLXBra1elkrXacoig6sRxa6K4=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,6 +76,9 @@ type AIConfig struct {
 
 	// HTTP Client Overrides
 	HTTPResponseHeaderTimeout string `mapstructure:"http_response_header_timeout"` // Timeout for waiting for HTTP response headers (e.g., "30s", "120s")
+
+	// Context Assembly
+	ContextTokenBudget int `mapstructure:"context_token_budget"` // Max tokens for RAG context (default: 16000)
 }
 
 func (c *AIConfig) Validate() error {
@@ -255,6 +258,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("ai.model_keep_alive", "10m")   // Keep models loaded for 10 minutes
 	v.SetDefault("ai.http_response_header_timeout", "120s")
 	v.SetDefault("ai.consensus_quorum", 0.66)
+	v.SetDefault("ai.context_token_budget", 16000) // Reasonable default for 128K context models
 
 	// Storage
 	v.SetDefault("storage.qdrant_host", "localhost:6334")

--- a/internal/llm/tokenizer.go
+++ b/internal/llm/tokenizer.go
@@ -74,7 +74,9 @@ func NewEstimatingTokenizer() llms.Tokenizer {
 	return &EstimatingTokenizer{}
 }
 
-// CountTokens estimates token count using the 1 token ≈ 3 characters heuristic.
+// CountTokens estimates token count using the industry-standard approximation
+// of 1 token ≈ 3-4 characters for English text.
+// Note: This is less accurate for code or non-English languages.
 func (e *EstimatingTokenizer) CountTokens(_ context.Context, text string) (int, error) {
 	return len(text) / 3, nil
 }

--- a/internal/llm/tokenizer.go
+++ b/internal/llm/tokenizer.go
@@ -64,3 +64,27 @@ func (a *OllamaTokenizerAdapter) GetOptimalOverlapTokens(_ context.Context, _ st
 func (a *OllamaTokenizerAdapter) GetMaxContextWindow(_ context.Context, _ string) int {
 	return 8192
 }
+
+// EstimatingTokenizer is a fallback tokenizer that uses character-based estimation.
+// It's used when the LLM provider doesn't implement llms.Tokenizer (e.g., Gemini).
+type EstimatingTokenizer struct{}
+
+// NewEstimatingTokenizer creates a tokenizer that estimates token count from characters.
+func NewEstimatingTokenizer() llms.Tokenizer {
+	return &EstimatingTokenizer{}
+}
+
+// CountTokens estimates token count using the 1 token ≈ 3 characters heuristic.
+func (e *EstimatingTokenizer) CountTokens(_ context.Context, text string) (int, error) {
+	return len(text) / 3, nil
+}
+
+// AsTokenizer returns an llms.Tokenizer for the given model.
+// If the model implements llms.Tokenizer, it's returned directly.
+// Otherwise, an EstimatingTokenizer is returned as fallback.
+func AsTokenizer(model llms.Model) llms.Tokenizer {
+	if t, ok := model.(llms.Tokenizer); ok {
+		return t
+	}
+	return NewEstimatingTokenizer()
+}

--- a/internal/rag/rag.go
+++ b/internal/rag/rag.go
@@ -86,18 +86,28 @@ func NewService(
 	// Register sparse provider for hybrid search
 	sparse.RegisterProvider(sparse.NewBoWProvider())
 
-	// Create context packer with 6000 token budget for context assembly
+	// Get token budget from config, with fallback
+	tokenBudget := cfg.AI.ContextTokenBudget
+	if tokenBudget <= 0 {
+		tokenBudget = 16000 // Default for 128K context models
+	}
+
+	// Create context packer with configurable token budget
 	tokenizer := llm.AsTokenizer(gen)
-	contextPacker, err := contextpacker.New(tokenizer, 6000,
+	contextPacker, err := contextpacker.New(tokenizer, tokenBudget,
 		contextpacker.WithTemplate(contextpacker.CompactTemplate),
 		contextpacker.WithLogger(logger),
 	)
 	if err != nil {
-		logger.Warn("failed to create context packer, using fallback", "error", err)
-		// Create a fallback packer with nil tokenizer (will use estimation)
-		contextPacker, _ = contextpacker.New(llm.NewEstimatingTokenizer(), 6000,
+		logger.Error("failed to create context packer with model tokenizer, using estimation fallback", "error", err)
+		// Fallback to estimation-based packer
+		contextPacker, err = contextpacker.New(llm.NewEstimatingTokenizer(), tokenBudget,
 			contextpacker.WithTemplate(contextpacker.CompactTemplate),
 		)
+		if err != nil {
+			// This should never happen with EstimatingTokenizer, but handle it
+			logger.Error("critical: failed to create fallback context packer", "error", err)
+		}
 	}
 
 	return &ragService{

--- a/internal/rag/rag.go
+++ b/internal/rag/rag.go
@@ -82,7 +82,7 @@ func NewService(
 	pr parsers.ParserRegistry,
 	splitter textsplitter.TextSplitter,
 	logger *slog.Logger,
-) Service {
+) (Service, error) {
 	// Register sparse provider for hybrid search
 	sparse.RegisterProvider(sparse.NewBoWProvider())
 
@@ -99,14 +99,13 @@ func NewService(
 		contextpacker.WithLogger(logger),
 	)
 	if err != nil {
-		logger.Error("failed to create context packer with model tokenizer, using estimation fallback", "error", err)
+		logger.Warn("failed to create context packer with model tokenizer, using estimation fallback", "error", err)
 		// Fallback to estimation-based packer
 		contextPacker, err = contextpacker.New(llm.NewEstimatingTokenizer(), tokenBudget,
 			contextpacker.WithTemplate(contextpacker.CompactTemplate),
 		)
 		if err != nil {
-			// This should never happen with EstimatingTokenizer, but handle it
-			logger.Error("critical: failed to create fallback context packer", "error", err)
+			return nil, fmt.Errorf("failed to initialize context packer: %w", err)
 		}
 	}
 
@@ -121,7 +120,7 @@ func NewService(
 		splitter:       splitter,
 		contextPacker:  contextPacker,
 		logger:         logger,
-	}
+	}, nil
 }
 
 func (r *ragService) GetTextSplitter() textsplitter.TextSplitter {

--- a/internal/rag/rag.go
+++ b/internal/rag/rag.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sevigo/goframe/contextpacker"
 	"github.com/sevigo/goframe/embeddings/sparse"
 	"github.com/sevigo/goframe/httpclient"
 	"github.com/sevigo/goframe/llms"
@@ -64,6 +65,7 @@ type ragService struct {
 	reranker       schema.Reranker
 	parserRegistry parsers.ParserRegistry
 	splitter       textsplitter.TextSplitter
+	contextPacker  *contextpacker.Packer
 	logger         *slog.Logger
 	hydeCache      sync.Map // map[string]string: patchHash -> hydeSnippet
 	llmCache       sync.Map // map[string]llms.Model: modelName -> LLM instance
@@ -84,6 +86,20 @@ func NewService(
 	// Register sparse provider for hybrid search
 	sparse.RegisterProvider(sparse.NewBoWProvider())
 
+	// Create context packer with 6000 token budget for context assembly
+	tokenizer := llm.AsTokenizer(gen)
+	contextPacker, err := contextpacker.New(tokenizer, 6000,
+		contextpacker.WithTemplate(contextpacker.CompactTemplate),
+		contextpacker.WithLogger(logger),
+	)
+	if err != nil {
+		logger.Warn("failed to create context packer, using fallback", "error", err)
+		// Create a fallback packer with nil tokenizer (will use estimation)
+		contextPacker, _ = contextpacker.New(llm.NewEstimatingTokenizer(), 6000,
+			contextpacker.WithTemplate(contextpacker.CompactTemplate),
+		)
+	}
+
 	return &ragService{
 		cfg:            cfg,
 		promptMgr:      promptMgr,
@@ -93,6 +109,7 @@ func NewService(
 		reranker:       reranker,
 		parserRegistry: pr,
 		splitter:       splitter,
+		contextPacker:  contextPacker,
 		logger:         logger,
 	}
 }

--- a/internal/rag/rag_context.go
+++ b/internal/rag/rag_context.go
@@ -442,7 +442,7 @@ func (r *ragService) buildRelevantContext(ctx context.Context, collectionName, e
 		impactContext, descriptionContext = r.splitAndFormatDocs(ctx, allDocs, results.descriptionDocs, prDescription, &seenDocs)
 	}
 
-	fullContext := r.assembleContext(results.archContext, impactContext, descriptionContext, results.definitionsContext, results.hydeResults, results.hydeIndices, changedFiles)
+	fullContext := r.assembleContext(ctx, results.archContext, impactContext, descriptionContext, results.definitionsContext, results.hydeResults, results.hydeIndices, changedFiles)
 	return fullContext, results.definitionsContext
 }
 
@@ -682,6 +682,7 @@ func (r *ragService) gatherImpactDocs(ctx context.Context, store storage.ScopedV
 
 // assembleContext assembles the final prompt context using the contextpacker.
 func (r *ragService) assembleContext(
+	ctx context.Context,
 	arch, impact, description, definitions string,
 	hyde [][]schema.Document, indices []int,
 	files []internalgithub.ChangedFile,
@@ -690,17 +691,17 @@ func (r *ragService) assembleContext(
 	// Priority (highest first): Definitions > Description > Impact > Arch > HyDE
 	docs := r.buildContextDocuments(arch, impact, description, definitions, hyde, indices, files)
 
-	// Pack documents using the contextpacker
-	result, err := r.contextPacker.Pack(context.Background(), docs)
+	// Nil check for defensive programming
+	if r.contextPacker == nil {
+		r.logger.Error("context packer not initialized, using limited fallback")
+		return r.fallbackConcat(docs)
+	}
+
+	// Pack documents using the contextpacker with proper context propagation
+	result, err := r.contextPacker.Pack(ctx, docs)
 	if err != nil {
-		r.logger.Warn("context packer failed, using fallback", "error", err)
-		// Fallback: concatenate all content
-		var fallback strings.Builder
-		for _, doc := range docs {
-			fallback.WriteString(doc.PageContent)
-			fallback.WriteString("\n---\n\n")
-		}
-		return fallback.String()
+		r.logger.Error("context packer failed, using limited fallback - token budget may not be enforced", "error", err)
+		return r.fallbackConcat(docs)
 	}
 
 	r.logger.Info("relevant context built",
@@ -716,6 +717,31 @@ func (r *ragService) assembleContext(
 	)
 
 	return result.Content
+}
+
+// fallbackConcat provides a safe fallback when contextpacker is unavailable.
+// It uses character-based estimation to respect token budget.
+func (r *ragService) fallbackConcat(docs []schema.Document) string {
+	const tokensPerChar = 3
+	maxChars := r.cfg.AI.ContextTokenBudget * tokensPerChar
+	if maxChars <= 0 {
+		maxChars = 48000 // Default: 16000 tokens * 3
+	}
+
+	var fallback strings.Builder
+	currentChars := 0
+
+	for _, doc := range docs {
+		docLen := len(doc.PageContent)
+		if currentChars+docLen > maxChars {
+			break // Respect budget
+		}
+		fallback.WriteString(doc.PageContent)
+		fallback.WriteString("\n---\n\n")
+		currentChars += docLen + 5 // Account for separator
+	}
+
+	return fallback.String()
 }
 
 // buildContextDocuments creates prioritized documents for the context packer.

--- a/internal/rag/rag_context.go
+++ b/internal/rag/rag_context.go
@@ -688,71 +688,7 @@ func (r *ragService) assembleContext(
 ) string {
 	// Build documents with priority-based ordering for the packer
 	// Priority (highest first): Definitions > Description > Impact > Arch > HyDE
-	var docs []schema.Document
-
-	// Priority 1: Definitions (type context is most critical for accuracy)
-	if definitions != "" {
-		docs = append(docs, schema.Document{
-			PageContent: definitions,
-			Metadata:    map[string]any{"section": "definitions", "priority": 1},
-		})
-	}
-
-	// Priority 2: Description-related snippets
-	if description != "" {
-		docs = append(docs, schema.Document{
-			PageContent: description,
-			Metadata:    map[string]any{"section": "description", "priority": 2},
-		})
-	}
-
-	// Priority 3: Impact analysis
-	if impact != "" {
-		docs = append(docs, schema.Document{
-			PageContent: fmt.Sprintf("# Potential Impacted Callers & Usages\n\nThe following code snippets may be affected by the changes in modified symbols:\n\n%s", impact),
-			Metadata:    map[string]any{"section": "impact", "priority": 3},
-		})
-	}
-
-	// Priority 4: Architectural context
-	if arch != "" {
-		docs = append(docs, schema.Document{
-			PageContent: fmt.Sprintf("# Architectural Context\n\nThe following describes the purpose of the affected modules:\n\n%s", arch),
-			Metadata:    map[string]any{"section": "arch", "priority": 4},
-		})
-	}
-
-	// Priority 5: HyDE snippets (may be redundant if impact/description already covered)
-	if len(hyde) > 0 {
-		var hydeBuilder strings.Builder
-		hydeBuilder.WriteString("# Related Code Snippets\n\nThe following code snippets might be relevant to the changes being reviewed:\n\n")
-		hydeSeenKeys := make(map[string]struct{})
-		for i, hydeDocs := range hyde {
-			if i >= len(indices) {
-				continue
-			}
-			originalIdx := indices[i]
-			if originalIdx >= len(files) {
-				continue
-			}
-			filePath := files[originalIdx].Filename
-			for _, doc := range hydeDocs {
-				key := r.getDocKey(doc)
-				if _, exists := hydeSeenKeys[key]; exists {
-					continue
-				}
-				hydeSeenKeys[key] = struct{}{}
-				hydeBuilder.WriteString(fmt.Sprintf("## Related to: %s\n", filePath))
-				hydeBuilder.WriteString("```\n")
-				hydeBuilder.WriteString(r.getDocContent(doc))
-				hydeBuilder.WriteString("\n```\n\n")
-			}
-		}
-		docs = append(docs, schema.Document{
-			PageContent: hydeBuilder.String(),
-			Metadata:    map[string]any{"section": "hyde", "priority": 5},
-		})
-	}
+	docs := r.buildContextDocuments(arch, impact, description, definitions, hyde, indices, files)
 
 	// Pack documents using the contextpacker
 	result, err := r.contextPacker.Pack(context.Background(), docs)
@@ -780,6 +716,80 @@ func (r *ragService) assembleContext(
 	)
 
 	return result.Content
+}
+
+// buildContextDocuments creates prioritized documents for the context packer.
+func (r *ragService) buildContextDocuments(
+	arch, impact, description, definitions string,
+	hyde [][]schema.Document, indices []int,
+	files []internalgithub.ChangedFile,
+) []schema.Document {
+	var docs []schema.Document
+
+	// Priority 1: Definitions (type context is most critical for accuracy)
+	if definitions != "" {
+		docs = append(docs, schema.Document{
+			PageContent: definitions,
+		})
+	}
+
+	// Priority 2: Description-related snippets
+	if description != "" {
+		docs = append(docs, schema.Document{
+			PageContent: description,
+		})
+	}
+
+	// Priority 3: Impact analysis
+	if impact != "" {
+		docs = append(docs, schema.Document{
+			PageContent: fmt.Sprintf("# Potential Impacted Callers & Usages\n\nThe following code snippets may be affected by the changes in modified symbols:\n\n%s", impact),
+		})
+	}
+
+	// Priority 4: Architectural context
+	if arch != "" {
+		docs = append(docs, schema.Document{
+			PageContent: fmt.Sprintf("# Architectural Context\n\nThe following describes the purpose of the affected modules:\n\n%s", arch),
+		})
+	}
+
+	// Priority 5: HyDE snippets
+	if hydeContent := r.buildHyDEContent(hyde, indices, files); hydeContent != "" {
+		docs = append(docs, schema.Document{
+			PageContent: hydeContent,
+		})
+	}
+
+	return docs
+}
+
+// buildHyDEContent builds the HyDE section content from retrieved documents.
+func (r *ragService) buildHyDEContent(hyde [][]schema.Document, indices []int, files []internalgithub.ChangedFile) string {
+	if len(hyde) == 0 {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.WriteString("# Related Code Snippets\n\nThe following code snippets might be relevant to the changes being reviewed:\n\n")
+
+	seenKeys := make(map[string]struct{})
+	for i, hydeDocs := range hyde {
+		if i >= len(indices) || indices[i] >= len(files) {
+			continue
+		}
+		filePath := files[indices[i]].Filename
+		for _, doc := range hydeDocs {
+			key := r.getDocKey(doc)
+			if _, exists := seenKeys[key]; exists {
+				continue
+			}
+			seenKeys[key] = struct{}{}
+			builder.WriteString(fmt.Sprintf("## Related to: %s\n```\n%s\n```\n\n", filePath, r.getDocContent(doc)))
+		}
+	}
+
+	return builder.String()
 }
 
 func (r *ragService) processRelatedSnippet(doc schema.Document, originalFile internalgithub.ChangedFile, rank int, seenDocs map[string]struct{}, seenMu *sync.RWMutex, topFiles []string, builder *strings.Builder) []string {

--- a/internal/rag/rag_context.go
+++ b/internal/rag/rag_context.go
@@ -680,37 +680,54 @@ func (r *ragService) gatherImpactDocs(ctx context.Context, store storage.ScopedV
 	return docs, err
 }
 
-// assembleContext assembles the final prompt context.
+// assembleContext assembles the final prompt context using the contextpacker.
 func (r *ragService) assembleContext(
 	arch, impact, description, definitions string,
 	hyde [][]schema.Document, indices []int,
 	files []internalgithub.ChangedFile,
 ) string {
-	const tokenBudget = 6000
-	packer := newTokenContextPacker(tokenBudget)
+	// Build documents with priority-based ordering for the packer
+	// Priority (highest first): Definitions > Description > Impact > Arch > HyDE
+	var docs []schema.Document
 
 	// Priority 1: Definitions (type context is most critical for accuracy)
 	if definitions != "" {
-		packer.add("Definitions", definitions)
+		docs = append(docs, schema.Document{
+			PageContent: definitions,
+			Metadata:    map[string]any{"section": "definitions", "priority": 1},
+		})
 	}
+
 	// Priority 2: Description-related snippets
 	if description != "" {
-		packer.add("Description", description)
+		docs = append(docs, schema.Document{
+			PageContent: description,
+			Metadata:    map[string]any{"section": "description", "priority": 2},
+		})
 	}
+
 	// Priority 3: Impact analysis
 	if impact != "" {
-		packer.add("Impact", fmt.Sprintf("# Potential Impacted Callers & Usages\n\nThe following code snippets may be affected by the changes in modified symbols:\n\n%s", impact))
+		docs = append(docs, schema.Document{
+			PageContent: fmt.Sprintf("# Potential Impacted Callers & Usages\n\nThe following code snippets may be affected by the changes in modified symbols:\n\n%s", impact),
+			Metadata:    map[string]any{"section": "impact", "priority": 3},
+		})
 	}
+
 	// Priority 4: Architectural context
 	if arch != "" {
-		packer.add("Arch", fmt.Sprintf("# Architectural Context\n\nThe following describes the purpose of the affected modules:\n\n%s", arch))
+		docs = append(docs, schema.Document{
+			PageContent: fmt.Sprintf("# Architectural Context\n\nThe following describes the purpose of the affected modules:\n\n%s", arch),
+			Metadata:    map[string]any{"section": "arch", "priority": 4},
+		})
 	}
+
 	// Priority 5: HyDE snippets (may be redundant if impact/description already covered)
 	if len(hyde) > 0 {
 		var hydeBuilder strings.Builder
 		hydeBuilder.WriteString("# Related Code Snippets\n\nThe following code snippets might be relevant to the changes being reviewed:\n\n")
 		hydeSeenKeys := make(map[string]struct{})
-		for i, docs := range hyde {
+		for i, hydeDocs := range hyde {
 			if i >= len(indices) {
 				continue
 			}
@@ -719,7 +736,7 @@ func (r *ragService) assembleContext(
 				continue
 			}
 			filePath := files[originalIdx].Filename
-			for _, doc := range docs {
+			for _, doc := range hydeDocs {
 				key := r.getDocKey(doc)
 				if _, exists := hydeSeenKeys[key]; exists {
 					continue
@@ -731,10 +748,24 @@ func (r *ragService) assembleContext(
 				hydeBuilder.WriteString("\n```\n\n")
 			}
 		}
-		packer.add("HyDE", hydeBuilder.String())
+		docs = append(docs, schema.Document{
+			PageContent: hydeBuilder.String(),
+			Metadata:    map[string]any{"section": "hyde", "priority": 5},
+		})
 	}
 
-	result := packer.build()
+	// Pack documents using the contextpacker
+	result, err := r.contextPacker.Pack(context.Background(), docs)
+	if err != nil {
+		r.logger.Warn("context packer failed, using fallback", "error", err)
+		// Fallback: concatenate all content
+		var fallback strings.Builder
+		for _, doc := range docs {
+			fallback.WriteString(doc.PageContent)
+			fallback.WriteString("\n---\n\n")
+		}
+		return fallback.String()
+	}
 
 	r.logger.Info("relevant context built",
 		"changed_files", len(files),
@@ -742,76 +773,13 @@ func (r *ragService) assembleContext(
 		"impact_len", len(impact),
 		"definitions_len", len(definitions),
 		"hyde_results_count", len(hyde),
-		"packed_len", len(result),
-		"is_truncated", packer.isTruncated,
+		"total_tokens", result.TokenStats.TotalTokens,
+		"documents_packed", result.TokenStats.DocumentsPacked,
+		"documents_considered", result.TokenStats.DocumentsConsidered,
+		"truncated", result.Truncated,
 	)
 
-	return result
-}
-
-// tokenContextSection represents a named section in the context packer.
-type tokenContextSection struct {
-	name    string
-	content string
-}
-
-// tokenContextPacker packs context sections into a token budget.
-type tokenContextPacker struct {
-	budget      int
-	sections    []tokenContextSection
-	isTruncated bool
-}
-
-func newTokenContextPacker(tokenBudget int) *tokenContextPacker {
-	return &tokenContextPacker{budget: tokenBudget}
-}
-
-// add appends a named section. Sections are packed in the order they are added
-// (first added = highest priority).
-func (p *tokenContextPacker) add(name, content string) {
-	if content != "" {
-		p.sections = append(p.sections, tokenContextSection{name: name, content: content})
-	}
-}
-
-// estimateTokens returns a fast character-based token estimate (1 token ≈ 3 chars).
-func estimateTokens(s string) int { return len(s) / 3 }
-
-// build assembles sections into a single string, truncating lower-priority
-// sections when the total would exceed the token budget.
-func (p *tokenContextPacker) build() string {
-	var out strings.Builder
-	remaining := p.budget
-
-	for _, sec := range p.sections {
-		tokens := estimateTokens(sec.content)
-
-		switch {
-		case tokens <= remaining:
-			out.WriteString(sec.content)
-			out.WriteString("\n---\n\n")
-			remaining -= tokens
-
-		case remaining > 50: // Only truncate if there's meaningful space left
-			p.isTruncated = true
-			// Truncate to remaining budget
-			maxChars := remaining * 3
-			truncated := sec.content[:maxChars]
-			// Try to cut at a newline boundary
-			if idx := strings.LastIndex(truncated, "\n"); idx > maxChars/2 {
-				truncated = truncated[:idx]
-			}
-			out.WriteString(truncated)
-			out.WriteString(fmt.Sprintf("\n[%s context truncated due to length]\n\n---\n\n", sec.name))
-			remaining = 0
-
-		default: // Budget exhausted
-			p.isTruncated = true
-			out.WriteString(fmt.Sprintf("[%s context omitted — token budget exhausted]\n\n---\n\n", sec.name))
-		}
-	}
-
-	return out.String()
+	return result.Content
 }
 
 func (r *ragService) processRelatedSnippet(doc schema.Document, originalFile internalgithub.ChangedFile, rank int, seenDocs map[string]struct{}, seenMu *sync.RWMutex, topFiles []string, builder *strings.Builder) []string {

--- a/internal/wire/wire_gen.go
+++ b/internal/wire/wire_gen.go
@@ -88,7 +88,11 @@ func InitializeApp(ctx context.Context) (*app.App, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	service := rag.NewService(configConfig, promptManager, vectorStore, store, model, reranker, parserRegistry, textSplitter, logger)
+	service, err := rag.NewService(configConfig, promptManager, vectorStore, store, model, reranker, parserRegistry, textSplitter, logger)
+	if err != nil {
+		cleanup()
+		return nil, nil, err
+	}
 	job := jobs.NewReviewJob(configConfig, service, store, repoManager, logger)
 	jobDispatcher := jobs.NewDispatcher(ctx, job, configConfig, logger)
 	serverServer := server.NewServer(ctx, configConfig, jobDispatcher, logger)


### PR DESCRIPTION
- Update goframe from v0.28.3 to v0.29.0
- Add EstimatingTokenizer and AsTokenizer helper for fallback tokenization
- Replace custom tokenContextPacker with goframe's contextpacker.Packer
- Use LLM tokenizer for accurate token counting (Ollama) with estimation fallback
- Log TokenStats (TotalTokens, DocumentsPacked, Truncated) for better observability

Benefits:
- Accurate token counting when using Ollama (uses native tokenizer)
- Graceful fallback to estimation for providers without tokenizer (Gemini)
- Better context packing statistics and truncation tracking
- Reduced code complexity by removing ~65 lines of custom packing logic