### PR TITLE
feat: OpenCode agent integration for autonomous issue implementation

### DIFF
--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -1,0 +1,355 @@
+// Package agent provides orchestration for AI coding agents.
+// It manages agent sessions, spawns OpenCode processes, and handles the
+// communication between code-warden and the agent.
+package agent
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/sevigo/code-warden/internal/core"
+	"github.com/sevigo/code-warden/internal/github"
+	"github.com/sevigo/code-warden/internal/mcp"
+	"github.com/sevigo/code-warden/internal/rag"
+	"github.com/sevigo/code-warden/internal/storage"
+)
+
+// Orchestrator manages agent sessions and their lifecycle.
+type Orchestrator struct {
+	store        storage.Store
+	vectorStore  storage.ScopedVectorStore
+	ragService   rag.Service
+	ghClient     github.Client
+	mcpServer    *mcp.Server
+	logger       *slog.Logger
+	config       Config
+
+	sessions     map[string]*Session
+	sessionsMu   sync.RWMutex
+}
+
+// Config holds configuration for the agent orchestrator.
+type Config struct {
+	// Enabled determines if agent functionality is active.
+	Enabled bool `yaml:"enabled"`
+
+	// Provider is the agent provider (currently only "opencode").
+	Provider string `yaml:"provider"`
+
+	// Model is the Ollama model to use.
+	Model string `yaml:"model"`
+
+	// Timeout is the maximum time for an agent session.
+	Timeout time.Duration `yaml:"timeout"`
+
+	// MaxIterations is the maximum review iterations before escalation.
+	MaxIterations int `yaml:"max_iterations"`
+
+	// MCPAddr is the address for the MCP server.
+	MCPAddr string `yaml:"mcp_addr"`
+
+	// WorkingDir is the directory for agent workspaces.
+	WorkingDir string `yaml:"working_dir"`
+}
+
+// DefaultConfig returns default configuration.
+func DefaultConfig() Config {
+	return Config{
+		Enabled:       false,
+		Provider:      "opencode",
+		Model:         "llama3.1:70b",
+		Timeout:       30 * time.Minute,
+		MaxIterations: 3,
+		MCPAddr:       ":8081",
+		WorkingDir:    "/tmp/code-warden-agents",
+	}
+}
+
+// NewOrchestrator creates a new agent orchestrator.
+func NewOrchestrator(
+	store storage.Store,
+	vectorStore storage.ScopedVectorStore,
+	ragService rag.Service,
+	ghClient github.Client,
+	repo *storage.Repository,
+	repoConfig *core.RepoConfig,
+	projectRoot string,
+	config Config,
+	logger *slog.Logger,
+) *Orchestrator {
+	// Create MCP server
+	mcpServer := mcp.NewServer(
+		store,
+		vectorStore,
+		ragService,
+		ghClient,
+		repo,
+		repoConfig,
+		projectRoot,
+		logger,
+	)
+
+	return &Orchestrator{
+		store:       store,
+		vectorStore: vectorStore,
+		ragService:  ragService,
+		ghClient:    ghClient,
+		mcpServer:   mcpServer,
+		logger:      logger,
+		config:      config,
+		sessions:    make(map[string]*Session),
+	}
+}
+
+// Issue represents a GitHub issue to be implemented.
+type Issue struct {
+	Number       int
+	Title        string
+	Body         string
+	Instructions string // Additional instructions from /implement comment
+	RepoOwner    string
+	RepoName     string
+}
+
+// Session represents an active agent session.
+type Session struct {
+	ID          string
+	Issue       Issue
+	Status      SessionStatus
+	StartedAt   time.Time
+	CompletedAt time.Time
+	Result      *Result
+	Error       string
+	cancel      context.CancelFunc
+}
+
+// SessionStatus represents the status of an agent session.
+type SessionStatus string
+
+const (
+	StatusPending   SessionStatus = "pending"
+	StatusRunning   SessionStatus = "running"
+	StatusReviewing SessionStatus = "reviewing"
+	StatusCompleted SessionStatus = "completed"
+	StatusFailed    SessionStatus = "failed"
+	StatusCancelled SessionStatus = "cancelled"
+)
+
+// Result represents the result of an agent session.
+type Result struct {
+	PRNumber      int          `json:"pr_number"`
+	PRURL         string       `json:"pr_url"`
+	Branch        string       `json:"branch"`
+	FilesChanged  []string     `json:"files_changed"`
+	ReviewSummary string       `json:"review_summary"`
+	Verdict       string       `json:"verdict"`
+	Iterations    int          `json:"iterations"`
+}
+
+// SpawnAgent creates a new agent session to implement an issue.
+func (o *Orchestrator) SpawnAgent(ctx context.Context, issue Issue) (*Session, error) {
+	if !o.config.Enabled {
+		return nil, fmt.Errorf("agent functionality is disabled")
+	}
+
+	sessionID := generateSessionID()
+	session := &Session{
+		ID:        sessionID,
+		Issue:     issue,
+		Status:    StatusPending,
+		StartedAt: time.Now(),
+	}
+
+	o.sessionsMu.Lock()
+	o.sessions[sessionID] = session
+	o.sessionsMu.Unlock()
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(ctx, o.config.Timeout)
+	session.cancel = cancel
+
+	// Start agent in background
+	go o.runAgent(ctx, session)
+
+	o.logger.Info("agent session started",
+		"session_id", sessionID,
+		"issue", issue.Number,
+		"repo", issue.RepoOwner+"/"+issue.RepoName)
+
+	return session, nil
+}
+
+// GetSession retrieves a session by ID.
+func (o *Orchestrator) GetSession(id string) (*Session, bool) {
+	o.sessionsMu.RLock()
+	defer o.sessionsMu.RUnlock()
+	session, ok := o.sessions[id]
+	return session, ok
+}
+
+// CancelSession cancels a running session.
+func (o *Orchestrator) CancelSession(id string) error {
+	o.sessionsMu.RLock()
+	session, ok := o.sessions[id]
+	o.sessionsMu.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("session not found: %s", id)
+	}
+
+	if session.cancel != nil {
+		session.cancel()
+	}
+
+	session.Status = StatusCancelled
+	session.CompletedAt = time.Now()
+
+	o.logger.Info("agent session cancelled", "session_id", id)
+	return nil
+}
+
+// runAgent executes the agent workflow.
+func (o *Orchestrator) runAgent(ctx context.Context, session *Session) {
+	session.Status = StatusRunning
+
+	// Build the system prompt
+	systemPrompt := o.buildSystemPrompt(session.Issue)
+
+	// Create branch name
+	branch := fmt.Sprintf("agent/%s", session.ID)
+
+	// Build OpenCode command
+	cmd := o.buildOpenCodeCommand(ctx, session.Issue, systemPrompt, branch)
+
+	o.logger.Debug("starting agent process",
+		"session_id", session.ID,
+		"command", cmd.String())
+
+	// Run the agent
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		session.Status = StatusFailed
+		session.Error = fmt.Sprintf("Agent failed: %v\nOutput: %s", err, string(output))
+		session.CompletedAt = time.Now()
+		o.logger.Error("agent failed",
+			"session_id", session.ID,
+			"error", err,
+			"output", string(output))
+		return
+	}
+
+	// Parse result
+	result, err := o.parseAgentOutput(string(output))
+	if err != nil {
+		session.Status = StatusFailed
+		session.Error = fmt.Sprintf("Failed to parse agent output: %v", err)
+		session.CompletedAt = time.Now()
+		return
+	}
+
+	session.Result = result
+	session.Status = StatusCompleted
+	session.CompletedAt = time.Now()
+
+	o.logger.Info("agent session completed",
+		"session_id", session.ID,
+		"pr_number", result.PRNumber,
+		"iterations", result.Iterations)
+}
+
+// buildSystemPrompt creates the system prompt for the agent.
+func (o *Orchestrator) buildSystemPrompt(issue Issue) string {
+	return fmt.Sprintf(`You are an autonomous coding agent working on the code-warden project.
+
+## Your Tools
+- MCP server available at %s with these tools:
+  - search_code(query, limit, chunk_type) - Find relevant code in the codebase
+  - get_arch_context(directory) - Get architectural summary for a directory
+  - get_symbol(name) - Get type/function definition
+  - get_structure() - Get project structure
+  - review_code(diff) - Request internal code review
+
+## Your Task
+Implement the issue described below. Follow these steps:
+
+1. **Understand** - Read the issue carefully
+2. **Explore** - Use MCP tools to understand the codebase
+3. **Plan** - Identify files to modify and changes needed
+4. **Implement** - Write the code
+5. **Review** - Call review_code on your changes
+6. **Iterate** - If REQUEST_CHANGES, fix issues and review again
+7. **Submit** - Create a pull request when APPROVED
+
+## Issue #%d: %s
+
+%s
+
+## Additional Instructions
+%s
+
+## MCP Server
+Connect to the MCP server at %s to access project context.
+
+## Working Directory
+Work in the current directory. Create a branch named 'agent/%s' for your changes.
+`,
+		o.config.MCPAddr,
+		issue.Number,
+		issue.Title,
+		issue.Body,
+		issue.Instructions,
+		o.config.MCPAddr,
+		sessionIDFromIssue(issue),
+	)
+}
+
+// buildOpenCodeCommand creates the command to run OpenCode.
+func (o *Orchestrator) buildOpenCodeCommand(ctx context.Context, issue Issue, systemPrompt, branch string) *exec.Cmd {
+	// OpenCode command structure (headless mode with Ollama)
+	// This is a placeholder - adjust based on actual OpenCode CLI
+	cmd := exec.CommandContext(ctx, "opencode",
+		"--headless",
+		"--model", o.config.Model,
+		"--mcp", o.config.MCPAddr,
+		"--branch", branch,
+		"--prompt", systemPrompt,
+	)
+
+	// Set working directory
+	cmd.Dir = o.config.WorkingDir
+
+	// Set environment variables
+	cmd.Env = append(os.Environ(),
+		"OPENCODE_MCP_SERVER="+o.config.MCPAddr,
+		"OPENCODE_MAX_ITERATIONS="+fmt.Sprintf("%d", o.config.MaxIterations),
+	)
+
+	return cmd
+}
+
+// parseAgentOutput extracts the result from agent output.
+func (o *Orchestrator) parseAgentOutput(output string) (*Result, error) {
+	// TODO: Parse structured output from OpenCode
+	// This will depend on the actual OpenCode output format
+	return &Result{
+		PRNumber:     0,
+		Branch:       "",
+		FilesChanged: []string{},
+		Verdict:      "UNKNOWN",
+		Iterations:   1,
+	}, nil
+}
+
+// generateSessionID creates a unique session ID.
+func generateSessionID() string {
+	return fmt.Sprintf("agent-%d", time.Now().UnixNano())
+}
+
+func sessionIDFromIssue(issue Issue) string {
+	return fmt.Sprintf("issue-%d-%d", issue.Number, time.Now().Unix())
+}

--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -28,6 +28,7 @@ type Orchestrator struct {
 	ragService  rag.Service
 	ghClient    github.Client
 	mcpServer   *mcp.Server
+	httpServer  *http.Server
 	logger      *slog.Logger
 	config      Config
 
@@ -115,19 +116,95 @@ func (o *Orchestrator) Start() error {
 		return nil
 	}
 
+	o.httpServer = &http.Server{
+		Addr:              o.config.MCPAddr,
+		Handler:           o.mcpServer,
+		ReadHeaderTimeout: 10 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+
 	go func() {
 		o.logger.Info("starting MCP HTTP server",
 			"addr", o.config.MCPAddr,
 			"provider", o.config.Provider,
 			"model", o.config.Model)
 
-		//nolint:gosec // G114: Internal MCP server with localhost-only binding
-		if err := http.ListenAndServe(o.config.MCPAddr, o.mcpServer); err != nil {
+		if err := o.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			o.logger.Error("MCP HTTP server failed", "error", err, "addr", o.config.MCPAddr)
 		}
 	}()
 
+	// Start session cleanup goroutine
+	go o.cleanupLoop()
+
 	return nil
+}
+
+// Shutdown gracefully stops the MCP server and cleans up resources.
+func (o *Orchestrator) Shutdown(ctx context.Context) error {
+	o.logger.Info("shutting down agent orchestrator")
+
+	// Cancel all running sessions
+	o.sessionsMu.Lock()
+	for _, session := range o.sessions {
+		if session.cancel != nil {
+			session.cancel()
+		}
+	}
+	o.sessionsMu.Unlock()
+
+	// Shutdown HTTP server
+	if o.httpServer != nil {
+		if err := o.httpServer.Shutdown(ctx); err != nil {
+			o.logger.Error("MCP server shutdown error", "error", err)
+			return err
+		}
+	}
+
+	o.logger.Info("agent orchestrator shutdown complete")
+	return nil
+}
+
+// cleanupLoop periodically removes old completed/failed sessions.
+func (o *Orchestrator) cleanupLoop() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		o.cleanupOldSessions()
+	}
+}
+
+// cleanupOldSessions removes sessions that have been completed for more than 1 hour.
+func (o *Orchestrator) cleanupOldSessions() {
+	o.sessionsMu.Lock()
+	defer o.sessionsMu.Unlock()
+
+	cutoff := time.Now().Add(-1 * time.Hour)
+	removed := 0
+
+	for id, session := range o.sessions {
+		status := session.GetStatus()
+		if status == StatusCompleted || status == StatusFailed || status == StatusCancelled {
+			snapshot := session.Snapshot()
+			if snapshot.CompletedAt.Before(cutoff) {
+				delete(o.sessions, id)
+				removed++
+			}
+		}
+	}
+
+	if removed > 0 {
+		o.logger.Info("cleaned up old sessions", "count", removed, "remaining", len(o.sessions))
+	}
+}
+
+// DeleteSession removes a session from the map.
+func (o *Orchestrator) DeleteSession(id string) {
+	o.sessionsMu.Lock()
+	defer o.sessionsMu.Unlock()
+	delete(o.sessions, id)
 }
 
 // MCPServer returns the MCP server instance for external routing if needed.

--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/exec"
+	"regexp"
 	"sync"
 	"time"
 
@@ -65,7 +67,7 @@ func DefaultConfig() Config {
 		Model:         "llama3.1:70b",
 		Timeout:       30 * time.Minute,
 		MaxIterations: 3,
-		MCPAddr:       ":8081",
+		MCPAddr:       "127.0.0.1:8081", // Bind to localhost only for security
 		WorkingDir:    "/tmp/code-warden-agents",
 	}
 }
@@ -106,6 +108,33 @@ func NewOrchestrator(
 	}
 }
 
+// Start begins the MCP HTTP server. Must be called before agents can use tools.
+func (o *Orchestrator) Start() error {
+	if !o.config.Enabled {
+		o.logger.Info("agent orchestrator is disabled, not starting MCP server")
+		return nil
+	}
+
+	go func() {
+		o.logger.Info("starting MCP HTTP server",
+			"addr", o.config.MCPAddr,
+			"provider", o.config.Provider,
+			"model", o.config.Model)
+
+		//nolint:gosec // G114: Internal MCP server with localhost-only binding
+		if err := http.ListenAndServe(o.config.MCPAddr, o.mcpServer); err != nil {
+			o.logger.Error("MCP HTTP server failed", "error", err, "addr", o.config.MCPAddr)
+		}
+	}()
+
+	return nil
+}
+
+// MCPServer returns the MCP server instance for external routing if needed.
+func (o *Orchestrator) MCPServer() *mcp.Server {
+	return o.mcpServer
+}
+
 // Issue represents a GitHub issue to be implemented.
 type Issue struct {
 	Number       int
@@ -118,14 +147,81 @@ type Issue struct {
 
 // Session represents an active agent session.
 type Session struct {
+	mu          sync.Mutex
 	ID          string
 	Issue       Issue
-	Status      SessionStatus
+	status      SessionStatus
 	StartedAt   time.Time
 	CompletedAt time.Time
 	Result      *Result
-	Error       string
+	err         string
 	cancel      context.CancelFunc
+}
+
+// GetStatus returns the current session status (thread-safe).
+func (s *Session) GetStatus() SessionStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.status
+}
+
+// SetStatus updates the session status (thread-safe).
+func (s *Session) SetStatus(status SessionStatus) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.status = status
+}
+
+// GetError returns the session error message (thread-safe).
+func (s *Session) GetError() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.err
+}
+
+// SetError sets the session error message (thread-safe).
+func (s *Session) SetError(err string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.err = err
+}
+
+// GetResult returns the session result (thread-safe).
+func (s *Session) GetResult() *Result {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.Result
+}
+
+// SetResult sets the session result (thread-safe).
+func (s *Session) SetResult(result *Result) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Result = result
+}
+
+// Snapshot returns a thread-safe copy of session state for external reading.
+func (s *Session) Snapshot() SessionSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return SessionSnapshot{
+		ID:          s.ID,
+		Status:      s.status,
+		StartedAt:   s.StartedAt,
+		CompletedAt: s.CompletedAt,
+		Error:       s.err,
+		Result:      s.Result,
+	}
+}
+
+// SessionSnapshot is an immutable snapshot of session state.
+type SessionSnapshot struct {
+	ID          string
+	Status      SessionStatus
+	StartedAt   time.Time
+	CompletedAt time.Time
+	Error       string
+	Result      *Result
 }
 
 // SessionStatus represents the status of an agent session.
@@ -161,7 +257,7 @@ func (o *Orchestrator) SpawnAgent(ctx context.Context, issue Issue) (*Session, e
 	session := &Session{
 		ID:        sessionID,
 		Issue:     issue,
-		Status:    StatusPending,
+		status:    StatusPending,
 		StartedAt: time.Now(),
 	}
 
@@ -206,8 +302,10 @@ func (o *Orchestrator) CancelSession(id string) error {
 		session.cancel()
 	}
 
-	session.Status = StatusCancelled
+	session.SetStatus(StatusCancelled)
+	session.mu.Lock()
 	session.CompletedAt = time.Now()
+	session.mu.Unlock()
 
 	o.logger.Info("agent session cancelled", "session_id", id)
 	return nil
@@ -215,12 +313,19 @@ func (o *Orchestrator) CancelSession(id string) error {
 
 // runAgent executes the agent workflow.
 func (o *Orchestrator) runAgent(ctx context.Context, session *Session) {
+	// Ensure context is cancelled when done (prevents resource leak)
+	defer func() {
+		if session.cancel != nil {
+			session.cancel()
+		}
+	}()
+
 	o.logger.Info("runAgent: starting agent workflow",
 		"session_id", session.ID,
 		"issue_number", session.Issue.Number,
 		"issue_title", session.Issue.Title)
 
-	session.Status = StatusRunning
+	session.SetStatus(StatusRunning)
 
 	// Build the system prompt
 	o.logger.Debug("runAgent: building system prompt", "session_id", session.ID)
@@ -229,8 +334,8 @@ func (o *Orchestrator) runAgent(ctx context.Context, session *Session) {
 		"session_id", session.ID,
 		"prompt_length", len(systemPrompt))
 
-	// Create branch name
-	branch := fmt.Sprintf("agent/%s", session.ID)
+	// Create branch name (sanitize for git safety)
+	branch := sanitizeBranch(fmt.Sprintf("agent/%s", session.ID))
 	o.logger.Info("runAgent: created branch name",
 		"session_id", session.ID,
 		"branch", branch)
@@ -247,9 +352,11 @@ func (o *Orchestrator) runAgent(ctx context.Context, session *Session) {
 	// Run the agent
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		session.Status = StatusFailed
-		session.Error = fmt.Sprintf("Agent failed: %v\nOutput: %s", err, string(output))
+		session.SetStatus(StatusFailed)
+		session.SetError(fmt.Sprintf("Agent failed: %v\nOutput: %s", err, string(output)))
+		session.mu.Lock()
 		session.CompletedAt = time.Now()
+		session.mu.Unlock()
 		o.logger.Error("runAgent: agent process failed",
 			"session_id", session.ID,
 			"error", err,
@@ -265,9 +372,11 @@ func (o *Orchestrator) runAgent(ctx context.Context, session *Session) {
 	// Parse result
 	result := o.parseAgentOutput(string(output))
 
-	session.Result = result
-	session.Status = StatusCompleted
+	session.SetResult(result)
+	session.SetStatus(StatusCompleted)
+	session.mu.Lock()
 	session.CompletedAt = time.Now()
+	session.mu.Unlock()
 
 	o.logger.Info("runAgent: agent session completed successfully",
 		"session_id", session.ID,
@@ -381,4 +490,27 @@ func truncateString(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen] + "..."
+}
+
+// sanitizeBranch sanitizes a string to be a valid git branch name.
+// Git branch names cannot contain spaces, ~, ^, :, *, ?, [, \\, or start with -.
+func sanitizeBranch(name string) string {
+	// Replace invalid characters with hyphens
+	re := regexp.MustCompile(`[\s~^:?*\[\\]`)
+	sanitized := re.ReplaceAllString(name, "-")
+
+	// Remove leading/trailing hyphens and dots
+	for len(sanitized) > 0 && (sanitized[0] == '-' || sanitized[0] == '.') {
+		sanitized = sanitized[1:]
+	}
+	for len(sanitized) > 0 && (sanitized[len(sanitized)-1] == '-' || sanitized[len(sanitized)-1] == '.') {
+		sanitized = sanitized[:len(sanitized)-1]
+	}
+
+	// Limit length to 200 characters
+	if len(sanitized) > 200 {
+		sanitized = sanitized[:200]
+	}
+
+	return sanitized
 }

--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -21,16 +21,16 @@ import (
 
 // Orchestrator manages agent sessions and their lifecycle.
 type Orchestrator struct {
-	store        storage.Store
-	vectorStore  storage.ScopedVectorStore
-	ragService   rag.Service
-	ghClient     github.Client
-	mcpServer    *mcp.Server
-	logger       *slog.Logger
-	config       Config
+	store       storage.Store
+	vectorStore storage.ScopedVectorStore
+	ragService  rag.Service
+	ghClient    github.Client
+	mcpServer   *mcp.Server
+	logger      *slog.Logger
+	config      Config
 
-	sessions     map[string]*Session
-	sessionsMu   sync.RWMutex
+	sessions   map[string]*Session
+	sessionsMu sync.RWMutex
 }
 
 // Config holds configuration for the agent orchestrator.
@@ -142,13 +142,13 @@ const (
 
 // Result represents the result of an agent session.
 type Result struct {
-	PRNumber      int          `json:"pr_number"`
-	PRURL         string       `json:"pr_url"`
-	Branch        string       `json:"branch"`
-	FilesChanged  []string     `json:"files_changed"`
-	ReviewSummary string       `json:"review_summary"`
-	Verdict       string       `json:"verdict"`
-	Iterations    int          `json:"iterations"`
+	PRNumber      int      `json:"pr_number"`
+	PRURL         string   `json:"pr_url"`
+	Branch        string   `json:"branch"`
+	FilesChanged  []string `json:"files_changed"`
+	ReviewSummary string   `json:"review_summary"`
+	Verdict       string   `json:"verdict"`
+	Iterations    int      `json:"iterations"`
 }
 
 // SpawnAgent creates a new agent session to implement an issue.
@@ -215,20 +215,34 @@ func (o *Orchestrator) CancelSession(id string) error {
 
 // runAgent executes the agent workflow.
 func (o *Orchestrator) runAgent(ctx context.Context, session *Session) {
+	o.logger.Info("runAgent: starting agent workflow",
+		"session_id", session.ID,
+		"issue_number", session.Issue.Number,
+		"issue_title", session.Issue.Title)
+
 	session.Status = StatusRunning
 
 	// Build the system prompt
+	o.logger.Debug("runAgent: building system prompt", "session_id", session.ID)
 	systemPrompt := o.buildSystemPrompt(session.Issue)
+	o.logger.Debug("runAgent: system prompt built",
+		"session_id", session.ID,
+		"prompt_length", len(systemPrompt))
 
 	// Create branch name
 	branch := fmt.Sprintf("agent/%s", session.ID)
+	o.logger.Info("runAgent: created branch name",
+		"session_id", session.ID,
+		"branch", branch)
 
 	// Build OpenCode command
 	cmd := o.buildOpenCodeCommand(ctx, session.Issue, systemPrompt, branch)
 
-	o.logger.Debug("starting agent process",
+	o.logger.Info("runAgent: starting OpenCode process",
 		"session_id", session.ID,
-		"command", cmd.String())
+		"command", cmd.String(),
+		"working_dir", cmd.Dir,
+		"timeout", o.config.Timeout)
 
 	// Run the agent
 	output, err := cmd.CombinedOutput()
@@ -236,30 +250,34 @@ func (o *Orchestrator) runAgent(ctx context.Context, session *Session) {
 		session.Status = StatusFailed
 		session.Error = fmt.Sprintf("Agent failed: %v\nOutput: %s", err, string(output))
 		session.CompletedAt = time.Now()
-		o.logger.Error("agent failed",
+		o.logger.Error("runAgent: agent process failed",
 			"session_id", session.ID,
 			"error", err,
-			"output", string(output))
+			"output_length", len(output),
+			"output_preview", truncateString(string(output), 500))
 		return
 	}
 
+	o.logger.Info("runAgent: agent process completed successfully",
+		"session_id", session.ID,
+		"output_length", len(output))
+
 	// Parse result
-	result, err := o.parseAgentOutput(string(output))
-	if err != nil {
-		session.Status = StatusFailed
-		session.Error = fmt.Sprintf("Failed to parse agent output: %v", err)
-		session.CompletedAt = time.Now()
-		return
-	}
+	result := o.parseAgentOutput(string(output))
 
 	session.Result = result
 	session.Status = StatusCompleted
 	session.CompletedAt = time.Now()
 
-	o.logger.Info("agent session completed",
+	o.logger.Info("runAgent: agent session completed successfully",
 		"session_id", session.ID,
 		"pr_number", result.PRNumber,
-		"iterations", result.Iterations)
+		"pr_url", result.PRURL,
+		"branch", result.Branch,
+		"files_changed", len(result.FilesChanged),
+		"iterations", result.Iterations,
+		"verdict", result.Verdict,
+		"duration", session.CompletedAt.Sub(session.StartedAt))
 }
 
 // buildSystemPrompt creates the system prompt for the agent.
@@ -309,9 +327,10 @@ Work in the current directory. Create a branch named 'agent/%s' for your changes
 }
 
 // buildOpenCodeCommand creates the command to run OpenCode.
-func (o *Orchestrator) buildOpenCodeCommand(ctx context.Context, issue Issue, systemPrompt, branch string) *exec.Cmd {
+func (o *Orchestrator) buildOpenCodeCommand(ctx context.Context, _ Issue, systemPrompt, branch string) *exec.Cmd {
 	// OpenCode command structure (headless mode with Ollama)
 	// This is a placeholder - adjust based on actual OpenCode CLI
+	//nolint:gosec // G204: Subprocess launched with variable arguments - intentional for agent execution
 	cmd := exec.CommandContext(ctx, "opencode",
 		"--headless",
 		"--model", o.config.Model,
@@ -333,16 +352,18 @@ func (o *Orchestrator) buildOpenCodeCommand(ctx context.Context, issue Issue, sy
 }
 
 // parseAgentOutput extracts the result from agent output.
-func (o *Orchestrator) parseAgentOutput(output string) (*Result, error) {
+// TODO: Implement actual parsing when OpenCode output format is defined.
+func (o *Orchestrator) parseAgentOutput(_ string) *Result {
 	// TODO: Parse structured output from OpenCode
 	// This will depend on the actual OpenCode output format
+	o.logger.Debug("parseAgentOutput: parsing agent output (placeholder)")
 	return &Result{
 		PRNumber:     0,
 		Branch:       "",
 		FilesChanged: []string{},
 		Verdict:      "UNKNOWN",
 		Iterations:   1,
-	}, nil
+	}
 }
 
 // generateSessionID creates a unique session ID.
@@ -352,4 +373,12 @@ func generateSessionID() string {
 
 func sessionIDFromIssue(issue Issue) string {
 	return fmt.Sprintf("issue-%d-%d", issue.Number, time.Now().Unix())
+}
+
+// truncateString truncates a string to maxLen characters.
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -17,15 +17,15 @@ import (
 
 // Server implements an MCP server for code-warden.
 type Server struct {
-	store        storage.Store
-	vectorStore  storage.ScopedVectorStore
-	ragService   rag.Service
-	ghClient     github.Client
-	repo         *storage.Repository
-	repoConfig   *core.RepoConfig
-	projectRoot  string
-	logger       *slog.Logger
-	tools        map[string]Tool
+	store       storage.Store
+	vectorStore storage.ScopedVectorStore
+	ragService  rag.Service
+	ghClient    github.Client
+	repo        *storage.Repository
+	repoConfig  *core.RepoConfig
+	projectRoot string
+	logger      *slog.Logger
+	tools       map[string]Tool
 }
 
 // Tool represents an MCP tool that can be called by an agent.
@@ -133,24 +133,24 @@ type ToolInfo struct {
 	InputSchema map[string]any `json:"inputSchema"`
 }
 
-// MCPRequest represents a JSON-RPC 2.0 request.
-type MCPRequest struct {
+// Request represents a JSON-RPC 2.0 request.
+type Request struct {
 	JSONRPC string          `json:"jsonrpc"`
 	ID      any             `json:"id,omitempty"`
 	Method  string          `json:"method"`
 	Params  json.RawMessage `json:"params,omitempty"`
 }
 
-// MCPResponse represents a JSON-RPC 2.0 response.
-type MCPResponse struct {
+// Response represents a JSON-RPC 2.0 response.
+type Response struct {
 	JSONRPC string `json:"jsonrpc"`
 	ID      any    `json:"id,omitempty"`
 	Result  any    `json:"result,omitempty"`
-	Error   *MCPError `json:"error,omitempty"`
+	Error   *Error `json:"error,omitempty"`
 }
 
-// MCPError represents a JSON-RPC 2.0 error.
-type MCPError struct {
+// Error represents a JSON-RPC 2.0 error.
+type Error struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
 }
@@ -162,7 +162,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var req MCPRequest
+	var req Request
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		s.writeError(w, nil, -32700, "parse error")
 		return
@@ -215,27 +215,31 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) writeResult(w http.ResponseWriter, id any, result any) {
-	resp := MCPResponse{
+	resp := Response{
 		JSONRPC: "2.0",
 		ID:      id,
 		Result:  result,
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		s.logger.Error("failed to encode response", "error", err)
+	}
 }
 
 func (s *Server) writeError(w http.ResponseWriter, id any, code int, message string) {
-	resp := MCPResponse{
+	resp := Response{
 		JSONRPC: "2.0",
 		ID:      id,
-		Error: &MCPError{
+		Error: &Error{
 			Code:    code,
 			Message: message,
 		},
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusBadRequest)
-	json.NewEncoder(w).Encode(resp)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		s.logger.Error("failed to encode error response", "error", err)
+	}
 }
 
 func mustMarshal(v any) string {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,244 @@
+// Package mcp provides a Model Context Protocol (MCP) server for code-warden.
+// It exposes tools for AI agents to interact with the codebase context stored in Qdrant.
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/sevigo/code-warden/internal/core"
+	"github.com/sevigo/code-warden/internal/github"
+	"github.com/sevigo/code-warden/internal/rag"
+	"github.com/sevigo/code-warden/internal/storage"
+)
+
+// Server implements an MCP server for code-warden.
+type Server struct {
+	store        storage.Store
+	vectorStore  storage.ScopedVectorStore
+	ragService   rag.Service
+	ghClient     github.Client
+	repo         *storage.Repository
+	repoConfig   *core.RepoConfig
+	projectRoot  string
+	logger       *slog.Logger
+	tools        map[string]Tool
+}
+
+// Tool represents an MCP tool that can be called by an agent.
+type Tool interface {
+	// Name returns the tool name.
+	Name() string
+	// Description returns a human-readable description.
+	Description() string
+	// InputSchema returns the JSON schema for the tool's input parameters.
+	InputSchema() map[string]any
+	// Execute runs the tool with the given arguments.
+	Execute(ctx context.Context, args map[string]any) (any, error)
+}
+
+// Config holds configuration for the MCP server.
+type Config struct {
+	// Port is the HTTP port for the MCP server.
+	Port int
+	// ProjectRoot is the path to the repository root.
+	ProjectRoot string
+}
+
+// NewServer creates a new MCP server.
+func NewServer(
+	store storage.Store,
+	vectorStore storage.ScopedVectorStore,
+	ragService rag.Service,
+	ghClient github.Client,
+	repo *storage.Repository,
+	repoConfig *core.RepoConfig,
+	projectRoot string,
+	logger *slog.Logger,
+) *Server {
+	s := &Server{
+		store:       store,
+		vectorStore: vectorStore,
+		ragService:  ragService,
+		ghClient:    ghClient,
+		repo:        repo,
+		repoConfig:  repoConfig,
+		projectRoot: projectRoot,
+		logger:      logger,
+		tools:       make(map[string]Tool),
+	}
+
+	// Register default tools
+	s.registerTools()
+
+	return s
+}
+
+// registerTools registers all available MCP tools.
+func (s *Server) registerTools() {
+	s.tools["search_code"] = &SearchCodeTool{
+		vectorStore: s.vectorStore,
+		logger:      s.logger,
+	}
+	s.tools["get_arch_context"] = &GetArchContextTool{
+		vectorStore: s.vectorStore,
+		logger:      s.logger,
+	}
+	s.tools["get_symbol"] = &GetSymbolTool{
+		vectorStore: s.vectorStore,
+		logger:      s.logger,
+	}
+	s.tools["get_structure"] = &GetStructureTool{
+		vectorStore: s.vectorStore,
+		projectRoot: s.projectRoot,
+		logger:      s.logger,
+	}
+	s.tools["review_code"] = &ReviewCodeTool{
+		ragService: s.ragService,
+		repo:       s.repo,
+		repoConfig: s.repoConfig,
+		logger:     s.logger,
+	}
+}
+
+// ListTools returns all available tools.
+func (s *Server) ListTools() []ToolInfo {
+	tools := make([]ToolInfo, 0, len(s.tools))
+	for name, tool := range s.tools {
+		tools = append(tools, ToolInfo{
+			Name:        name,
+			Description: tool.Description(),
+			InputSchema: tool.InputSchema(),
+		})
+	}
+	return tools
+}
+
+// CallTool executes a tool by name.
+func (s *Server) CallTool(ctx context.Context, name string, args map[string]any) (any, error) {
+	tool, ok := s.tools[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown tool: %s", name)
+	}
+	return tool.Execute(ctx, args)
+}
+
+// ToolInfo represents tool metadata for the MCP protocol.
+type ToolInfo struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	InputSchema map[string]any `json:"inputSchema"`
+}
+
+// MCPRequest represents a JSON-RPC 2.0 request.
+type MCPRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      any             `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// MCPResponse represents a JSON-RPC 2.0 response.
+type MCPResponse struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      any    `json:"id,omitempty"`
+	Result  any    `json:"result,omitempty"`
+	Error   *MCPError `json:"error,omitempty"`
+}
+
+// MCPError represents a JSON-RPC 2.0 error.
+type MCPError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// ServeHTTP implements http.Handler for the MCP server.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req MCPRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeError(w, nil, -32700, "parse error")
+		return
+	}
+
+	var result any
+	var err error
+
+	switch req.Method {
+	case "tools/list":
+		result = map[string]any{
+			"tools": s.ListTools(),
+		}
+	case "tools/call":
+		var params struct {
+			Name      string         `json:"name"`
+			Arguments map[string]any `json:"arguments"`
+		}
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			s.writeError(w, req.ID, -32602, "invalid params")
+			return
+		}
+		result, err = s.CallTool(r.Context(), params.Name, params.Arguments)
+		if err != nil {
+			s.writeError(w, req.ID, -32603, err.Error())
+			return
+		}
+		result = map[string]any{
+			"content": []map[string]any{
+				{"type": "text", "text": mustMarshal(result)},
+			},
+		}
+	case "initialize":
+		result = map[string]any{
+			"protocolVersion": "2024-11-05",
+			"serverInfo": map[string]any{
+				"name":    "code-warden-mcp",
+				"version": "1.0.0",
+			},
+			"capabilities": map[string]any{
+				"tools": map[string]any{},
+			},
+		}
+	default:
+		s.writeError(w, req.ID, -32601, "method not found")
+		return
+	}
+
+	s.writeResult(w, req.ID, result)
+}
+
+func (s *Server) writeResult(w http.ResponseWriter, id any, result any) {
+	resp := MCPResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  result,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+func (s *Server) writeError(w http.ResponseWriter, id any, code int, message string) {
+	resp := MCPResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: &MCPError{
+			Code:    code,
+			Message: message,
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	json.NewEncoder(w).Encode(resp)
+}
+
+func mustMarshal(v any) string {
+	b, _ := json.MarshalIndent(v, "", "  ")
+	return string(b)
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -236,7 +236,8 @@ func (s *Server) writeError(w http.ResponseWriter, id any, code int, message str
 		},
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusBadRequest)
+	// JSON-RPC over HTTP should return 200 OK even for errors
+	// The error is indicated in the JSON body, not the HTTP status
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		s.logger.Error("failed to encode error response", "error", err)
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/sevigo/goframe/vectorstores"
+
 	"github.com/sevigo/code-warden/internal/core"
 	"github.com/sevigo/code-warden/internal/rag"
 	"github.com/sevigo/code-warden/internal/storage"
-	"github.com/sevigo/goframe/vectorstores"
 )
 
 // SearchCodeTool searches for code using semantic similarity.
@@ -52,6 +53,7 @@ func (t *SearchCodeTool) InputSchema() map[string]any {
 func (t *SearchCodeTool) Execute(ctx context.Context, args map[string]any) (any, error) {
 	query, ok := args["query"].(string)
 	if !ok || query == "" {
+		t.logger.Warn("search_code: missing query parameter")
 		return nil, fmt.Errorf("query is required")
 	}
 
@@ -61,15 +63,24 @@ func (t *SearchCodeTool) Execute(ctx context.Context, args map[string]any) (any,
 	}
 
 	opts := []vectorstores.Option{}
-	if chunkType, ok := args["chunk_type"].(string); ok && chunkType != "" {
+	chunkType := ""
+	if ct, ok := args["chunk_type"].(string); ok && ct != "" {
+		chunkType = ct
 		opts = append(opts, vectorstores.WithFilters(map[string]any{
-			"chunk_type": chunkType,
+			"chunk_type": ct,
 		}))
 	}
 
+	t.logger.Info("search_code: executing search",
+		"query", query,
+		"limit", limit,
+		"chunk_type", chunkType)
+
 	docsWithScores, err := t.vectorStore.SimilaritySearchWithScores(ctx, query, limit, opts...)
 	if err != nil {
-		t.logger.Error("search failed", "query", query, "error", err)
+		t.logger.Error("search_code: search failed",
+			"query", query,
+			"error", err)
 		return nil, fmt.Errorf("search failed: %w", err)
 	}
 
@@ -82,6 +93,16 @@ func (t *SearchCodeTool) Execute(ctx context.Context, args map[string]any) (any,
 		}
 		results = append(results, result)
 	}
+
+	t.logger.Info("search_code: search completed",
+		"query", query,
+		"results_count", len(results),
+		"top_score", func() float64 {
+			if len(results) > 0 {
+				return results[0].Score
+			}
+			return 0
+		}())
 
 	return SearchCodeResponse{
 		Query:   query,
@@ -295,7 +316,7 @@ func (t *GetStructureTool) InputSchema() map[string]any {
 	}
 }
 
-func (t *GetStructureTool) Execute(ctx context.Context, args map[string]any) (any, error) {
+func (t *GetStructureTool) Execute(ctx context.Context, _ map[string]any) (any, error) {
 	// Get root-level architectural summary
 	query := "project structure architecture overview main directories"
 	docs, err := t.vectorStore.SimilaritySearch(ctx, query, 10,
@@ -405,9 +426,9 @@ func (t *ReviewCodeTool) Execute(ctx context.Context, args map[string]any) (any,
 		PRTitle: title,
 		PRBody:  description,
 		// These fields are needed but can be mock values for internal review
-		RepoFullName:  t.repo.FullName,
-		HeadSHA:       "internal-review",
-		PRNumber:      0,
+		RepoFullName:   t.repo.FullName,
+		HeadSHA:        "internal-review",
+		PRNumber:       0,
 		InstallationID: 0,
 	}
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1,0 +1,435 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/sevigo/code-warden/internal/core"
+	"github.com/sevigo/code-warden/internal/rag"
+	"github.com/sevigo/code-warden/internal/storage"
+	"github.com/sevigo/goframe/vectorstores"
+)
+
+// SearchCodeTool searches for code using semantic similarity.
+type SearchCodeTool struct {
+	vectorStore storage.ScopedVectorStore
+	logger      *slog.Logger
+}
+
+func (t *SearchCodeTool) Name() string {
+	return "search_code"
+}
+
+func (t *SearchCodeTool) Description() string {
+	return `Search for code in the repository using semantic similarity.
+Returns relevant code snippets that match the query.
+Use this to find implementations, understand patterns, or locate related code.`
+}
+
+func (t *SearchCodeTool) InputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"query": map[string]any{
+				"type":        "string",
+				"description": "The search query describing what code you're looking for",
+			},
+			"limit": map[string]any{
+				"type":        "integer",
+				"description": "Maximum number of results to return (default: 10)",
+				"default":     10,
+			},
+			"chunk_type": map[string]any{
+				"type":        "string",
+				"description": "Filter by chunk type: 'code', 'arch', 'definition'",
+			},
+		},
+		"required": []string{"query"},
+	}
+}
+
+func (t *SearchCodeTool) Execute(ctx context.Context, args map[string]any) (any, error) {
+	query, ok := args["query"].(string)
+	if !ok || query == "" {
+		return nil, fmt.Errorf("query is required")
+	}
+
+	limit := 10
+	if l, ok := args["limit"].(float64); ok {
+		limit = int(l)
+	}
+
+	opts := []vectorstores.Option{}
+	if chunkType, ok := args["chunk_type"].(string); ok && chunkType != "" {
+		opts = append(opts, vectorstores.WithFilters(map[string]any{
+			"chunk_type": chunkType,
+		}))
+	}
+
+	docsWithScores, err := t.vectorStore.SimilaritySearchWithScores(ctx, query, limit, opts...)
+	if err != nil {
+		t.logger.Error("search failed", "query", query, "error", err)
+		return nil, fmt.Errorf("search failed: %w", err)
+	}
+
+	results := make([]CodeResult, 0, len(docsWithScores))
+	for _, ds := range docsWithScores {
+		result := CodeResult{
+			Content:  ds.Document.PageContent,
+			Score:    float64(ds.Score),
+			Metadata: ds.Document.Metadata,
+		}
+		results = append(results, result)
+	}
+
+	return SearchCodeResponse{
+		Query:   query,
+		Count:   len(results),
+		Results: results,
+	}, nil
+}
+
+// CodeResult represents a single search result.
+type CodeResult struct {
+	Content  string         `json:"content"`
+	Score    float64        `json:"score"`
+	Metadata map[string]any `json:"metadata"`
+}
+
+// SearchCodeResponse is the response for search_code tool.
+type SearchCodeResponse struct {
+	Query   string       `json:"query"`
+	Count   int          `json:"count"`
+	Results []CodeResult `json:"results"`
+}
+
+// GetArchContextTool retrieves architectural context for a directory.
+type GetArchContextTool struct {
+	vectorStore storage.ScopedVectorStore
+	logger      *slog.Logger
+}
+
+func (t *GetArchContextTool) Name() string {
+	return "get_arch_context"
+}
+
+func (t *GetArchContextTool) Description() string {
+	return `Get architectural context for a directory in the repository.
+Returns a summary of the directory's purpose, key files, and patterns.
+Use this to understand the structure and role of a module before making changes.`
+}
+
+func (t *GetArchContextTool) InputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"directory": map[string]any{
+				"type":        "string",
+				"description": "The directory path (e.g., 'internal/jobs', 'pkg/cache'). Use '.' for root.",
+			},
+		},
+		"required": []string{"directory"},
+	}
+}
+
+func (t *GetArchContextTool) Execute(ctx context.Context, args map[string]any) (any, error) {
+	directory, ok := args["directory"].(string)
+	if !ok || directory == "" {
+		return nil, fmt.Errorf("directory is required")
+	}
+
+	// Search for architectural summary of this directory
+	query := fmt.Sprintf("Summary of directory %s architecture structure purpose", directory)
+	docs, err := t.vectorStore.SimilaritySearch(ctx, query, 3,
+		vectorstores.WithFilters(map[string]any{
+			"chunk_type": "arch",
+		}),
+	)
+	if err != nil {
+		t.logger.Error("failed to get arch context", "directory", directory, "error", err)
+		return nil, fmt.Errorf("failed to get architectural context: %w", err)
+	}
+
+	if len(docs) == 0 {
+		return ArchContextResponse{
+			Directory: directory,
+			Found:     false,
+			Message:   "No architectural context found for this directory",
+		}, nil
+	}
+
+	// Combine all found summaries
+	summaries := make([]string, 0, len(docs))
+	for _, doc := range docs {
+		summaries = append(summaries, doc.PageContent)
+	}
+
+	return ArchContextResponse{
+		Directory: directory,
+		Found:     true,
+		Summaries: summaries,
+	}, nil
+}
+
+// ArchContextResponse is the response for get_arch_context tool.
+type ArchContextResponse struct {
+	Directory string   `json:"directory"`
+	Found     bool     `json:"found"`
+	Summaries []string `json:"summaries,omitempty"`
+	Message   string   `json:"message,omitempty"`
+}
+
+// GetSymbolTool retrieves a symbol definition by name.
+type GetSymbolTool struct {
+	vectorStore storage.ScopedVectorStore
+	logger      *slog.Logger
+}
+
+func (t *GetSymbolTool) Name() string {
+	return "get_symbol"
+}
+
+func (t *GetSymbolTool) Description() string {
+	return `Get the definition of a symbol (type, function, interface) by name.
+Returns the full definition including signature and documentation.
+Use this to understand how a type or function is defined before using it.`
+}
+
+func (t *GetSymbolTool) InputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{
+				"type":        "string",
+				"description": "The symbol name (e.g., 'ReviewJob', 'GenerateReview', 'Store')",
+			},
+		},
+		"required": []string{"name"},
+	}
+}
+
+func (t *GetSymbolTool) Execute(ctx context.Context, args map[string]any) (any, error) {
+	name, ok := args["name"].(string)
+	if !ok || name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	// Search for symbol definition
+	query := fmt.Sprintf("definition of %s type function interface struct", name)
+	docs, err := t.vectorStore.SimilaritySearch(ctx, query, 5,
+		vectorstores.WithFilters(map[string]any{
+			"chunk_type": "definition",
+		}),
+	)
+	if err != nil {
+		t.logger.Error("failed to get symbol", "name", name, "error", err)
+		return nil, fmt.Errorf("failed to get symbol: %w", err)
+	}
+
+	if len(docs) == 0 {
+		return SymbolResponse{
+			Name:    name,
+			Found:   false,
+			Message: fmt.Sprintf("Symbol '%s' not found", name),
+		}, nil
+	}
+
+	definitions := make([]SymbolDefinition, 0, len(docs))
+	for _, doc := range docs {
+		def := SymbolDefinition{
+			Content: doc.PageContent,
+		}
+		if source, ok := doc.Metadata["source"].(string); ok {
+			def.Source = source
+		}
+		if line, ok := doc.Metadata["line"].(int); ok {
+			def.Line = line
+		}
+		definitions = append(definitions, def)
+	}
+
+	return SymbolResponse{
+		Name:        name,
+		Found:       true,
+		Definitions: definitions,
+	}, nil
+}
+
+// SymbolDefinition represents a single symbol definition.
+type SymbolDefinition struct {
+	Content string `json:"content"`
+	Source  string `json:"source,omitempty"`
+	Line    int    `json:"line,omitempty"`
+}
+
+// SymbolResponse is the response for get_symbol tool.
+type SymbolResponse struct {
+	Name        string             `json:"name"`
+	Found       bool               `json:"found"`
+	Definitions []SymbolDefinition `json:"definitions,omitempty"`
+	Message     string             `json:"message,omitempty"`
+}
+
+// GetStructureTool returns the overall project structure.
+type GetStructureTool struct {
+	vectorStore storage.ScopedVectorStore
+	projectRoot string
+	logger      *slog.Logger
+}
+
+func (t *GetStructureTool) Name() string {
+	return "get_structure"
+}
+
+func (t *GetStructureTool) Description() string {
+	return `Get the overall project structure and architecture.
+Returns a high-level overview of directories and their purposes.
+Use this to understand how the project is organized before making changes.`
+}
+
+func (t *GetStructureTool) InputSchema() map[string]any {
+	return map[string]any{
+		"type":       "object",
+		"properties": map[string]any{},
+	}
+}
+
+func (t *GetStructureTool) Execute(ctx context.Context, args map[string]any) (any, error) {
+	// Get root-level architectural summary
+	query := "project structure architecture overview main directories"
+	docs, err := t.vectorStore.SimilaritySearch(ctx, query, 10,
+		vectorstores.WithFilters(map[string]any{
+			"chunk_type": "arch",
+		}),
+	)
+	if err != nil {
+		t.logger.Error("failed to get structure", "error", err)
+		return nil, fmt.Errorf("failed to get project structure: %w", err)
+	}
+
+	directories := make([]DirectoryInfo, 0)
+	seen := make(map[string]bool)
+
+	for _, doc := range docs {
+		dir, ok := doc.Metadata["source"].(string)
+		if !ok || dir == "" || seen[dir] {
+			continue
+		}
+		seen[dir] = true
+
+		info := DirectoryInfo{
+			Path:      dir,
+			Summary:   doc.PageContent,
+			ChunkType: "arch",
+		}
+		if lang, ok := doc.Metadata["language"].(string); ok {
+			info.Language = lang
+		}
+		directories = append(directories, info)
+	}
+
+	return StructureResponse{
+		ProjectRoot: t.projectRoot,
+		Directories: directories,
+	}, nil
+}
+
+// DirectoryInfo represents information about a directory.
+type DirectoryInfo struct {
+	Path      string `json:"path"`
+	Summary   string `json:"summary"`
+	Language  string `json:"language,omitempty"`
+	ChunkType string `json:"chunkType"`
+}
+
+// StructureResponse is the response for get_structure tool.
+type StructureResponse struct {
+	ProjectRoot string          `json:"projectRoot"`
+	Directories []DirectoryInfo `json:"directories"`
+}
+
+// ReviewCodeTool performs an internal code review.
+type ReviewCodeTool struct {
+	ragService rag.Service
+	repo       *storage.Repository
+	repoConfig *core.RepoConfig
+	logger     *slog.Logger
+}
+
+func (t *ReviewCodeTool) Name() string {
+	return "review_code"
+}
+
+func (t *ReviewCodeTool) Description() string {
+	return `Perform an internal code review on a diff.
+Returns structured feedback with suggestions and verdict.
+Use this to validate your changes before creating a PR.`
+}
+
+func (t *ReviewCodeTool) InputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"diff": map[string]any{
+				"type":        "string",
+				"description": "The git diff to review",
+			},
+			"title": map[string]any{
+				"type":        "string",
+				"description": "Optional title for the review context",
+			},
+			"description": map[string]any{
+				"type":        "string",
+				"description": "Optional description for additional context",
+			},
+		},
+		"required": []string{"diff"},
+	}
+}
+
+func (t *ReviewCodeTool) Execute(ctx context.Context, args map[string]any) (any, error) {
+	diff, ok := args["diff"].(string)
+	if !ok || diff == "" {
+		return nil, fmt.Errorf("diff is required")
+	}
+
+	// Create a mock event for the review
+	title, _ := args["title"].(string)
+	if title == "" {
+		title = "Internal Code Review"
+	}
+	description, _ := args["description"].(string)
+
+	event := &core.GitHubEvent{
+		PRTitle: title,
+		PRBody:  description,
+		// These fields are needed but can be mock values for internal review
+		RepoFullName:  t.repo.FullName,
+		HeadSHA:       "internal-review",
+		PRNumber:      0,
+		InstallationID: 0,
+	}
+
+	// Generate the review
+	review, _, err := t.ragService.GenerateReview(ctx, t.repoConfig, t.repo, event, diff, nil)
+	if err != nil {
+		t.logger.Error("internal review failed", "error", err)
+		return nil, fmt.Errorf("review failed: %w", err)
+	}
+
+	return ReviewCodeResponse{
+		Verdict:     review.Verdict,
+		Confidence:  review.Confidence,
+		Summary:     review.Summary,
+		Suggestions: review.Suggestions,
+	}, nil
+}
+
+// ReviewCodeResponse is the response for review_code tool.
+type ReviewCodeResponse struct {
+	Verdict     string            `json:"verdict"`
+	Confidence  int               `json:"confidence"`
+	Summary     string            `json:"summary"`
+	Suggestions []core.Suggestion `json:"suggestions,omitempty"`
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -12,6 +12,17 @@ import (
 	"github.com/sevigo/code-warden/internal/storage"
 )
 
+// Input validation limits.
+const (
+	maxQueryLength   = 10000
+	maxResultLimit   = 100
+	minResultLimit   = 1
+	maxDiffLength    = 1000000 // 1MB max diff
+	maxTitleLength   = 500
+	maxSymbolLength  = 200
+	maxDirPathLength = 500
+)
+
 // SearchCodeTool searches for code using semantic similarity.
 type SearchCodeTool struct {
 	vectorStore storage.ScopedVectorStore
@@ -56,10 +67,19 @@ func (t *SearchCodeTool) Execute(ctx context.Context, args map[string]any) (any,
 		t.logger.Warn("search_code: missing query parameter")
 		return nil, fmt.Errorf("query is required")
 	}
+	if len(query) > maxQueryLength {
+		t.logger.Warn("search_code: query too long", "length", len(query))
+		return nil, fmt.Errorf("query exceeds maximum length of %d characters", maxQueryLength)
+	}
 
 	limit := 10
 	if l, ok := args["limit"].(float64); ok {
 		limit = int(l)
+		if limit < minResultLimit {
+			limit = minResultLimit
+		} else if limit > maxResultLimit {
+			limit = maxResultLimit
+		}
 	}
 
 	opts := []vectorstores.Option{}
@@ -159,6 +179,10 @@ func (t *GetArchContextTool) Execute(ctx context.Context, args map[string]any) (
 	if !ok || directory == "" {
 		return nil, fmt.Errorf("directory is required")
 	}
+	if len(directory) > maxDirPathLength {
+		t.logger.Warn("get_arch_context: directory path too long", "length", len(directory))
+		return nil, fmt.Errorf("directory path exceeds maximum length of %d characters", maxDirPathLength)
+	}
 
 	// Search for architectural summary of this directory
 	query := fmt.Sprintf("Summary of directory %s architecture structure purpose", directory)
@@ -234,6 +258,10 @@ func (t *GetSymbolTool) Execute(ctx context.Context, args map[string]any) (any, 
 	name, ok := args["name"].(string)
 	if !ok || name == "" {
 		return nil, fmt.Errorf("name is required")
+	}
+	if len(name) > maxSymbolLength {
+		t.logger.Warn("get_symbol: symbol name too long", "length", len(name))
+		return nil, fmt.Errorf("symbol name exceeds maximum length of %d characters", maxSymbolLength)
 	}
 
 	// Search for symbol definition
@@ -414,11 +442,18 @@ func (t *ReviewCodeTool) Execute(ctx context.Context, args map[string]any) (any,
 	if !ok || diff == "" {
 		return nil, fmt.Errorf("diff is required")
 	}
+	if len(diff) > maxDiffLength {
+		t.logger.Warn("review_code: diff too large", "length", len(diff))
+		return nil, fmt.Errorf("diff exceeds maximum size of %d bytes", maxDiffLength)
+	}
 
 	// Create a mock event for the review
 	title, _ := args["title"].(string)
 	if title == "" {
 		title = "Internal Code Review"
+	}
+	if len(title) > maxTitleLength {
+		title = title[:maxTitleLength]
 	}
 	description, _ := args["description"].(string)
 


### PR DESCRIPTION
## Summary

This PR implements the foundation for integrating code-warden with OpenCode to enable autonomous issue implementation.

## Architecture

```
GitHub Issue (/implement)
         ↓
   Agent Orchestrator
         ↓
   OpenCode (headless)
         ↓
   MCP Server (Qdrant tools)
         ↓
   Internal Code Review
         ↓
   Pull Request
```

## Implementation Status

### ✅ Completed
- [x] MCP Server with JSON-RPC 2.0 protocol
- [x] MCP Tools for codebase interaction:
  - `search_code` - Semantic code search
  - `get_arch_context` - Architectural summaries
  - `get_symbol` - Symbol definitions
  - `get_structure` - Project structure
  - `review_code` - Internal code review
- [x] Agent Orchestrator session management
- [x] OpenCode process spawning framework
- [x] System prompt generation

### 🔄 In Progress
- [ ] Integration with webhook handler (detect `/implement` command)
- [ ] Configuration file updates
- [ ] Tests

### 📋 TODO
- [ ] Wire up orchestrator to main server
- [ ] Add `/implement` command detection
- [ ] Add configuration for agent settings
- [ ] Test with actual OpenCode binary
- [ ] Add tests for MCP tools

## Files Changed

| File | Description |
|------|-------------|
| `internal/mcp/server.go` | MCP server implementation |
| `internal/mcp/tools.go` | MCP tool definitions |
| `internal/agent/orchestrator.go` | Agent session management |

## Configuration (Planned)

```yaml
agent:
  enabled: true
  provider: "opencode"
  model: "llama3.1:70b"
  timeout: "30m"
  max_iterations: 3
  mcp_addr: ":8081"
```

## Related

- Issue #144 - Mutex memory leak
- Issue #145 - Concurrency tests
- Issue #146 - Graceful shutdown