### PR TITLE
feat(agent): implement full agent orchestration for /implement command

### DIFF
--- a/internal/jobs/review.go
+++ b/internal/jobs/review.go
@@ -7,7 +7,9 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/sevigo/code-warden/internal/agent"
 	"github.com/sevigo/code-warden/internal/config"
 	"github.com/sevigo/code-warden/internal/core"
 	"github.com/sevigo/code-warden/internal/github"
@@ -25,6 +27,7 @@ type ReviewJob struct {
 	cfg         *config.Config
 	ragService  rag.Service
 	store       storage.Store
+	vectorStore storage.VectorStore
 	repoMgr     repomanager.RepoManager
 	logger      *slog.Logger
 	repoMutexes sync.Map
@@ -35,6 +38,7 @@ func NewReviewJob(
 	cfg *config.Config,
 	rag rag.Service,
 	store storage.Store,
+	vectorStore storage.VectorStore,
 	repoMgr repomanager.RepoManager,
 	logger *slog.Logger,
 ) core.Job {
@@ -42,6 +46,7 @@ func NewReviewJob(
 		cfg:         cfg,
 		ragService:  rag,
 		store:       store,
+		vectorStore: vectorStore,
 		repoMgr:     repoMgr,
 		logger:      logger,
 		repoMutexes: sync.Map{},
@@ -92,8 +97,7 @@ func (j *ReviewJob) runReReview(ctx context.Context, event *core.GitHubEvent) er
 }
 
 // runImplementIssue handles the `/implement` command on issues.
-// TODO: Full implementation with agent orchestration.
-func (j *ReviewJob) runImplementIssue(_ context.Context, event *core.GitHubEvent) error {
+func (j *ReviewJob) runImplementIssue(ctx context.Context, event *core.GitHubEvent) error {
 	j.logger.Info("🤖 Starting Issue Implementation",
 		"repo", event.RepoFullName,
 		"issue", event.IssueNumber,
@@ -105,14 +109,166 @@ func (j *ReviewJob) runImplementIssue(_ context.Context, event *core.GitHubEvent
 		return fmt.Errorf("agent functionality is disabled; enable it in config to use /implement")
 	}
 
-	// TODO: Implement full agent orchestration:
 	// 1. Create GitHub client for the installation
-	// 2. Create orchestrator with proper dependencies
-	// 3. Spawn agent to implement the issue
-	// 4. Monitor session and report progress
-	// 5. Post result as PR comment
+	ghClient, _, err := github.CreateInstallationClient(ctx, j.cfg, event.InstallationID, j.logger)
+	if err != nil {
+		return fmt.Errorf("failed to create GitHub client: %w", err)
+	}
 
-	return fmt.Errorf("issue implementation not yet fully implemented")
+	// 2. Sync the repository to get the latest code
+	updateResult, err := j.repoMgr.SyncRepo(ctx, event, "")
+	if err != nil {
+		return fmt.Errorf("failed to sync repo: %w", err)
+	}
+
+	// 3. Get the repository record
+	repo, err := j.repoMgr.GetRepoRecord(ctx, event.RepoFullName)
+	if err != nil {
+		return fmt.Errorf("failed to get repo record: %w", err)
+	}
+
+	// 4. Load repository config
+	repoConfig := j.loadAndProcessRepoConfig(updateResult.RepoPath, event.RepoFullName)
+
+	// 5. Get scoped vector store for this repo
+	scopedStore := j.vectorStore.ForRepo(repo.QdrantCollectionName, repo.EmbedderModelName)
+
+	// 6. Parse agent timeout
+	timeout, err := j.cfg.Agent.GetTimeout()
+	if err != nil {
+		return fmt.Errorf("invalid agent timeout: %w", err)
+	}
+
+	// 7. Create orchestrator
+	orchestrator := agent.NewOrchestrator(
+		j.store,
+		scopedStore,
+		j.ragService,
+		ghClient,
+		repo,
+		repoConfig,
+		updateResult.RepoPath,
+		agent.Config{
+			Enabled:       j.cfg.Agent.Enabled,
+			Provider:      j.cfg.Agent.Provider,
+			Model:         j.cfg.Agent.Model,
+			Timeout:       timeout,
+			MaxIterations: j.cfg.Agent.MaxIterations,
+			MCPAddr:       j.cfg.Agent.MCPAddr,
+			WorkingDir:    j.cfg.Agent.WorkingDir,
+		},
+		j.logger,
+	)
+
+	// 8. Start the MCP server
+	if err := orchestrator.Start(); err != nil {
+		return fmt.Errorf("failed to start orchestrator: %w", err)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := orchestrator.Shutdown(shutdownCtx); err != nil {
+			j.logger.Error("failed to shutdown orchestrator", "error", err)
+		}
+	}()
+
+	// 9. Spawn agent to implement the issue
+	issue := agent.Issue{
+		Number:       event.IssueNumber,
+		Title:        event.IssueTitle,
+		Body:         event.IssueBody,
+		Instructions: event.UserInstructions,
+		RepoOwner:    event.RepoOwner,
+		RepoName:     event.RepoName,
+	}
+
+	session, err := orchestrator.SpawnAgent(ctx, issue)
+	if err != nil {
+		return fmt.Errorf("failed to spawn agent: %w", err)
+	}
+
+	// 10. Monitor session and wait for completion
+	result, err := j.waitForAgentSession(ctx, orchestrator, session, timeout)
+	if err != nil {
+		return err
+	}
+
+	// 11. Post result as comment on the issue
+	comment := j.formatImplementResult(result)
+	return ghClient.CreateComment(ctx, event.RepoOwner, event.RepoName, event.IssueNumber, comment)
+}
+
+// waitForAgentSession monitors the agent session until completion or timeout.
+func (j *ReviewJob) waitForAgentSession(ctx context.Context, orchestrator *agent.Orchestrator, session *agent.Session, timeout time.Duration) (*agent.Result, error) {
+	j.logger.Info("agent session started, waiting for completion",
+		"session_id", session.ID,
+		"timeout", timeout)
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for {
+		select {
+		case <-timeoutCtx.Done():
+			if err := orchestrator.CancelSession(session.ID); err != nil {
+				j.logger.Error("failed to cancel session on timeout", "error", err)
+			}
+			return nil, fmt.Errorf("agent session timed out after %v", timeout)
+
+		case <-ticker.C:
+			snapshot := session.Snapshot()
+			j.logger.Info("agent session status",
+				"session_id", session.ID,
+				"status", snapshot.Status,
+				"duration", time.Since(snapshot.StartedAt).Round(time.Second))
+
+			switch snapshot.Status {
+			case agent.StatusCompleted:
+				if snapshot.Result == nil {
+					return nil, fmt.Errorf("agent completed with no result")
+				}
+				j.logger.Info("agent session completed",
+					"session_id", session.ID,
+					"pr_number", snapshot.Result.PRNumber,
+					"pr_url", snapshot.Result.PRURL,
+					"verdict", snapshot.Result.Verdict,
+					"iterations", snapshot.Result.Iterations)
+				return snapshot.Result, nil
+
+			case agent.StatusFailed:
+				return nil, fmt.Errorf("agent session failed: %s", snapshot.Error)
+
+			case agent.StatusCancelled:
+				return nil, fmt.Errorf("agent session was cancelled: %s", snapshot.Error)
+			}
+		}
+	}
+}
+
+// formatImplementResult creates a comment body from the agent result.
+func (j *ReviewJob) formatImplementResult(result *agent.Result) string {
+	var sb strings.Builder
+
+	if result.PRNumber > 0 {
+		sb.WriteString("## ✅ Implementation Complete\n\n")
+		sb.WriteString(fmt.Sprintf("I've created pull request [#%d](%s) with the implementation.\n\n", result.PRNumber, result.PRURL))
+		sb.WriteString(fmt.Sprintf("**Branch:** `%s`\n", result.Branch))
+		sb.WriteString(fmt.Sprintf("**Files Changed:** %d\n", len(result.FilesChanged)))
+		sb.WriteString(fmt.Sprintf("**Iterations:** %d\n", result.Iterations))
+		sb.WriteString(fmt.Sprintf("**Verdict:** %s\n", result.Verdict))
+
+		if result.ReviewSummary != "" {
+			sb.WriteString(fmt.Sprintf("\n**Review Summary:**\n%s\n", result.ReviewSummary))
+		}
+	} else {
+		sb.WriteString("## ❌ Implementation Failed\n\n")
+		sb.WriteString("The agent was unable to complete the implementation. Please check the logs for details.\n")
+	}
+
+	return sb.String()
 }
 
 func (j *ReviewJob) executeReReviewWorkflow(ctx context.Context, event *core.GitHubEvent) (err error) {

--- a/internal/wire/wire_gen.go
+++ b/internal/wire/wire_gen.go
@@ -9,13 +9,6 @@ package wire
 import (
 	"context"
 	"fmt"
-	"io"
-	"log/slog"
-	"net"
-	"net/http"
-	"os"
-	"time"
-
 	"github.com/jmoiron/sqlx"
 	"github.com/sevigo/code-warden/internal/app"
 	"github.com/sevigo/code-warden/internal/config"
@@ -29,6 +22,7 @@ import (
 	"github.com/sevigo/code-warden/internal/server"
 	"github.com/sevigo/code-warden/internal/storage"
 	"github.com/sevigo/goframe/embeddings"
+	"github.com/sevigo/goframe/httpclient"
 	"github.com/sevigo/goframe/llms"
 	"github.com/sevigo/goframe/llms/gemini"
 	"github.com/sevigo/goframe/llms/ollama"
@@ -36,6 +30,10 @@ import (
 	"github.com/sevigo/goframe/schema"
 	"github.com/sevigo/goframe/textsplitter"
 	"github.com/sevigo/goframe/vectorstores/qdrant"
+	"io"
+	"log/slog"
+	"os"
+	"time"
 )
 
 // Injectors from wire.go:
@@ -93,7 +91,7 @@ func InitializeApp(ctx context.Context) (*app.App, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	job := jobs.NewReviewJob(configConfig, service, store, repoManager, logger)
+	job := jobs.NewReviewJob(configConfig, service, store, vectorStore, repoManager, logger)
 	jobDispatcher := jobs.NewDispatcher(ctx, job, configConfig, logger)
 	serverServer := server.NewServer(ctx, configConfig, jobDispatcher, logger)
 	appApp := app.NewApp(configConfig, dbDB, store, vectorStore, repoManager, jobDispatcher, service, serverServer, client, logger)
@@ -127,14 +125,16 @@ func provideVectorStore(cfg *config.Config, embedder embeddings.Embedder, logger
 			MaxConcurrency:          8,
 			EmbeddingBatchSize:      64,
 			EmbeddingMaxConcurrency: 8,
-			RetryAttempts:           2,
-			RetryDelay:              1 * time.Second,
+			RetryAttempts:           qdrant.DefaultRetryAttempts,
+			RetryDelay:              qdrant.DefaultRetryDelay,
+			RetryJitter:             qdrant.DefaultRetryJitter,
+			MaxRetryDelay:           qdrant.DefaultMaxRetryDelay,
 		}
 	}
 
 	return storage.NewQdrantVectorStore(
 		cfg,
-		logger, storage.WithBatchConfig(batchConfig), storage.WithInitialEmbedder(cfg.AI.EmbedderModel, embedder),
+		logger, storage.WithBatchConfig(batchConfig), storage.WithInitialEmbedder(cfg.AI.EmbedderModel, embedder), storage.WithQdrantOptions(qdrant.WithTimeout(60*time.Second), qdrant.WithKeepaliveTime(15*time.Second), qdrant.WithKeepaliveTimeout(5*time.Second), qdrant.WithPoolSize(20)),
 	)
 }
 
@@ -146,7 +146,19 @@ func provideGeneratorLLM(ctx context.Context, cfg *config.Config, logger *slog.L
 		}
 		return gemini.New(ctx, gemini.WithModel(cfg.AI.GeneratorModel), gemini.WithAPIKey(cfg.AI.GeminiAPIKey))
 	case "ollama":
-		return ollama.New(ollama.WithServerURL(cfg.AI.OllamaHost), ollama.WithHTTPClient(newOllamaHTTPClient()), ollama.WithModel(cfg.AI.GeneratorModel), ollama.WithLogger(logger))
+		opts := []ollama.Option{ollama.WithServerURL(cfg.AI.OllamaHost), ollama.WithAPIKey(cfg.AI.OllamaAPIKey), ollama.WithHTTPClient(httpclient.DefaultClient), ollama.WithModel(cfg.AI.GeneratorModel), ollama.WithLogger(logger), ollama.WithRetryAttempts(3), ollama.WithRetryDelay(2 * time.Second)}
+
+		if cfg.AI.EnableThinking {
+			opts = append(opts, ollama.WithThinking(true))
+			if cfg.AI.ThinkingEffort != "" {
+				opts = append(opts, ollama.WithReasoningEffort(cfg.AI.ThinkingEffort))
+			}
+		}
+
+		if cfg.AI.ModelKeepAlive != "" {
+			opts = append(opts, ollama.WithKeepAlive(cfg.AI.ModelKeepAlive))
+		}
+		return ollama.New(opts...)
 	default:
 		return nil, fmt.Errorf("unsupported LLM provider: %s", cfg.AI.LLMProvider)
 	}
@@ -160,7 +172,12 @@ func provideEmbedder(ctx context.Context, cfg *config.Config, logger *slog.Logge
 	case "gemini":
 		embedderLLM, err = gemini.New(ctx, gemini.WithEmbeddingModel(cfg.AI.EmbedderModel), gemini.WithAPIKey(cfg.AI.GeminiAPIKey))
 	case "ollama":
-		embedderLLM, err = ollama.New(ollama.WithServerURL(cfg.AI.OllamaHost), ollama.WithModel(cfg.AI.EmbedderModel), ollama.WithHTTPClient(newOllamaHTTPClient()), ollama.WithLogger(logger))
+		opts := []ollama.Option{ollama.WithServerURL(cfg.AI.OllamaHost), ollama.WithAPIKey(cfg.AI.OllamaAPIKey), ollama.WithModel(cfg.AI.EmbedderModel), ollama.WithHTTPClient(httpclient.DefaultClient), ollama.WithLogger(logger), ollama.WithRetryAttempts(3), ollama.WithRetryDelay(2 * time.Second)}
+
+		if cfg.AI.ModelKeepAlive != "" {
+			opts = append(opts, ollama.WithKeepAlive(cfg.AI.ModelKeepAlive))
+		}
+		embedderLLM, err = ollama.New(opts...)
 	default:
 		return nil, fmt.Errorf("unsupported embedder provider: %s", cfg.AI.EmbedderProvider)
 	}
@@ -186,22 +203,6 @@ func provideTextSplitter(registry parsers.ParserRegistry, model llms.Model, logg
 		return nil, err
 	}
 	return splitter, nil
-}
-
-func newOllamaHTTPClient() *http.Client {
-	return &http.Client{
-		Transport: &http.Transport{
-			DialContext: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
-			}).DialContext,
-			MaxIdleConns:        100,
-			MaxConnsPerHost:     10,
-			IdleConnTimeout:     90 * time.Second,
-			TLSHandshakeTimeout: 10 * time.Second,
-		},
-		Timeout: 15 * time.Minute,
-	}
 }
 
 func provideLoggerConfig(cfg *config.Config) logger.Config {
@@ -243,12 +244,18 @@ func provideReranker(ctx context.Context, cfg *config.Config, logger2 *slog.Logg
 	logger2.
 		Info("Initializing LLM Reranker", "model", cfg.AI.RerankerModel)
 
-	rerankLLM, err := ollama.New(ollama.WithServerURL(cfg.AI.OllamaHost), ollama.WithModel(cfg.AI.RerankerModel), ollama.WithHTTPClient(newOllamaHTTPClient()), ollama.WithLogger(logger2))
+	opts := []ollama.Option{ollama.WithServerURL(cfg.AI.OllamaHost), ollama.WithModel(cfg.AI.RerankerModel), ollama.WithHTTPClient(httpclient.DefaultClient), ollama.WithLogger(logger2), ollama.WithRetryAttempts(3), ollama.WithRetryDelay(2 * time.Second)}
+
+	if cfg.AI.ModelKeepAlive != "" {
+		opts = append(opts, ollama.WithKeepAlive(cfg.AI.ModelKeepAlive))
+	}
+
+	rerankLLM, err := ollama.New(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create reranker LLM: %w", err)
 	}
 
-	const RerankPromptKey = "rerank_precision" // I will define this in llm package or use string here for now to avoid circular deps if any (unlikely as wire imports llm).
+	const RerankPromptKey = "rerank_precision"
 
 	prompt, err := promptMgr.Render("rerank_precision", nil)
 	if err != nil {


### PR DESCRIPTION
## Summary
This PR implements the full agent orchestration for the `/implement` command, connecting all the pieces from the previous agent integration PRs.

### Changes
- **ReviewJob**: Added `VectorStore` dependency for scoped vector access
- **runImplementIssue**: Complete implementation workflow:
  1. Create GitHub client for installation
  2. Sync repository to get latest code
  3. Get repository record and config
  4. Create scoped vector store for the repo
  5. Create and start orchestrator with MCP server
  6. Spawn agent session to implement the issue
  7. Monitor session with timeout and status polling
  8. Post result as comment on the issue
- **waitForAgentSession**: Helper for monitoring session status
- **formatImplementResult**: GitHub comment formatting for results

### How it works
When a user comments `/implement` on an issue:
1. Webhook receives the comment and dispatches an `ImplementIssue` event
2. ReviewJob creates an orchestrator with MCP tools (search_code, get_arch_context, etc.)
3. Agent session is spawned to implement the issue
4. Session is monitored until completion/timeout
5. Result (PR URL or error) is posted as a comment on the issue

### Dependencies
- Requires PR #150 (agent integration) and #151 (config + webhook) to be merged ✅

## Test Plan
- [x] Linter passes
- [x] All tests pass
- [ ] Manual test with `/implement` on an issue (requires OpenCode setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)