### PR TITLE
fix: remove redundant context check in PostStructuredReview

### DIFF
--- a/internal/github/status.go
+++ b/internal/github/status.go
@@ -109,10 +109,6 @@ func (s *statusUpdater) PostStructuredReview(ctx context.Context, event *core.Gi
 			continue
 		}
 
-		if ctx.Err() != nil {
-			return fmt.Errorf("review cancelled: %w", ctx.Err())
-		}
-
 		formattedComment := formatInlineComment(ctx, sug)
 		if formattedComment == "" {
 			continue


### PR DESCRIPTION
## Summary

- Removed a redundant context cancellation check in `PostStructuredReview`
- The context is already checked at the start of each loop iteration via the `select` block
- The second `ctx.Err()` check just a few lines later provides no additional value

## Before

```go
for _, sug := range review.Suggestions {
    // Context check at start of loop iteration for responsiveness
    select {
    case <-ctx.Done():
        return ctx.Err()
    default:
    }

    if sug.FilePath == "" || sug.LineNumber <= 0 || sug.Comment == "" {
        continue
    }

    if ctx.Err() != nil {  // <-- REDUNDANT
        return fmt.Errorf("review cancelled: %w", ctx.Err())
    }
    ...
}
```

## After

The redundant check is removed. Context cancellation is still properly handled by the `select` block at the start of each iteration.

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./internal/github/...` passes

/review