### PR TITLE
fix: mutex memory leak in per-repository locking

### DIFF
--- a/internal/jobs/review.go
+++ b/internal/jobs/review.go
@@ -60,7 +60,12 @@ func (j *ReviewJob) acquireRepoMutex(repoFullName string) func() {
 		mu:       &sync.Mutex{},
 		refCount: 0,
 	})
-	e := entry.(*repoMutexEntry)
+	e, ok := entry.(*repoMutexEntry)
+	if !ok {
+		j.repoMutexMu.Unlock()
+		j.logger.Error("type assertion failed for repo mutex entry", "repo", repoFullName)
+		return func() {}
+	}
 	e.refCount++
 	j.repoMutexMu.Unlock()
 
@@ -79,7 +84,11 @@ func (j *ReviewJob) releaseRepoMutex(repoFullName string) {
 	if !ok {
 		return
 	}
-	e := entry.(*repoMutexEntry)
+	e, ok := entry.(*repoMutexEntry)
+	if !ok {
+		j.logger.Error("type assertion failed for repo mutex entry in release", "repo", repoFullName)
+		return
+	}
 	e.refCount--
 	if e.refCount <= 0 {
 		j.repoMutexes.Delete(repoFullName)

--- a/internal/jobs/review_test.go
+++ b/internal/jobs/review_test.go
@@ -11,7 +11,7 @@ func TestRepoMutexCleanup(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -36,11 +36,11 @@ func TestRepoMutexConcurrentAccess(t *testing.T) {
 	var counter int
 	var mu sync.Mutex
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for k := 0; k < 10; k++ {
+			for range 10 {
 				release := j.acquireRepoMutex("test/repo")
 				mu.Lock()
 				counter++
@@ -102,7 +102,7 @@ func TestRepoMutexRefCountConcurrent(t *testing.T) {
 	var wg sync.WaitGroup
 	startBarrier := make(chan struct{})
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -130,7 +130,7 @@ func TestRepoMutexSequentialAcquireRelease(t *testing.T) {
 		repoMutexes: sync.Map{},
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		release := j.acquireRepoMutex("test/repo")
 		_, exists := j.repoMutexes.Load("test/repo")
 		if !exists {


### PR DESCRIPTION
## Summary
- Fixes #144: Implements reference counting for repository mutexes to prevent unbounded memory growth
- Previously, mutexes were stored in `sync.Map` but never cleaned up
- Now uses `acquireRepoMutex`/`releaseRepoMutex` pattern with reference counting

## Changes
- Added `repoMutexEntry` struct with mutex and refCount
- Added `repoMutexMu` to protect map operations  
- Replaced `getRepoMutex` with `acquireRepoMutex`/`releaseRepoMutex` pattern
- Entry is deleted when reference count drops to zero
- Added comprehensive tests for cleanup behavior and race conditions

## Testing
- All tests pass with `-race` flag
- Tests verify:
  - Mutex cleanup after all references released
  - Concurrent access with proper synchronization
  - Multiple repos handled independently
  - Reference counting works correctly