### PR TITLE
feat: add start_line support for multi-line code suggestions

### DIFF
--- a/internal/llm/prompts/code_review.prompt
+++ b/internal/llm/prompts/code_review.prompt
@@ -158,7 +158,7 @@ Every suggestion MUST include a `<source>` tag that grounds the finding in evide
 ### 1. ABSOLUTE REQUIREMENT: TAG CLOSURE DISCIPLINE
 You MUST follow this sequence EXACTLY for every suggestion:
 1. Write the opening `<suggestion>` tag.
-2. Fill in `<file>`, `<line>`, `<severity>`, `<category>`, `<confidence>`, `<reproducibility>`.
+2. Fill in `<file>`, optionally `<start_line>` (for multi-line suggestions), `<line>`, `<severity>`, `<category>`, `<confidence>`, `<reproducibility>`.
 3. Open `<comment>`.
 4. Write your detailed observation and fix recommendation.
 5. **Type `</comment>` IMMEDIATELY after the last word of your comment.**
@@ -166,6 +166,12 @@ You MUST follow this sequence EXACTLY for every suggestion:
 7. Write ONLY RAW CODE inside `<code_suggestion>` (No backticks!).
 8. **Type `</code_suggestion>` IMMEDIATELY after the code code.**
 9. Close the `<suggestion>` block with `</suggestion>`.
+
+**Multi-line Suggestions:** When your code suggestion replaces multiple lines, include `<start_line>` with the first line to replace. The `<line>` tag always indicates the last line. For single-line suggestions, omit `<start_line>`.
+
+**Example:**
+- Single-line fix at line 45: `<line>45</line>` (no start_line)
+- Multi-line fix replacing lines 100-115: `<start_line>100</start_line><line>115</line>`
 
 ### 2. TAG STACK MENTAL MODEL
 When you open a tag, imagine pushing it onto a stack:
@@ -203,12 +209,13 @@ If your stack shows `[comment]` and you are about to write code, you **MUST** po
   <suggestions>
     <suggestion>
       <file>relative/path/to/file.go</file>
+      <start_line>115</start_line>
       <line>123</line>
       <severity>Critical</severity>
       <category>Security</category>
       <confidence>100</confidence>
       <reproducibility>Always</reproducibility>
-      <source>diff:L123</source>
+      <source>diff:L115</source>
       <comment>
 **Observation:** [Detail]
 **Rationale:** [Impact]
@@ -216,8 +223,25 @@ If your stack shows `[comment]` and you are about to write code, you **MUST** po
       </comment>  <!-- CLOSE COMMENT HERE, BEFORE NEXT TAG -->
       <code_suggestion>
 // RAW CODE ONLY - NO markdown backticks
-(OPTIONAL code fix)
+// This code will replace lines 115-123
+(OPTIONAL multi-line code fix)
       </code_suggestion>  <!-- CLOSE CODE_SUGGESTION HERE -->
+    </suggestion>
+    <suggestion>
+      <file>another/file.go</file>
+      <line>45</line>
+      <severity>Medium</severity>
+      <category>Style</category>
+      <confidence>80</confidence>
+      <reproducibility>Always</reproducibility>
+      <source>diff:L45</source>
+      <comment>
+**Observation:** Single-line fix example (no start_line needed)
+**Fix:** [Recommendation]
+      </comment>
+      <code_suggestion>
+// Single-line replacement code
+      </code_suggestion>
     </suggestion>
   </suggestions>
 </review>

--- a/internal/llm/prompts/consensus_review.prompt
+++ b/internal/llm/prompts/consensus_review.prompt
@@ -41,7 +41,7 @@ Combine independent reviews of the same Pull Request into a single, high-quality
 ### 1. ABSOLUTE REQUIREMENT: TAG CLOSURE DISCIPLINE
 You MUST follow this sequence EXACTLY for every suggestion:
 1. Write the opening `<suggestion>` tag.
-2. Fill in metadata tags: `<file>`, `<line>`, etc.
+2. Fill in metadata tags: `<file>`, optionally `<start_line>` (for multi-line suggestions), `<line>`, etc.
 3. Open `<comment>`.
 4. Write your detailed observation.
 5. **Type `</comment>` IMMEDIATELY after the last word of your comment.**
@@ -49,6 +49,8 @@ You MUST follow this sequence EXACTLY for every suggestion:
 7. Write only raw code (no markdown).
 8. **Type `</code_suggestion>` IMMEDIATELY after the last character of code.**
 9. Close with `</suggestion>`.
+
+**Multi-line Suggestions:** Include `<start_line>` when replacing multiple lines. Omit for single-line suggestions.
 
 ### 2. TAG STACK MENTAL MODEL
 When you open a tag, imagine pushing it onto a stack:
@@ -76,6 +78,7 @@ If your stack shows `[comment]` and you're about to write code, you **MUST** pop
   <suggestions>
     <suggestion>
       <file>path/to/file.go</file>
+      <start_line>40</start_line>
       <line>42</line>
       ...
       <comment>
@@ -83,6 +86,7 @@ If your stack shows `[comment]` and you're about to write code, you **MUST** pop
       </comment>  <!-- CLOSE COMMENT HERE, BEFORE NEXT TAG -->
       <code_suggestion>
 // RAW CODE ONLY - NO BACKTICKS
+// This replaces lines 40-42
 if (x == nil) {
     return err
 }

--- a/internal/llm/prompts/rereview.prompt
+++ b/internal/llm/prompts/rereview.prompt
@@ -103,11 +103,14 @@ The following types are referenced in the diff. Use these definitions to verify 
 
 4. **SUMMARY**: The summary MUST include a "📊 Issue Status Table" section using a Markdown table.
 
+5. **MULTI-LINE SUGGESTIONS**: When replacing multiple lines, include `<start_line>` with the first line to replace. Omit for single-line suggestions.
+
 ### Example of Valid XML Structure:
 
 ```xml
 <suggestion>
   <file>path/to/file.go</file>
+  <start_line>38</start_line>
   <line>42</line>
   <severity>High</severity>
   <comment>
@@ -156,6 +159,7 @@ safeCopy := data.Clone()
   <suggestions>
     <suggestion>
       <file>path/to/filename.go</file>
+      <start_line>5</start_line>
       <line>10</line>
       <severity>Critical | High | Medium</severity>
       <comment>
@@ -170,6 +174,7 @@ safeCopy := data.Clone()
       <code_suggestion>
 // Provide code fix here ONLY if you have 95%+ confidence
 // Raw code, no markdown formatting
+// This replaces lines 5-10
       </code_suggestion>
     </suggestion>
   </suggestions>


### PR DESCRIPTION
## Summary

- Added `<start_line>` tag support in the XML output format for all prompts
- The LLM can now correctly suggest multi-line code replacements
- Previously, only `<line>` was requested, causing GitHub to replace only one line

## Problem

When the LLM suggests replacing a 10-line function, it would only provide `<line>123</line>`. GitHub's API would then attach the comment to a single line, and the ````suggestion` block would replace just that one line instead of the intended range.

## Solution

The prompt now instructs the LLM to provide `<start_line>` for multi-line suggestions:

```xml
<suggestion>
  <file>path/to/file.go</file>
  <start_line>115</start_line>  <!-- First line to replace -->
  <line>123</line>              <!-- Last line to replace -->
  ...
</suggestion>
```

This enables GitHub's API to correctly attach the comment to lines 115-123, and the ````suggestion` block will replace that entire range.

## Files Changed

| File | Change |
|------|--------|
| `internal/llm/prompts/code_review.prompt` | Added start_line to XML format and instructions |
| `internal/llm/prompts/rereview.prompt` | Added start_line to XML format and instructions |
| `internal/llm/prompts/consensus_review.prompt` | Added start_line to XML format and instructions |

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./internal/llm/...` passes
- [ ] Manual testing with a multi-line code suggestion

/review