### PR TITLE
fix: improve review comment formatting and add issue status table

### DIFF
--- a/internal/github/status.go
+++ b/internal/github/status.go
@@ -207,6 +207,7 @@ func formatInlineComment(ctx context.Context, sug core.Suggestion) string {
 }
 
 // preprocessComment cleans up LLM-generated comments by:
+// - Stripping trailing whitespace from each line (fixes markdown rendering)
 // - Stripping legacy ### title headers
 // - Converting #### headers to bold with emojis
 func preprocessComment(comment string) string {
@@ -216,6 +217,9 @@ func preprocessComment(comment string) string {
 
 	for i := range lines {
 		line := lines[i]
+		// Strip trailing whitespace from each line (fixes markdown rendering issues
+		// where "**Rationale:** " with trailing space breaks the bold formatting)
+		line = strings.TrimRight(line, " \t")
 		trimmed := strings.TrimSpace(line)
 
 		// Strip legacy ### headers (e.g., "### Old Style Title")

--- a/internal/llm/prompts/code_review.prompt
+++ b/internal/llm/prompts/code_review.prompt
@@ -188,7 +188,23 @@ If your stack shows `[comment]` and you are about to write code, you **MUST** po
   <confidence>95</confidence>
   <summary>
     # REVIEW SUMMARY
-    [High-level assessment]
+    [High-level assessment of the changes]
+
+    ### 📊 Issue Status Table
+
+    | Issue | Severity | Blocking? |
+    | :--- | :--- | :--- |
+    | [Brief title] | [Indicator] [Severity] | [Yes/No] |
+    | [Brief title] | [Indicator] [Severity] | [Yes/No] |
+
+    #### Severity Legend:
+    - 🔴 Critical: Security vulnerabilities, data loss, guaranteed crashes
+    - 🟡 High: Logic bugs, breaking changes, resource leaks
+    - 🟠 Medium: Performance issues, code smells, anti-patterns
+    - 🟢 Low: Minor improvements, style suggestions
+
+    ## Overall Assessment
+    [Conclusion about whether the code is ready to merge]
   </summary>
   <suggestions>
     <suggestion>


### PR DESCRIPTION
- Strip trailing whitespace from comment lines in preprocessComment (fixes markdown rendering where "**Rationale:** " breaks bold formatting)
- Add Issue Status Table to code review prompt for consistency with rereview
- Add comment formatting rules to prevent trailing whitespace issues