### PR TITLE
chore: remove redundant severity legend from review output

### DIFF
--- a/internal/llm/prompts/code_review.prompt
+++ b/internal/llm/prompts/code_review.prompt
@@ -197,12 +197,6 @@ If your stack shows `[comment]` and you are about to write code, you **MUST** po
 | [Brief title] | [Indicator] [Severity] | [Yes/No] |
 | [Brief title] | [Indicator] [Severity] | [Yes/No] |
 
-#### Severity Legend:
-- 🔴 Critical: Security vulnerabilities, data loss, guaranteed crashes
-- 🟡 High: Logic bugs, breaking changes, resource leaks
-- 🟠 Medium: Performance issues, code smells, anti-patterns
-- 🟢 Low: Minor improvements, style suggestions
-
 ## Overall Assessment
 [Conclusion about whether the code is ready to merge]
   </summary>


### PR DESCRIPTION
The severity levels (Critical, High, Medium, Low) are self-explanatory with the emoji indicators. The definitions already exist in the prompt guidelines (lines 146-150) for the LLM to understand severity levels, so repeating them in every review output adds unnecessary noise.