### PR TITLE
feat(config): add configuration validation at startup

### DIFF
--- a/.vscode/opencode.http
+++ b/.vscode/opencode.http
@@ -1,0 +1,56 @@
+@host = http://127.0.0.1:4096
+# To run these tests: Install the "REST Client" extension in VS Code.
+# Click "Send Request" above each HTTP call.
+
+### 1. Check Server Health
+GET {{host}}/global/health
+
+### 2. Create a new Session
+# @name createSession
+POST {{host}}/session
+Content-Type: application/json
+
+{
+    "title": "Manual Test Session",
+    "model": "",
+    "env": {
+        "OPENCODE_MCP_SERVER": "127.0.0.1:8081"
+    }
+}
+
+### Store the Session ID for subsequent calls
+@sessionId = {{createSession.response.body.id}}
+
+### 3. Check Session Information
+GET {{host}}/session/{{sessionId}}
+
+### 4. Send a Message to the Session
+POST {{host}}/session/{{sessionId}}/message
+Content-Type: application/json
+
+{
+    "agent": "build",
+    "model": "glm-5:cloud",
+    "parts": [
+        {
+            "type": "text",
+            "text": "Hello, this is a manual test message. Can you return a short greeting?"
+        }
+    ],
+    "stream": false
+}
+
+### 5. Execute a Shell Command in the Session Context
+POST {{host}}/session/{{sessionId}}/shell
+Content-Type: application/json
+
+{
+    "agent": "build",
+    "command": "echo 'Command execution works!'"
+}
+
+### 6. Get all Messages from the Session so far
+GET {{host}}/session/{{sessionId}}/message
+
+### 7. Delete / Close the Session
+DELETE {{host}}/session/{{sessionId}}

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,12 @@ GOLINT_BIN_DIR=$(CURDIR)/bin
 GOLINT_CMD=$(GOLINT_BIN_DIR)/golangci-lint
 GOLINT_VERSION=v2.5.0
 
+# OpenCode configuration
+OPENCODE_PORT=4096
+OPENCODE_MCP_URL=http://127.0.0.1:8081/sse
+
 .DEFAULT_GOAL := all
-.PHONY: all build run clean test lint
+.PHONY: all build run clean test lint opencode-start opencode-stop opencode-config dev
 
 all: build
 
@@ -42,13 +46,47 @@ test:
 	@echo "Running tests..."
 	@go test -v ./...
 
-lint: 
+lint:
 	@echo "Linting Go code..."
 	@if ! command -v $(GOLINT_CMD) &> /dev/null; then \
 		echo "golangci-lint $(GOLINT_VERSION) not found or wrong version, installing to $(GOLINT_BIN_DIR)..."; \
 		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOLINT_BIN_DIR) $(GOLINT_VERSION); \
 	fi
 	$(GOLINT_CMD) run ./...
+
+# OpenCode server management
+opencode-start:
+	@echo "Starting OpenCode server on port $(OPENCODE_PORT)..."
+	@OPENCODE_PORT=$(OPENCODE_PORT) opencode serve &>/tmp/opencode.log &
+	@sleep 2
+	@echo "OpenCode server started. Logs: /tmp/opencode.log"
+
+opencode-stop:
+	@echo "Stopping OpenCode server..."
+	@pkill -f "opencode serve" || echo "OpenCode server not running"
+	@echo "OpenCode server stopped"
+
+opencode-config:
+	@echo "Configuring OpenCode MCP server..."
+	@mkdir -p ~/.config/opencode
+	@echo '{\n\
+  "$$schema": "https://opencode.ai/config.json",\n\
+  "mcp": {\n\
+    "code-warden": {\n\
+      "type": "sse",\n\
+      "url": "$(OPENCODE_MCP_URL)",\n\
+      "enabled": true\n\
+    }\n\
+  }\n\
+}' > ~/.config/opencode/opencode.json
+	@echo "OpenCode MCP configured to connect to $(OPENCODE_MCP_URL)"
+
+# Development mode: start both code-warden and OpenCode
+dev: build-server opencode-config
+	@echo "Starting development environment..."
+	@$(MAKE) opencode-start
+	@echo "Starting code-warden server..."
+	@$(BIN_DIR)/$(SERVER_BINARY_NAME)
 
 # Clean up the built binary and tools
 clean:

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ opencode-config:
   "$$schema": "https://opencode.ai/config.json",\n\
   "mcp": {\n\
     "code-warden": {\n\
-      "type": "sse",\n\
+      "type": "remote",\n\
       "url": "$(OPENCODE_MCP_URL)",\n\
       "enabled": true\n\
     }\n\

--- a/cmd/mcp-test/main.go
+++ b/cmd/mcp-test/main.go
@@ -1,5 +1,20 @@
-// Package main provides a simple MCP server for testing tool calling.
-// Run: go run ./cmd/mcp-test
+// Package main provides a standalone MCP test server for validating tool calling.
+//
+// This is a simple MCP server that implements three fun tools:
+//   - roll_dice: Roll dice and get random results (great for making decisions!)
+//   - echo: Echo back messages with customizable enthusiasm levels
+//   - get_time: Get the current time in various formats
+//
+// Usage:
+//
+//	go run ./cmd/mcp-test
+//	curl http://127.0.0.1:8082/tools
+//	curl -X POST http://127.0.0.1:8082/ -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"roll_dice","arguments":{"sides":20,"count":3}}}'
+//
+// This server is useful for:
+//   - Testing MCP client implementations
+//   - Validating tool discovery and execution
+//   - Debugging SSE transport issues
 package main
 
 import (

--- a/cmd/mcp-test/main.go
+++ b/cmd/mcp-test/main.go
@@ -1,0 +1,502 @@
+// Package main provides a simple MCP server for testing tool calling.
+// Run: go run ./cmd/mcp-test
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"math/rand/v2"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Tool represents an MCP tool.
+type Tool interface {
+	Name() string
+	Description() string
+	InputSchema() map[string]any
+	Execute(ctx context.Context, args map[string]any) (any, error)
+}
+
+// Server implements a simple MCP server.
+type Server struct {
+	tools      map[string]Tool
+	toolsMu    sync.RWMutex
+	sessions   map[string]*sseSession
+	sessionsMu sync.RWMutex
+}
+
+type sseSession struct {
+	id       string
+	messages chan []byte
+	done     chan struct{}
+}
+
+// Request represents a JSON-RPC 2.0 request.
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      any             `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// Response represents a JSON-RPC 2.0 response.
+type Response struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      any    `json:"id,omitempty"`
+	Result  any    `json:"result,omitempty"`
+	Error   *Error `json:"error,omitempty"`
+}
+
+// Error represents a JSON-RPC 2.0 error.
+type Error struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// DiceRollTool rolls dice and returns the result.
+type DiceRollTool struct{}
+
+func (t *DiceRollTool) Name() string { return "roll_dice" }
+func (t *DiceRollTool) Description() string {
+	return "Roll dice and return the result. Great for making random decisions!"
+}
+func (t *DiceRollTool) InputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"sides": map[string]any{
+				"type":        "integer",
+				"description": "Number of sides on the die (default 6)",
+				"default":     6,
+			},
+			"count": map[string]any{
+				"type":        "integer",
+				"description": "Number of dice to roll (default 1)",
+				"default":     1,
+			},
+		},
+	}
+}
+func (t *DiceRollTool) Execute(_ context.Context, args map[string]any) (any, error) {
+	sides := 6
+	if s, ok := args["sides"].(float64); ok {
+		sides = int(s)
+	}
+	if sides < 2 {
+		return nil, fmt.Errorf("sides must be at least 2")
+	}
+
+	count := 1
+	if c, ok := args["count"].(float64); ok {
+		count = int(c)
+	}
+	if count < 1 {
+		return nil, fmt.Errorf("count must be at least 1")
+	}
+	if count > 100 {
+		return nil, fmt.Errorf("count cannot exceed 100")
+	}
+
+	rolls := make([]int, count)
+	total := 0
+	for i := range count {
+		roll := rand.IntN(sides) + 1 //nolint:gosec // G404: weak random is fine for dice game
+		rolls[i] = roll
+		total += roll
+	}
+
+	return map[string]any{
+		"rolls":   rolls,
+		"total":   total,
+		"sides":   sides,
+		"count":   count,
+		"message": fmt.Sprintf("Rolled %d dice with %d sides: %v (total: %d)", count, sides, rolls, total),
+	}, nil
+}
+
+// EchoTool echoes back the message with a fun twist.
+type EchoTool struct{}
+
+func (t *EchoTool) Name() string        { return "echo" }
+func (t *EchoTool) Description() string { return "Echo back your message with a friendly greeting" }
+func (t *EchoTool) InputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"message": map[string]any{
+				"type":        "string",
+				"description": "The message to echo back",
+			},
+			"enthusiasm": map[string]any{
+				"type":        "string",
+				"description": "Level of enthusiasm: 'low', 'medium', or 'high'",
+				"default":     "medium",
+				"enum":        []string{"low", "medium", "high"},
+			},
+		},
+		"required": []string{"message"},
+	}
+}
+func (t *EchoTool) Execute(_ context.Context, args map[string]any) (any, error) {
+	message, ok := args["message"].(string)
+	if !ok {
+		return nil, fmt.Errorf("message is required")
+	}
+
+	enthusiasm := "medium"
+	if e, ok := args["enthusiasm"].(string); ok {
+		enthusiasm = e
+	}
+
+	var prefix, suffix string
+	switch enthusiasm {
+	case "high":
+		prefix = "🎉 WOW! You said: "
+		suffix = "!!! THAT'S AMAZING!!! 🎊"
+	case "low":
+		prefix = "You said: "
+		suffix = "."
+	default:
+		prefix = "👋 You said: "
+		suffix = "!"
+	}
+
+	return map[string]any{
+		"original":   message,
+		"enthusiasm": enthusiasm,
+		"response":   prefix + message + suffix,
+	}, nil
+}
+
+// TimeTool returns the current time in various formats.
+type TimeTool struct{}
+
+func (t *TimeTool) Name() string        { return "get_time" }
+func (t *TimeTool) Description() string { return "Get the current time in various formats" }
+func (t *TimeTool) InputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"timezone": map[string]any{
+				"type":        "string",
+				"description": "Time zone (e.g., 'UTC', 'America/New_York')",
+				"default":     "Local",
+			},
+		},
+	}
+}
+func (t *TimeTool) Execute(_ context.Context, _ map[string]any) (any, error) {
+	now := time.Now()
+
+	return map[string]any{
+		"iso":         now.Format(time.RFC3339),
+		"unix":        now.Unix(),
+		"readable":    now.Format("3:04 PM on Monday, January 2, 2006"),
+		"hour":        now.Hour(),
+		"minute":      now.Minute(),
+		"day_of_week": now.Format("Monday"),
+	}, nil
+}
+
+// NewServer creates a new MCP test server.
+func NewServer() *Server {
+	s := &Server{
+		tools:    make(map[string]Tool),
+		sessions: make(map[string]*sseSession),
+	}
+	s.tools["roll_dice"] = &DiceRollTool{}
+	s.tools["echo"] = &EchoTool{}
+	s.tools["get_time"] = &TimeTool{}
+	return s
+}
+
+// ListTools returns all available tools.
+func (s *Server) ListTools() []map[string]any {
+	s.toolsMu.RLock()
+	defer s.toolsMu.RUnlock()
+
+	tools := make([]map[string]any, 0, len(s.tools))
+	for name, tool := range s.tools {
+		tools = append(tools, map[string]any{
+			"name":        name,
+			"description": tool.Description(),
+			"inputSchema": tool.InputSchema(),
+		})
+	}
+	return tools
+}
+
+// CallTool executes a tool by name.
+func (s *Server) CallTool(ctx context.Context, name string, args map[string]any) (any, error) {
+	s.toolsMu.RLock()
+	tool, ok := s.tools[name]
+	s.toolsMu.RUnlock()
+
+	if !ok {
+		return nil, fmt.Errorf("unknown tool: %s", name)
+	}
+	return tool.Execute(ctx, args)
+}
+
+// ServeHTTP implements http.Handler.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Enable CORS
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+
+	if r.Method == http.MethodOptions {
+		return
+	}
+
+	switch r.URL.Path {
+	case "/sse":
+		s.handleSSE(w, r)
+	case "/message":
+		s.handleMessage(w, r)
+	case "/tools":
+		s.handleToolsList(w, r)
+	default:
+		s.handleJSONRPC(w, r)
+	}
+}
+
+func (s *Server) handleToolsList(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(s.ListTools()); err != nil {
+		log.Printf("Failed to encode tools list: %v", err)
+	}
+}
+
+func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "SSE not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	sessionID := fmt.Sprintf("sess_%d", time.Now().UnixNano())
+	session := &sseSession{
+		id:       sessionID,
+		messages: make(chan []byte, 100),
+		done:     make(chan struct{}),
+	}
+
+	s.sessionsMu.Lock()
+	s.sessions[sessionID] = session
+	s.sessionsMu.Unlock()
+
+	defer func() {
+		s.sessionsMu.Lock()
+		delete(s.sessions, sessionID)
+		s.sessionsMu.Unlock()
+		close(session.done)
+	}()
+
+	// Send endpoint event
+	fmt.Fprintf(w, "event: endpoint\ndata: /message?sessionId=%s\n\n", sessionID)
+	flusher.Flush()
+
+	log.Printf("📤 SSE client connected: %s", sessionID)
+
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			log.Printf("📥 SSE client disconnected: %s", sessionID)
+			return
+		case msg := <-session.messages:
+			fmt.Fprintf(w, "event: message\ndata: %s\n\n", msg)
+			flusher.Flush()
+		case <-ticker.C:
+			fmt.Fprint(w, ": keepalive\n\n")
+			flusher.Flush()
+		}
+	}
+}
+
+func (s *Server) handleMessage(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	sessionID := r.URL.Query().Get("sessionId")
+
+	var req Request
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeError(w, nil, -32700, "parse error")
+		return
+	}
+
+	result, err := s.processRequest(r.Context(), &req)
+	if err != nil {
+		s.writeError(w, req.ID, err.Code, err.Message)
+		return
+	}
+
+	if sessionID != "" {
+		s.sessionsMu.RLock()
+		session, ok := s.sessions[sessionID]
+		s.sessionsMu.RUnlock()
+
+		if ok {
+			resp := Response{JSONRPC: "2.0", ID: req.ID, Result: result}
+			respBytes, _ := json.Marshal(resp)
+			select {
+			case session.messages <- respBytes:
+			case <-session.done:
+				log.Printf("Session closed before message sent: %s", sessionID)
+			case <-time.After(5 * time.Second):
+				log.Printf("Timeout sending message to session: %s", sessionID)
+			}
+		}
+	}
+
+	s.writeResult(w, req.ID, result)
+}
+
+func (s *Server) handleJSONRPC(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req Request
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeError(w, nil, -32700, "parse error")
+		return
+	}
+
+	result, err := s.processRequest(r.Context(), &req)
+	if err != nil {
+		s.writeError(w, req.ID, err.Code, err.Message)
+		return
+	}
+
+	s.writeResult(w, req.ID, result)
+}
+
+type jsonRPCError struct {
+	Code    int
+	Message string
+}
+
+func (s *Server) processRequest(ctx context.Context, req *Request) (any, *jsonRPCError) {
+	log.Printf("📨 Received: %s (id: %v)", req.Method, req.ID)
+
+	switch req.Method {
+	case "initialize":
+		return map[string]any{
+			"protocolVersion": "2024-11-05",
+			"serverInfo": map[string]any{
+				"name":    "mcp-test-server",
+				"version": "1.0.0",
+			},
+			"capabilities": map[string]any{
+				"tools": map[string]any{},
+			},
+		}, nil
+
+	case "tools/list":
+		return map[string]any{"tools": s.ListTools()}, nil
+
+	case "tools/call":
+		var params struct {
+			Name      string         `json:"name"`
+			Arguments map[string]any `json:"arguments"`
+		}
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return nil, &jsonRPCError{Code: -32602, Message: "invalid params"}
+		}
+
+		log.Printf("🔧 Calling tool: %s with args: %v", params.Name, params.Arguments)
+
+		result, err := s.CallTool(ctx, params.Name, params.Arguments)
+		if err != nil {
+			log.Printf("❌ Tool error: %v", err)
+			return nil, &jsonRPCError{Code: -32603, Message: err.Error()}
+		}
+
+		log.Printf("✅ Tool result: %v", result)
+		return map[string]any{
+			"content": []map[string]any{
+				{"type": "text", "text": mustMarshal(result)},
+			},
+		}, nil
+
+	case "ping":
+		return map[string]any{}, nil
+
+	default:
+		return nil, &jsonRPCError{Code: -32601, Message: "method not found"}
+	}
+}
+
+func (s *Server) writeResult(w http.ResponseWriter, id any, result any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(Response{JSONRPC: "2.0", ID: id, Result: result}); err != nil {
+		log.Printf("Failed to encode result: %v", err)
+	}
+}
+
+func (s *Server) writeError(w http.ResponseWriter, id any, code int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(Response{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &Error{Code: code, Message: message},
+	}); err != nil {
+		log.Printf("Failed to encode error: %v", err)
+	}
+}
+
+func mustMarshal(v any) string {
+	b, _ := json.MarshalIndent(v, "", "  ")
+	return string(b)
+}
+
+func main() {
+	port := flag.Int("port", 8082, "Port to listen on")
+	flag.Parse()
+
+	server := NewServer()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", *port)
+	log.Printf("🎲 MCP Test Server starting on http://%s", addr)
+	log.Printf("📋 Available tools:")
+	log.Printf("   - roll_dice: Roll dice and get random results")
+	log.Printf("   - echo: Echo back messages with enthusiasm!")
+	log.Printf("   - get_time: Get current time in various formats")
+	log.Printf("")
+	log.Printf("🔌 SSE endpoint: http://%s/sse", addr)
+	log.Printf("🔌 JSON-RPC endpoint: http://%s/", addr)
+	log.Printf("📋 Tools list: http://%s/tools", addr)
+	log.Printf("")
+	log.Printf("💡 Test with: curl http://%s/tools", addr)
+
+	//nolint:gosec // G114: timeouts not needed for test server
+	if err := http.ListenAndServe(addr, server); err != nil {
+		log.Fatalf("Server failed: %v", err)
+	}
+}

--- a/docs/opencode-config.md
+++ b/docs/opencode-config.md
@@ -95,6 +95,8 @@ opencode serve &>/tmp/opencode.log &
 
 When connected, the agent has access to these MCP tools:
 
+### Code Understanding Tools
+
 | Tool | Description |
 |------|-------------|
 | `search_code` | Search for code using semantic similarity |
@@ -102,6 +104,49 @@ When connected, the agent has access to these MCP tools:
 | `get_symbol` | Get type/function definition by name |
 | `get_structure` | Get project structure overview |
 | `review_code` | Request internal code review |
+
+### GitHub Integration Tools
+
+| Tool | Description |
+|------|-------------|
+| `create_pull_request` | Create a pull request with title, body, and branch |
+| `list_issues` | List repository issues with filtering options |
+| `get_issue` | Get detailed information about a specific issue |
+
+These tools allow agents to:
+1. Understand what needs to be implemented (`get_issue`, `list_issues`)
+2. Explore the codebase (`search_code`, `get_arch_context`, `get_symbol`)
+3. Validate changes (`review_code`)
+4. Submit work (`create_pull_request`)
+
+## Agent Modes
+
+### CLI Mode (Recommended)
+
+When `opencode_addr` is empty or not set, the agent uses CLI mode:
+
+```yaml
+agent:
+  enabled: true
+  opencode_addr: ""  # Empty = CLI mode
+```
+
+CLI mode is recommended because:
+- ✅ Actually executes commands (git, make, etc.)
+- ✅ Better integration with MCP tools
+- ✅ Simpler architecture
+
+### HTTP API Mode
+
+When `opencode_addr` is set, the agent uses HTTP API mode:
+
+```yaml
+agent:
+  enabled: true
+  opencode_addr: "http://127.0.0.1:4096"
+```
+
+⚠️ **Note**: HTTP API mode may not execute commands automatically. The agent responds to prompts but may not run shell commands or use MCP tools without additional configuration.
 
 ## Troubleshooting
 

--- a/docs/opencode-config.md
+++ b/docs/opencode-config.md
@@ -1,0 +1,146 @@
+# OpenCode Agent Configuration
+
+This document describes how to configure OpenCode to work with code-warden's MCP server.
+
+## Prerequisites
+
+1. **OpenCode installed** - Follow installation instructions at [opencode.ai](https://opencode.ai)
+2. **code-warden MCP server running** - The MCP server should be accessible at `http://127.0.0.1:8081`
+3. **Ollama running** (or other configured LLM provider) - Required for the agent to function
+
+## Configuration
+
+### OpenCode Config File
+
+Create or edit `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "ollama": {
+      "models": {
+        "qwen2.5-coder:latest": {
+          "name": "qwen2.5-coder:latest"
+        }
+      },
+      "name": "Ollama (local)",
+      "npm": "@ai-sdk/openai-compatible",
+      "options": {
+        "baseURL": "http://127.0.0.1:11434/v1"
+      }
+    }
+  },
+  "mcp": {
+    "code-warden": {
+      "type": "remote",
+      "url": "http://127.0.0.1:8081/sse",
+      "enabled": true
+    }
+  }
+}
+```
+
+### Configuration Fields
+
+| Field | Description | Required |
+|-------|-------------|----------|
+| `type` | Must be `"remote"` for SSE transport | Yes |
+| `url` | The MCP server endpoint (must end with `/sse`) | Yes |
+| `enabled` | Whether the MCP server is active | Yes |
+
+### Important Notes
+
+1. **URL format**: The URL must end with `/sse` for SSE transport. Using `"type": "sse"` is incorrect; use `"type": "remote"` instead.
+
+2. **Provider configuration**: You can use any supported LLM provider. The example shows Ollama with qwen2.5-coder.
+
+3. **MCP server URL**: The default MCP server address is `http://127.0.0.1:8081`. This can be changed in code-warden's `config.yaml`:
+
+```yaml
+agent:
+  enabled: true
+  mcp_addr: "127.0.0.1:8081"
+  opencode_addr: "http://127.0.0.1:4096"
+  model: "qwen2.5-coder"
+  timeout: "30m"
+  max_iterations: 3
+  working_dir: "/tmp/code-warden-agents"
+```
+
+## Starting the Services
+
+### Option 1: Using Makefile
+
+```bash
+# Start code-warden server
+make run
+
+# In another terminal, start OpenCode server (optional)
+make opencode-start
+```
+
+### Option 2: Manual Start
+
+```bash
+# Start code-warden
+./bin/code-warden
+
+# OpenCode will connect automatically when needed
+# Or start OpenCode server manually:
+opencode serve &>/tmp/opencode.log &
+```
+
+## MCP Tools Available
+
+When connected, the agent has access to these MCP tools:
+
+| Tool | Description |
+|------|-------------|
+| `search_code` | Search for code using semantic similarity |
+| `get_arch_context` | Get architectural summary for a directory |
+| `get_symbol` | Get type/function definition by name |
+| `get_structure` | Get project structure overview |
+| `review_code` | Request internal code review |
+
+## Troubleshooting
+
+### MCP Tools Not Discovered
+
+If OpenCode connects but doesn't use MCP tools:
+
+1. Verify config format uses `"type": "remote"` not `"type": "sse"`
+2. Verify URL ends with `/sse`
+3. Check code-warden logs for "MCP tool call" messages
+
+### Connection Refused
+
+1. Ensure code-warden is running
+2. Verify `agent.mcp_addr` matches in config
+3. Check firewall settings
+
+### Session Timeout
+
+Default timeout is 30 minutes. Adjust in `config.yaml`:
+
+```yaml
+agent:
+  timeout: "60m"  # Increase timeout for complex issues
+```
+
+## Security Considerations
+
+1. **Local binding only**: MCP server binds to `127.0.0.1` by default
+2. **No authentication**: MCP server has no authentication - only use on trusted networks
+3. **Branch sanitization**: Agent branch names are sanitized to prevent injection
+4. **Shell command safety**: Git commands use proper escaping
+
+## Example Session Flow
+
+1. Agent receives issue via `/implement` comment on GitHub
+2. Agent connects to MCP server
+3. Agent explores codebase using MCP tools
+4. Agent implements changes
+5. Agent runs `make lint` and `make test` (mandatory)
+6. Agent calls `review_code` tool
+7. Agent creates pull request

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 )
 
 require (
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/google/pprof v0.0.0-20230207041349-798e818bf904 h1:4/hN5RUoecvl+RmJRE
 github.com/google/pprof v0.0.0-20230207041349-798e818bf904/go.mod h1:uglQLonpP8qtYCYyzA+8c/9qtqgA3qsXGYqCPKARAFg=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/internal/agent/opencode_client.go
+++ b/internal/agent/opencode_client.go
@@ -9,9 +9,31 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 )
+
+// safeBranchNameRegex validates that branch names contain only safe characters.
+var safeBranchNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._/-]*$`)
+
+// shellQuote safely quotes a string for shell execution by wrapping in single quotes
+// and escaping any existing single quotes.
+func shellQuote(s string) string {
+	// Replace single quotes with '\'' (end quote, escaped quote, start quote)
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+// validateBranchName checks if a branch name is safe for shell execution.
+func validateBranchName(name string) error {
+	if name == "" {
+		return fmt.Errorf("branch name cannot be empty")
+	}
+	if !safeBranchNameRegex.MatchString(name) {
+		return fmt.Errorf("invalid branch name: contains unsafe characters")
+	}
+	return nil
+}
 
 // OpenCodeClient handles communication with the OpenCode HTTP API.
 type OpenCodeClient struct {
@@ -241,7 +263,10 @@ func (c *OpenCodeClient) ExecuteCommand(ctx context.Context, sessionID, command 
 
 // CreateBranch creates a new git branch.
 func (c *OpenCodeClient) CreateBranch(ctx context.Context, sessionID, branchName string) error {
-	_, err := c.ExecuteCommand(ctx, sessionID, "git checkout -b "+branchName)
+	if err := validateBranchName(branchName); err != nil {
+		return fmt.Errorf("invalid branch name: %w", err)
+	}
+	_, err := c.ExecuteCommand(ctx, sessionID, "git checkout -b "+shellQuote(branchName))
 	return err
 }
 
@@ -252,26 +277,47 @@ func (c *OpenCodeClient) CommitChanges(ctx context.Context, sessionID, message s
 		return fmt.Errorf("failed to stage changes: %w", err)
 	}
 
-	// Commit with message
-	_, err := c.ExecuteCommand(ctx, sessionID, fmt.Sprintf("git commit -m %q", message))
+	// Commit with properly escaped message
+	_, err := c.ExecuteCommand(ctx, sessionID, "git commit -m "+shellQuote(message))
 	return err
 }
 
 // PushBranch pushes the current branch to remote.
 func (c *OpenCodeClient) PushBranch(ctx context.Context, sessionID, branchName string) error {
-	_, err := c.ExecuteCommand(ctx, sessionID, "git push -u origin "+branchName)
+	if err := validateBranchName(branchName); err != nil {
+		return fmt.Errorf("invalid branch name: %w", err)
+	}
+	_, err := c.ExecuteCommand(ctx, sessionID, "git push -u origin "+shellQuote(branchName))
 	return err
 }
 
-// CreatePullRequest creates a PR via gh CLI.
+// CreatePullRequest creates a PR via gh CLI and returns the PR URL and number.
 func (c *OpenCodeClient) CreatePullRequest(ctx context.Context, sessionID, title, body string) (string, int, error) {
-	cmd := fmt.Sprintf("gh pr create --title %q --body %q", title, body)
-	_, err := c.ExecuteCommand(ctx, sessionID, cmd)
+	// Use --json flag to get structured output
+	cmd := fmt.Sprintf("gh pr create --title %q --body %q --json url,number", title, body)
+	resp, err := c.ExecuteCommand(ctx, sessionID, cmd)
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to create PR: %w", err)
 	}
 
-	return "PR created successfully", 0, nil // PR number extraction would require parsing parts
+	// Parse the JSON response from gh
+	var prResult struct {
+		URL    string `json:"url"`
+		Number int    `json:"number"`
+	}
+	// The response comes as Parts from ExecuteCommand, we need to extract the JSON
+	// For now, we parse the text content
+	for _, part := range resp.Parts {
+		if part.Type == "text" {
+			if err := json.Unmarshal([]byte(part.Text), &prResult); err != nil {
+				c.logger.Warn("failed to parse PR response, returning default", "error", err)
+				return "PR created (URL not parsed)", 0, nil
+			}
+			return prResult.URL, prResult.Number, nil
+		}
+	}
+
+	return "PR created successfully", 0, nil
 }
 
 // CloseSession closes a session.

--- a/internal/agent/opencode_client.go
+++ b/internal/agent/opencode_client.go
@@ -1,0 +1,287 @@
+// Package agent provides the OpenCode client for interacting with the OpenCode server.
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// OpenCodeClient handles communication with the OpenCode HTTP API.
+type OpenCodeClient struct {
+	baseURL    string
+	password   string
+	httpClient *http.Client
+	logger     *slog.Logger
+}
+
+// NewOpenCodeClient creates a new OpenCode API client.
+func NewOpenCodeClient(baseURL, password string, logger *slog.Logger) *OpenCodeClient {
+	if baseURL != "" && !strings.HasPrefix(baseURL, "http://") && !strings.HasPrefix(baseURL, "https://") {
+		baseURL = "http://" + baseURL
+	}
+
+	return &OpenCodeClient{
+		baseURL:  baseURL,
+		password: password,
+		logger:   logger,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Minute, // Match the session timeout for LLM operations
+		},
+	}
+}
+
+// OpenCodeSession represents an OpenCode session.
+type OpenCodeSession struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	Status    string `json:"status"`
+	CreatedAt string `json:"created_at"`
+}
+
+// Message represents a message in a session.
+type Message struct {
+	ID        string `json:"id"`
+	Role      string `json:"role"`
+	Content   string `json:"content"`
+	CreatedAt string `json:"created_at"`
+}
+
+// CreateSessionRequest is the body for creating a session.
+type CreateSessionRequest struct {
+	Title string            `json:"title"`
+	Model string            `json:"model,omitempty"`
+	Env   map[string]string `json:"env,omitempty"`
+}
+
+// Part represents a content part in a message.
+type Part struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+// ModelConfig specifies the model and provider for a request.
+type ModelConfig struct {
+	ProviderID string `json:"providerID"`
+	ModelID    string `json:"modelID"`
+}
+
+// SendMessageRequest is the body for sending a message.
+type SendMessageRequest struct {
+	Agent  string           `json:"agent,omitempty"`
+	Model  *ModelConfig     `json:"model,omitempty"`
+	Parts  []Part           `json:"parts"`
+	Tools  []ToolDefinition `json:"tools,omitempty"`
+	Stream bool             `json:"stream,omitempty"`
+}
+
+// ToolDefinition defines a tool for the agent.
+type ToolDefinition struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	Parameters  map[string]interface{} `json:"parameters"`
+}
+
+// SendMessageResponse is the response from sending a message.
+type SendMessageResponse struct {
+	Info  Message `json:"info"`
+	Parts []Part  `json:"parts"`
+}
+
+// ShellRequest is the body for executing a shell command.
+type ShellRequest struct {
+	Agent   string       `json:"agent"`
+	Model   *ModelConfig `json:"model,omitempty"`
+	Command string       `json:"command"`
+}
+
+// doRequest performs an HTTP request with authentication.
+func (c *OpenCodeClient) doRequest(ctx context.Context, method, path string, body interface{}) ([]byte, error) {
+	var reqBody io.Reader
+	if body != nil {
+		jsonData, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		reqBody = bytes.NewReader(jsonData)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.password)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		c.logger.Error("API request failed", "method", method, "path", path, "status", resp.StatusCode, "response", string(respBody))
+		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	c.logger.Debug("API response received", "method", method, "path", path, "status", resp.StatusCode, "size", len(respBody))
+	return respBody, nil
+}
+
+// CreateSession creates a new OpenCode session.
+func (c *OpenCodeClient) CreateSession(ctx context.Context, title, model string, env map[string]string) (*OpenCodeSession, error) {
+	req := CreateSessionRequest{
+		Title: title,
+		Model: model,
+		Env:   env,
+	}
+
+	respBody, err := c.doRequest(ctx, http.MethodPost, "/session", req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create session: %w", err)
+	}
+
+	var session OpenCodeSession
+	if err := json.Unmarshal(respBody, &session); err != nil {
+		return nil, fmt.Errorf("failed to parse session response: %w", err)
+	}
+
+	return &session, nil
+}
+
+// SendMessage sends a message to a session and returns the response.
+func (c *OpenCodeClient) SendMessage(ctx context.Context, sessionID string, content string, tools []ToolDefinition) (*SendMessageResponse, error) {
+	req := SendMessageRequest{
+		Agent:  "build", // Use the "build" agent per curl defaults
+		Parts:  []Part{{Type: "text", Text: content}},
+		Tools:  tools,
+		Stream: false,
+	}
+
+	respBody, err := c.doRequest(ctx, http.MethodPost, "/session/"+sessionID+"/message", req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send message: %w", err)
+	}
+
+	c.logger.Debug("Raw SendMessage response", "response", string(respBody))
+
+	var response SendMessageResponse
+	if len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, &response); err != nil {
+			return nil, fmt.Errorf("failed to parse message response: %w", err)
+		}
+	}
+
+	return &response, nil
+}
+
+// GetSession retrieves session information.
+func (c *OpenCodeClient) GetSession(ctx context.Context, sessionID string) (*OpenCodeSession, error) {
+	respBody, err := c.doRequest(ctx, http.MethodGet, "/session/"+sessionID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get session: %w", err)
+	}
+
+	var session OpenCodeSession
+	if err := json.Unmarshal(respBody, &session); err != nil {
+		return nil, fmt.Errorf("failed to parse session response: %w", err)
+	}
+
+	return &session, nil
+}
+
+// GetMessages retrieves all messages in a session.
+func (c *OpenCodeClient) GetMessages(ctx context.Context, sessionID string) ([]Message, error) {
+	respBody, err := c.doRequest(ctx, http.MethodGet, "/session/"+sessionID+"/message", nil) // Use /message instead of /messages as per spec
+	if err != nil {
+		return nil, fmt.Errorf("failed to get messages: %w", err)
+	}
+
+	var messages []Message
+	if err := json.Unmarshal(respBody, &messages); err != nil {
+		return nil, fmt.Errorf("failed to parse messages response: %w", err)
+	}
+
+	return messages, nil
+}
+
+// ExecuteCommand runs a shell command in the session context.
+func (c *OpenCodeClient) ExecuteCommand(ctx context.Context, sessionID, command string) (*SendMessageResponse, error) {
+	req := ShellRequest{
+		Agent:   "build",
+		Command: command,
+	}
+
+	respBody, err := c.doRequest(ctx, http.MethodPost, "/session/"+sessionID+"/shell", req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute shell command: %w", err)
+	}
+
+	var response SendMessageResponse
+	if len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, &response); err != nil {
+			return nil, fmt.Errorf("failed to parse shell response: %w", err)
+		}
+	}
+
+	return &response, nil
+}
+
+// CreateBranch creates a new git branch.
+func (c *OpenCodeClient) CreateBranch(ctx context.Context, sessionID, branchName string) error {
+	_, err := c.ExecuteCommand(ctx, sessionID, "git checkout -b "+branchName)
+	return err
+}
+
+// CommitChanges commits all staged changes.
+func (c *OpenCodeClient) CommitChanges(ctx context.Context, sessionID, message string) error {
+	// Stage all changes first
+	if _, err := c.ExecuteCommand(ctx, sessionID, "git add -A"); err != nil {
+		return fmt.Errorf("failed to stage changes: %w", err)
+	}
+
+	// Commit with message
+	_, err := c.ExecuteCommand(ctx, sessionID, fmt.Sprintf("git commit -m %q", message))
+	return err
+}
+
+// PushBranch pushes the current branch to remote.
+func (c *OpenCodeClient) PushBranch(ctx context.Context, sessionID, branchName string) error {
+	_, err := c.ExecuteCommand(ctx, sessionID, "git push -u origin "+branchName)
+	return err
+}
+
+// CreatePullRequest creates a PR via gh CLI.
+func (c *OpenCodeClient) CreatePullRequest(ctx context.Context, sessionID, title, body string) (string, int, error) {
+	cmd := fmt.Sprintf("gh pr create --title %q --body %q", title, body)
+	_, err := c.ExecuteCommand(ctx, sessionID, cmd)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to create PR: %w", err)
+	}
+
+	return "PR created successfully", 0, nil // PR number extraction would require parsing parts
+}
+
+// CloseSession closes a session.
+func (c *OpenCodeClient) CloseSession(ctx context.Context, sessionID string) error {
+	_, err := c.doRequest(ctx, http.MethodDelete, "/session/"+sessionID, nil)
+	return err
+}
+
+// HealthCheck checks if the server is ready.
+func (c *OpenCodeClient) HealthCheck(ctx context.Context) error {
+	_, err := c.doRequest(ctx, http.MethodGet, "/global/health", nil)
+	return err
+}

--- a/internal/agent/opencode_client.go
+++ b/internal/agent/opencode_client.go
@@ -1,4 +1,10 @@
-// Package agent provides the OpenCode client for interacting with the OpenCode server.
+// Package agent provides the OpenCode HTTP client and orchestrator for autonomous coding.
+// It handles communication with the OpenCode server for executing agent tasks like
+// creating branches, committing changes, and creating pull requests.
+//
+// The package supports two modes:
+//   - CLI mode: Executes OpenCode CLI directly (recommended for actual code execution)
+//   - HTTP API mode: Communicates with OpenCode server via HTTP (for remote execution)
 package agent
 
 import (
@@ -15,11 +21,17 @@ import (
 	"time"
 )
 
-// safeBranchNameRegex validates that branch names contain only safe characters.
-var safeBranchNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._/-]*$`)
+// Input validation constants.
+const (
+	// maxBranchNameLength is the maximum length for git branch names (git limit is 255 bytes).
+	maxBranchNameLength = 255
+	// DefaultAgent is the default OpenCode agent type.
+	DefaultAgent = "build"
+)
 
-// maxBranchNameLength is the maximum length for git branch names.
-const maxBranchNameLength = 255
+// safeBranchNameRegex validates that branch names contain only safe characters.
+// This prevents shell injection and ensures valid git branch names.
+var safeBranchNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._/-]*$`)
 
 // shellQuote safely quotes a string for shell execution by wrapping in single quotes
 // and escaping any existing single quotes.
@@ -60,9 +72,6 @@ func (e *APIError) Error() string {
 	}
 	return fmt.Sprintf("API error (status %d): %s", e.StatusCode, e.Message)
 }
-
-// DefaultAgent is the default OpenCode agent type.
-const DefaultAgent = "build"
 
 // OpenCodeClient handles communication with the OpenCode HTTP API.
 type OpenCodeClient struct {

--- a/internal/agent/opencode_client.go
+++ b/internal/agent/opencode_client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"regexp"
 	"strings"
@@ -17,8 +18,33 @@ import (
 // safeBranchNameRegex validates that branch names contain only safe characters.
 var safeBranchNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._/-]*$`)
 
-// DefaultAgent is the default OpenCode agent type.
-const DefaultAgent = "build"
+// maxBranchNameLength is the maximum length for git branch names.
+const maxBranchNameLength = 255
+
+// shellQuote safely quotes a string for shell execution by wrapping in single quotes
+// and escaping any existing single quotes.
+func shellQuote(s string) string {
+	// Replace single quotes with '\'' (end quote, escaped quote, start quote)
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+// validateBranchName checks if a branch name is safe for shell execution.
+func validateBranchName(name string) error {
+	if name == "" {
+		return fmt.Errorf("branch name cannot be empty")
+	}
+	if len(name) > maxBranchNameLength {
+		return fmt.Errorf("branch name exceeds maximum length of %d bytes", maxBranchNameLength)
+	}
+	if !safeBranchNameRegex.MatchString(name) {
+		return fmt.Errorf("invalid branch name: contains unsafe characters")
+	}
+	// Check for consecutive dots which could lead to directory traversal
+	if strings.Contains(name, "..") {
+		return fmt.Errorf("branch name cannot contain consecutive dots")
+	}
+	return nil
+}
 
 // APIError represents an error response from the OpenCode API.
 type APIError struct {
@@ -35,23 +61,8 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("API error (status %d): %s", e.StatusCode, e.Message)
 }
 
-// shellQuote safely quotes a string for shell execution by wrapping in single quotes
-// and escaping any existing single quotes.
-func shellQuote(s string) string {
-	// Replace single quotes with '\'' (end quote, escaped quote, start quote)
-	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
-}
-
-// validateBranchName checks if a branch name is safe for shell execution.
-func validateBranchName(name string) error {
-	if name == "" {
-		return fmt.Errorf("branch name cannot be empty")
-	}
-	if !safeBranchNameRegex.MatchString(name) {
-		return fmt.Errorf("invalid branch name: contains unsafe characters")
-	}
-	return nil
-}
+// DefaultAgent is the default OpenCode agent type.
+const DefaultAgent = "build"
 
 // OpenCodeClient handles communication with the OpenCode HTTP API.
 type OpenCodeClient struct {
@@ -79,9 +90,15 @@ func NewOpenCodeClient(baseURL, password string, logger *slog.Logger) *OpenCodeC
 		// No global timeout - use context for per-request timeouts
 		HTTPClient: &http.Client{
 			Transport: &http.Transport{
-				MaxIdleConns:       10,
-				IdleConnTimeout:    30 * time.Second,
-				DisableCompression: false,
+				DialContext: (&net.Dialer{
+					Timeout:   30 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).DialContext,
+				MaxIdleConns:          10,
+				IdleConnTimeout:       30 * time.Second,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+				DisableCompression:    false,
 			},
 		},
 	}
@@ -308,8 +325,12 @@ func (c *OpenCodeClient) GetMessages(ctx context.Context, sessionID string) ([]M
 
 // ExecuteCommand runs a shell command in the session context.
 func (c *OpenCodeClient) ExecuteCommand(ctx context.Context, sessionID, command string) (*SendMessageResponse, error) {
+	agent := c.Agent
+	if agent == "" {
+		agent = DefaultAgent
+	}
 	req := ShellRequest{
-		Agent:   "build",
+		Agent:   agent,
 		Command: command,
 	}
 

--- a/internal/agent/opencode_client.go
+++ b/internal/agent/opencode_client.go
@@ -17,6 +17,24 @@ import (
 // safeBranchNameRegex validates that branch names contain only safe characters.
 var safeBranchNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._/-]*$`)
 
+// DefaultAgent is the default OpenCode agent type.
+const DefaultAgent = "build"
+
+// APIError represents an error response from the OpenCode API.
+type APIError struct {
+	StatusCode int
+	Message    string
+	Type       string `json:"type,omitempty"`
+	Code       string `json:"code,omitempty"`
+}
+
+func (e *APIError) Error() string {
+	if e.Code != "" {
+		return fmt.Sprintf("API error (status %d, code %s): %s", e.StatusCode, e.Code, e.Message)
+	}
+	return fmt.Sprintf("API error (status %d): %s", e.StatusCode, e.Message)
+}
+
 // shellQuote safely quotes a string for shell execution by wrapping in single quotes
 // and escaping any existing single quotes.
 func shellQuote(s string) string {
@@ -37,13 +55,17 @@ func validateBranchName(name string) error {
 
 // OpenCodeClient handles communication with the OpenCode HTTP API.
 type OpenCodeClient struct {
-	baseURL    string
-	password   string
-	httpClient *http.Client
-	logger     *slog.Logger
+	baseURL  string
+	password string
+	logger   *slog.Logger
+	// Agent is the OpenCode agent type to use (default: "build").
+	Agent string
+	// HTTPClient is the HTTP client for requests (uses context for timeouts).
+	HTTPClient *http.Client
 }
 
 // NewOpenCodeClient creates a new OpenCode API client.
+// The client uses context-driven timeouts instead of a global timeout.
 func NewOpenCodeClient(baseURL, password string, logger *slog.Logger) *OpenCodeClient {
 	if baseURL != "" && !strings.HasPrefix(baseURL, "http://") && !strings.HasPrefix(baseURL, "https://") {
 		baseURL = "http://" + baseURL
@@ -53,8 +75,14 @@ func NewOpenCodeClient(baseURL, password string, logger *slog.Logger) *OpenCodeC
 		baseURL:  baseURL,
 		password: password,
 		logger:   logger,
-		httpClient: &http.Client{
-			Timeout: 30 * time.Minute, // Match the session timeout for LLM operations
+		Agent:    DefaultAgent,
+		// No global timeout - use context for per-request timeouts
+		HTTPClient: &http.Client{
+			Transport: &http.Transport{
+				MaxIdleConns:       10,
+				IdleConnTimeout:    30 * time.Second,
+				DisableCompression: false,
+			},
 		},
 	}
 }
@@ -142,7 +170,7 @@ func (c *OpenCodeClient) doRequest(ctx context.Context, method, path string, bod
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.password)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
@@ -154,12 +182,47 @@ func (c *OpenCodeClient) doRequest(ctx context.Context, method, path string, bod
 	}
 
 	if resp.StatusCode >= 400 {
-		c.logger.Error("API request failed", "method", method, "path", path, "status", resp.StatusCode, "response", string(respBody))
-		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
+		return nil, c.parseAPIError(resp.StatusCode, respBody, method, path)
 	}
 
 	c.logger.Debug("API response received", "method", method, "path", path, "status", resp.StatusCode, "size", len(respBody))
 	return respBody, nil
+}
+
+// parseAPIError parses an error response from the OpenCode API.
+func (c *OpenCodeClient) parseAPIError(statusCode int, respBody []byte, method, path string) *APIError {
+	apiErr := &APIError{StatusCode: statusCode}
+
+	if len(respBody) == 0 {
+		apiErr.Message = "empty response body"
+		c.logger.Error("API request failed", "method", method, "path", path, "status", statusCode, "response", "")
+		return apiErr
+	}
+
+	// Try structured error format
+	var structuredErr struct {
+		Type    string `json:"type"`
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(respBody, &structuredErr); err == nil && structuredErr.Message != "" {
+		apiErr.Type = structuredErr.Type
+		apiErr.Code = structuredErr.Code
+		apiErr.Message = structuredErr.Message
+	} else {
+		// Try simple error format
+		var simpleErr struct {
+			Error string `json:"error"`
+		}
+		if err := json.Unmarshal(respBody, &simpleErr); err == nil && simpleErr.Error != "" {
+			apiErr.Message = simpleErr.Error
+		} else {
+			apiErr.Message = string(respBody)
+		}
+	}
+
+	c.logger.Error("API request failed", "method", method, "path", path, "status", statusCode, "response", string(respBody))
+	return apiErr
 }
 
 // CreateSession creates a new OpenCode session.
@@ -185,8 +248,12 @@ func (c *OpenCodeClient) CreateSession(ctx context.Context, title, model string,
 
 // SendMessage sends a message to a session and returns the response.
 func (c *OpenCodeClient) SendMessage(ctx context.Context, sessionID string, content string, tools []ToolDefinition) (*SendMessageResponse, error) {
+	agent := c.Agent
+	if agent == "" {
+		agent = DefaultAgent
+	}
 	req := SendMessageRequest{
-		Agent:  "build", // Use the "build" agent per curl defaults
+		Agent:  agent,
 		Parts:  []Part{{Type: "text", Text: content}},
 		Tools:  tools,
 		Stream: false,
@@ -292,6 +359,7 @@ func (c *OpenCodeClient) PushBranch(ctx context.Context, sessionID, branchName s
 }
 
 // CreatePullRequest creates a PR via gh CLI and returns the PR URL and number.
+// Returns an error if the PR was created but the response couldn't be parsed.
 func (c *OpenCodeClient) CreatePullRequest(ctx context.Context, sessionID, title, body string) (string, int, error) {
 	// Use --json flag to get structured output
 	cmd := fmt.Sprintf("gh pr create --title %q --body %q --json url,number", title, body)
@@ -306,18 +374,20 @@ func (c *OpenCodeClient) CreatePullRequest(ctx context.Context, sessionID, title
 		Number int    `json:"number"`
 	}
 	// The response comes as Parts from ExecuteCommand, we need to extract the JSON
-	// For now, we parse the text content
 	for _, part := range resp.Parts {
 		if part.Type == "text" {
 			if err := json.Unmarshal([]byte(part.Text), &prResult); err != nil {
-				c.logger.Warn("failed to parse PR response, returning default", "error", err)
-				return "PR created (URL not parsed)", 0, nil
+				// Return explicit error - PR may have been created but we couldn't parse the response
+				return "", 0, fmt.Errorf("PR may have been created but failed to parse response: %w (raw: %s)", err, part.Text)
+			}
+			if prResult.URL == "" || prResult.Number == 0 {
+				return "", 0, fmt.Errorf("PR response missing required fields: url=%q, number=%d", prResult.URL, prResult.Number)
 			}
 			return prResult.URL, prResult.Number, nil
 		}
 	}
 
-	return "PR created successfully", 0, nil
+	return "", 0, fmt.Errorf("no text response found in PR creation result")
 }
 
 // CloseSession closes a session.

--- a/internal/agent/opencode_client_manual_test.go
+++ b/internal/agent/opencode_client_manual_test.go
@@ -1,0 +1,33 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+)
+
+func TestOpenCodeClient_Manual(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	client := NewOpenCodeClient("http://127.0.0.1:4096", "", logger)
+	ctx := context.Background()
+
+	err := client.HealthCheck(ctx)
+	if err != nil {
+		t.Fatalf("Health check failed: %v", err)
+	}
+	fmt.Println("Health check passed.")
+
+	session, err := client.CreateSession(ctx, "Test Session", "", nil)
+	if err != nil {
+		t.Fatalf("Create session failed: %v", err)
+	}
+	fmt.Printf("Created session: %s\n", session.ID)
+
+	resp, err := client.SendMessage(ctx, session.ID, "echo 'Testing command execution'", nil)
+	if err != nil {
+		t.Fatalf("SendMessage failed: %v", err)
+	}
+	fmt.Printf("Message executed successfully, text response length: %d\n", len(resp.Info.Content))
+}

--- a/internal/agent/opencode_client_manual_test.go
+++ b/internal/agent/opencode_client_manual_test.go
@@ -1,3 +1,6 @@
+//go:build manual
+// +build manual
+
 package agent
 
 import (

--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -130,16 +131,39 @@ func (o *Orchestrator) Start() error {
 		IdleTimeout:       120 * time.Second,
 	}
 
+	// Use a channel to signal when the server is ready
+	ready := make(chan struct{})
+
 	go func() {
+		// Create a listener to know when the server is actually bound
+		listenConfig := net.ListenConfig{}
+		ln, err := listenConfig.Listen(context.Background(), "tcp", o.config.MCPAddr)
+		if err != nil {
+			o.logger.Error("failed to create MCP server listener", "error", err, "addr", o.config.MCPAddr)
+			close(ready)
+			return
+		}
+		close(ready)
+
 		o.logger.Info("starting MCP HTTP server",
 			"addr", o.config.MCPAddr,
 			"provider", o.config.Provider,
 			"model", o.config.Model)
 
-		if err := o.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := o.httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
 			o.logger.Error("MCP HTTP server failed", "error", err, "addr", o.config.MCPAddr)
 		}
 	}()
+
+	// Wait for the server to be ready (with timeout)
+	select {
+	case <-ready:
+		// Small delay to ensure the server is fully ready
+		time.Sleep(100 * time.Millisecond)
+		o.logger.Info("MCP HTTP server is ready", "addr", o.config.MCPAddr)
+	case <-time.After(5 * time.Second):
+		return fmt.Errorf("timeout waiting for MCP server to start")
+	}
 
 	// Start session cleanup goroutine
 	go o.cleanupLoop()

--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -584,23 +584,28 @@ func (o *Orchestrator) buildSystemPrompt(issue Issue) string {
   - review_code(diff) - Request internal code review
 
 ## Your Task
-Implement the issue described below. Follow these steps:
+Implement the issue described below. Follow these steps IN ORDER:
 
 1. **Understand** - Read the issue carefully
 2. **Explore** - Use MCP tools to understand the codebase
 3. **Plan** - Identify files to modify and changes needed
 4. **Implement** - Write the code
-5. **Verify** - Run 'make lint' and 'make test' - fix any issues before proceeding
+5. **STOP AND VERIFY** - You MUST run these commands before proceeding:
+   - Run: make lint
+   - Run: make test
+   - If EITHER command fails, you MUST fix the issues and run BOTH commands again
+   - Only proceed when BOTH commands pass with exit code 0
 6. **Review** - Call review_code on your changes
 7. **Iterate** - If REQUEST_CHANGES, fix issues, run lint/test again, and review again
-8. **Submit** - Create a pull request when APPROVED
+8. **Submit** - Create a pull request ONLY after steps 5-7 are complete
 
-## CRITICAL: Before Committing
-You MUST run these commands and ensure they pass:
-- 'make lint' - All linting errors must be fixed
-- 'make test' - All tests must pass
+## MANDATORY REQUIREMENTS (DO NOT SKIP):
+1. You MUST run 'make lint' and it MUST pass (exit code 0)
+2. You MUST run 'make test' and it MUST pass (exit code 0)
+3. You MUST call review_code tool for code review
+4. You MUST NOT create a PR until all above steps pass
 
-Do NOT commit or create a PR until both commands succeed.
+If you cannot complete any step, report what failed and why.
 
 ## Issue #%d: %s
 

--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -672,14 +672,19 @@ func (o *Orchestrator) buildOpenCodeCommand(ctx context.Context, issue Issue, sy
 	cmd := exec.CommandContext(ctx, "opencode",
 		"run",
 		"--model", o.config.Model,
+		"--agent", "build",
 		systemPrompt,
 	)
 
 	// Set working directory to the repository path
 	cmd.Dir = o.projectRoot
 
+	// Dynamically configure MCP server for this run
+	mcpConfig := fmt.Sprintf(`{"mcp": {"code-warden": {"type": "remote", "url": "http://%s/sse", "enabled": true}}}`, o.config.MCPAddr)
+
 	// Set environment variables for MCP and iteration config
 	cmd.Env = append(os.Environ(),
+		"OPENCODE_CONFIG_CONTENT="+mcpConfig,
 		"OPENCODE_MCP_SERVER="+o.config.MCPAddr,
 		"OPENCODE_MAX_ITERATIONS="+fmt.Sprintf("%d", o.config.MaxIterations),
 		"OPENCODE_BRANCH="+branch,

--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -57,6 +57,9 @@ type Config struct {
 	// MCPAddr is the address for the MCP server.
 	MCPAddr string `yaml:"mcp_addr"`
 
+	// OpencodeAddr is the address for the OpenCode HTTP API.
+	OpencodeAddr string `yaml:"opencode_addr"`
+
 	// WorkingDir is the directory for agent workspaces.
 	WorkingDir string `yaml:"working_dir"`
 }
@@ -70,6 +73,7 @@ func DefaultConfig() Config {
 		Timeout:       30 * time.Minute,
 		MaxIterations: 3,
 		MCPAddr:       "127.0.0.1:8081", // Bind to localhost only for security
+		OpencodeAddr:  "http://127.0.0.1:8000",
 		WorkingDir:    "/tmp/code-warden-agents",
 	}
 }
@@ -419,10 +423,19 @@ func (o *Orchestrator) runAgent(ctx context.Context, session *Session) {
 		"session_id", session.ID,
 		"branch", branch)
 
+	if o.config.OpencodeAddr != "" {
+		o.runAgentAPI(ctx, session, systemPrompt, branch)
+	} else {
+		o.runAgentCLI(ctx, session, systemPrompt, branch)
+	}
+}
+
+// runAgentCLI executes the agent workflow using the local OpenCode binary.
+func (o *Orchestrator) runAgentCLI(ctx context.Context, session *Session, systemPrompt, branch string) {
 	// Build OpenCode command
 	cmd := o.buildOpenCodeCommand(ctx, session.Issue, systemPrompt, branch)
 
-	o.logger.Info("runAgent: starting OpenCode process",
+	o.logger.Info("runAgentCLI: starting OpenCode process",
 		"session_id", session.ID,
 		"command", cmd.String(),
 		"working_dir", cmd.Dir,
@@ -436,7 +449,7 @@ func (o *Orchestrator) runAgent(ctx context.Context, session *Session) {
 		session.mu.Lock()
 		session.CompletedAt = time.Now()
 		session.mu.Unlock()
-		o.logger.Error("runAgent: agent process failed",
+		o.logger.Error("runAgentCLI: agent process failed",
 			"session_id", session.ID,
 			"error", err,
 			"output_length", len(output),
@@ -444,7 +457,7 @@ func (o *Orchestrator) runAgent(ctx context.Context, session *Session) {
 		return
 	}
 
-	o.logger.Info("runAgent: agent process completed successfully",
+	o.logger.Info("runAgentCLI: agent process completed successfully",
 		"session_id", session.ID,
 		"output_length", len(output))
 
@@ -457,7 +470,7 @@ func (o *Orchestrator) runAgent(ctx context.Context, session *Session) {
 	session.CompletedAt = time.Now()
 	session.mu.Unlock()
 
-	o.logger.Info("runAgent: agent session completed successfully",
+	o.logger.Info("runAgentCLI: agent session completed successfully",
 		"session_id", session.ID,
 		"pr_number", result.PRNumber,
 		"pr_url", result.PRURL,
@@ -465,6 +478,96 @@ func (o *Orchestrator) runAgent(ctx context.Context, session *Session) {
 		"files_changed", len(result.FilesChanged),
 		"iterations", result.Iterations,
 		"verdict", result.Verdict,
+		"duration", session.CompletedAt.Sub(session.StartedAt))
+}
+
+// runAgentAPI executes the agent workflow using the OpenCode HTTP API.
+func (o *Orchestrator) runAgentAPI(ctx context.Context, session *Session, systemPrompt, branch string) {
+	o.logger.Info("runAgentAPI: starting OpenCode API workflow", "session_id", session.ID, "api_url", o.config.OpencodeAddr)
+
+	client := NewOpenCodeClient(o.config.OpencodeAddr, "", o.logger)
+
+	// 1. Health check
+	if err := client.HealthCheck(ctx); err != nil {
+		o.failSessionf(session, "OpenCode API health check failed: %v", err)
+		o.logger.Error("runAgentAPI: health check failed", "session_id", session.ID, "error", err)
+		return
+	}
+
+	// 2. Verify MCP server is configured in OpenCode (best effort)
+	if err := o.verifyMCPConfig(ctx); err != nil {
+		o.logger.Warn("runAgentAPI: MCP server 'code-warden' may not be configured in OpenCode",
+			"error", err,
+			"hint", "Add MCP server to ~/.config/opencode/opencode.json or run: opencode mcp list")
+	}
+
+	// 3. Create session
+	title := fmt.Sprintf("Issue %d: %s", session.Issue.Number, session.Issue.Title)
+	opencodeSession, err := client.CreateSession(ctx, title, o.config.Model, nil)
+	if err != nil {
+		o.failSessionf(session, "Failed to create OpenCode session: %v", err)
+		o.logger.Error("runAgentAPI: failed to create session", "session_id", session.ID, "error", err)
+		return
+	}
+	o.logger.Info("runAgentAPI: created OpenCode session", "session_id", session.ID, "opencode_session_id", opencodeSession.ID)
+
+	// 4. Execute agent workflow
+	if !o.executeAgentWorkflow(ctx, session, client, opencodeSession.ID, systemPrompt, branch) {
+		return
+	}
+
+	// 5. Complete session
+	o.completeSession(session, branch, opencodeSession.ID)
+}
+
+// failSessionf marks a session as failed with the given error message.
+func (o *Orchestrator) failSessionf(session *Session, format string, args ...interface{}) {
+	session.SetStatus(StatusFailed)
+	session.SetError(fmt.Sprintf(format, args...))
+	session.mu.Lock()
+	session.CompletedAt = time.Now()
+	session.mu.Unlock()
+}
+
+// executeAgentWorkflow runs the agent workflow steps and returns true if successful.
+func (o *Orchestrator) executeAgentWorkflow(ctx context.Context, session *Session, client *OpenCodeClient, sessionID, systemPrompt, branch string) bool {
+	// Create branch
+	if err := client.CreateBranch(ctx, sessionID, branch); err != nil {
+		o.logger.Warn("runAgentAPI: failed to create branch via shell command", "error", err)
+	}
+
+	// Send message to agent
+	if _, err := client.SendMessage(ctx, sessionID, systemPrompt, nil); err != nil {
+		o.failSessionf(session, "Failed to send message: %v", err)
+		o.logger.Error("runAgentAPI: failed to send message", "session_id", session.ID, "error", err)
+		return false
+	}
+	o.logger.Info("runAgentAPI: message execution completed", "session_id", session.ID)
+
+	// Check session status
+	sessInfo, err := client.GetSession(ctx, sessionID)
+	if err == nil && sessInfo.Status == "failed" {
+		o.failSessionf(session, "OpenCode session failed remotely")
+		return false
+	}
+
+	return true
+}
+
+// completeSession finalizes a successful agent session.
+func (o *Orchestrator) completeSession(session *Session, branch, opencodeSessionID string) {
+	result := o.parseAgentOutput("API session completed")
+	result.Branch = branch
+
+	session.SetResult(result)
+	session.SetStatus(StatusCompleted)
+	session.mu.Lock()
+	session.CompletedAt = time.Now()
+	session.mu.Unlock()
+
+	o.logger.Info("runAgentAPI: agent session completed successfully",
+		"session_id", session.ID,
+		"opencode_session_id", opencodeSessionID,
 		"duration", session.CompletedAt.Sub(session.StartedAt))
 }
 
@@ -487,9 +590,17 @@ Implement the issue described below. Follow these steps:
 2. **Explore** - Use MCP tools to understand the codebase
 3. **Plan** - Identify files to modify and changes needed
 4. **Implement** - Write the code
-5. **Review** - Call review_code on your changes
-6. **Iterate** - If REQUEST_CHANGES, fix issues and review again
-7. **Submit** - Create a pull request when APPROVED
+5. **Verify** - Run 'make lint' and 'make test' - fix any issues before proceeding
+6. **Review** - Call review_code on your changes
+7. **Iterate** - If REQUEST_CHANGES, fix issues, run lint/test again, and review again
+8. **Submit** - Create a pull request when APPROVED
+
+## CRITICAL: Before Committing
+You MUST run these commands and ensure they pass:
+- 'make lint' - All linting errors must be fixed
+- 'make test' - All tests must pass
+
+Do NOT commit or create a PR until both commands succeed.
 
 ## Issue #%d: %s
 
@@ -594,4 +705,34 @@ func sanitizeBranch(name string) string {
 	}
 
 	return sanitized
+}
+
+// verifyMCPConfig checks if the code-warden MCP server is configured in OpenCode.
+// It returns an error if the MCP server is not found or not properly configured.
+func (o *Orchestrator) verifyMCPConfig(ctx context.Context) error {
+	// Try to check MCP server status via OpenCode's health/list endpoints
+	// This is a best-effort check - the actual verification happens when OpenCode
+	// tries to use the MCP tools.
+
+	// Check if our MCP server is reachable
+	mcpURL := fmt.Sprintf("http://%s/sse", o.config.MCPAddr)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, mcpURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create MCP health check request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("MCP server not reachable at %s: %w", mcpURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("MCP server returned status %d", resp.StatusCode)
+	}
+
+	o.logger.Info("MCP server health check passed", "url", mcpURL)
+	return nil
 }

--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -5,6 +5,7 @@ package agent
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"log/slog"
 	"net"
@@ -513,8 +514,8 @@ func (o *Orchestrator) runAgentAPI(ctx context.Context, session *Session, system
 
 	// 1. Health check
 	if err := client.HealthCheck(ctx); err != nil {
-		o.failSessionf(session, "OpenCode API health check failed: %v", err)
 		o.logger.Error("runAgentAPI: health check failed", "session_id", session.ID, "error", err)
+		o.failSessionf(session, "OpenCode API health check failed: %v", err)
 		return
 	}
 
@@ -529,11 +530,20 @@ func (o *Orchestrator) runAgentAPI(ctx context.Context, session *Session, system
 	title := fmt.Sprintf("Issue %d: %s", session.Issue.Number, session.Issue.Title)
 	opencodeSession, err := client.CreateSession(ctx, title, o.config.Model, nil)
 	if err != nil {
-		o.failSessionf(session, "Failed to create OpenCode session: %v", err)
 		o.logger.Error("runAgentAPI: failed to create session", "session_id", session.ID, "error", err)
+		o.failSessionf(session, "Failed to create OpenCode session: %v", err)
 		return
 	}
 	o.logger.Info("runAgentAPI: created OpenCode session", "session_id", session.ID, "opencode_session_id", opencodeSession.ID)
+
+	// Ensure session cleanup on error
+	defer func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := client.CloseSession(closeCtx, opencodeSession.ID); err != nil {
+			o.logger.Warn("runAgentAPI: failed to close OpenCode session", "session_id", opencodeSession.ID, "error", err)
+		}
+	}()
 
 	// 4. Execute agent workflow
 	if !o.executeAgentWorkflow(ctx, session, client, opencodeSession.ID, systemPrompt, branch) {
@@ -696,9 +706,11 @@ func (o *Orchestrator) parseAgentOutput(_ string) *Result {
 	}
 }
 
-// generateSessionID creates a unique session ID.
+// generateSessionID creates a unique session ID using cryptographic random.
 func generateSessionID() string {
-	return fmt.Sprintf("agent-%d", time.Now().UnixNano())
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	return fmt.Sprintf("agent-%x", b)
 }
 
 func sessionIDFromIssue(issue Issue) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -382,34 +382,140 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("agent.working_dir", "")   // Empty means disabled/no default; must be explicitly set
 }
 
-func (c *Config) ValidateForServer() error {
+func (c *Config) Validate() error {
+	var errs []string
+
+	if err := c.validateAI(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := c.validateServer(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := c.validateDatabase(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := c.validateStorage(); err != nil {
+		errs = append(errs, err.Error())
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("configuration errors: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+func (c *Config) validateAI() error {
+	var errs []string
+
+	if c.AI.LLMProvider == "" {
+		errs = append(errs, "ai.llm_provider is required")
+	} else if c.AI.LLMProvider != "ollama" && c.AI.LLMProvider != llmProviderGemini {
+		errs = append(errs, "ai.llm_provider must be 'ollama' or 'gemini'")
+	}
+
+	if c.AI.GeneratorModel == "" {
+		errs = append(errs, "ai.generator_model is required")
+	}
+
+	if c.AI.EmbedderModel == "" {
+		errs = append(errs, "ai.embedder_model is required")
+	}
+
+	if (c.AI.LLMProvider == llmProviderGemini || c.AI.EmbedderProvider == llmProviderGemini) && c.AI.GeminiAPIKey == "" {
+		errs = append(errs, "ai.gemini_api_key is required for gemini provider")
+	}
+
+	if err := c.AI.Validate(); err != nil {
+		errs = append(errs, err.Error())
+	}
+
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+func (c *Config) validateServer() error {
+	if c.Server.MaxWorkers <= 0 {
+		return errors.New("server.max_workers must be positive")
+	}
+	return nil
+}
+
+func (c *Config) validateDatabase() error {
+	var errs []string
+
+	if c.Database.Host == "" {
+		errs = append(errs, "database.host is required")
+	}
+	if c.Database.Port < 1 || c.Database.Port > 65535 {
+		errs = append(errs, "database.port must be between 1 and 65535")
+	}
+	if c.Database.Database == "" {
+		errs = append(errs, "database.database is required")
+	}
+	if c.Database.Username == "" {
+		errs = append(errs, "database.username is required")
+	}
+
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+func (c *Config) validateStorage() error {
+	if c.Storage.QdrantHost == "" {
+		return errors.New("storage.qdrant_host is required")
+	}
+	return nil
+}
+
+func (c *Config) validateGitHub() error {
+	var errs []string
 	if c.GitHub.AppID == 0 {
-		return errors.New("github.app_id is required")
+		errs = append(errs, "github.app_id is required")
 	}
 	if c.GitHub.WebhookSecret == "" {
-		return errors.New("github.webhook_secret is required")
+		errs = append(errs, "github.webhook_secret is required")
 	}
 	if _, err := os.Stat(c.GitHub.PrivateKeyPath); os.IsNotExist(err) {
-		return fmt.Errorf("github private key not found at path: %s", c.GitHub.PrivateKeyPath)
+		errs = append(errs, fmt.Sprintf("github private key not found at path: %s", c.GitHub.PrivateKeyPath))
 	}
-	if (c.AI.LLMProvider == llmProviderGemini || c.AI.EmbedderProvider == llmProviderGemini) && c.AI.GeminiAPIKey == "" {
-		return errors.New("ai.gemini_api_key is required for gemini provider")
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "; "))
 	}
-	if err := c.AI.Validate(); err != nil {
-		return fmt.Errorf("ai config invalid: %w", err)
+	return nil
+}
+
+func (c *Config) ValidateForServer() error {
+	var errs []string
+
+	if err := c.Validate(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := c.validateGitHub(); err != nil {
+		errs = append(errs, err.Error())
 	}
 	if err := c.Agent.Validate(); err != nil {
-		return fmt.Errorf("agent config invalid: %w", err)
+		errs = append(errs, err.Error())
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("configuration errors: %s", strings.Join(errs, "; "))
 	}
 	return nil
 }
 
 func (c *Config) ValidateForCLI() error {
-	if (c.AI.LLMProvider == llmProviderGemini || c.AI.EmbedderProvider == llmProviderGemini) && c.AI.GeminiAPIKey == "" {
-		return errors.New("ai.gemini_api_key is required for gemini provider")
+	var errs []string
+
+	if err := c.Validate(); err != nil {
+		errs = append(errs, err.Error())
 	}
-	if err := c.AI.Validate(); err != nil {
-		return fmt.Errorf("ai config invalid: %w", err)
+
+	if len(errs) > 0 {
+		return fmt.Errorf("configuration errors: %s", strings.Join(errs, "; "))
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -378,8 +378,8 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("agent.timeout", "30m")
 	v.SetDefault("agent.max_iterations", 3)
 	v.SetDefault("agent.mcp_addr", "127.0.0.1:8081")
-	v.SetDefault("agent.opencode_addr", "http://127.0.0.1:8000")
-	v.SetDefault("agent.working_dir", "") // Empty means disabled/no default; must be explicitly set
+	v.SetDefault("agent.opencode_addr", "") // Empty = CLI mode (recommended), non-empty = HTTP API mode
+	v.SetDefault("agent.working_dir", "")   // Empty means disabled/no default; must be explicitly set
 }
 
 func (c *Config) ValidateForServer() error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,7 @@ type AgentConfig struct {
 	// Enabled determines if agent functionality is active.
 	Enabled bool `mapstructure:"enabled"`
 
-	// Provider is the agent provider (currently only "opencode").
+	// Provider is the agent provider: "goose" or "opencode".
 	Provider string `mapstructure:"provider"`
 
 	// Model is the LLM model to use for the agent.
@@ -50,7 +50,7 @@ type AgentConfig struct {
 	// MCPAddr is the address for the MCP server.
 	MCPAddr string `mapstructure:"mcp_addr"`
 
-	// OpencodeAddr is the address of the opencode server API.
+	// OpencodeAddr is the address of the opencode server API (only for opencode provider).
 	OpencodeAddr string `mapstructure:"opencode_addr"`
 
 	// WorkingDir is the directory for agent workspaces.
@@ -374,7 +374,7 @@ func setDefaults(v *viper.Viper) {
 	// Agent
 	v.SetDefault("agent.enabled", false)
 	v.SetDefault("agent.provider", "opencode")
-	v.SetDefault("agent.model", "llama3.1:70b")
+	v.SetDefault("agent.model", "qwen2.5-coder")
 	v.SetDefault("agent.timeout", "30m")
 	v.SetDefault("agent.max_iterations", 3)
 	v.SetDefault("agent.mcp_addr", "127.0.0.1:8081")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,9 @@ type AgentConfig struct {
 	// MCPAddr is the address for the MCP server.
 	MCPAddr string `mapstructure:"mcp_addr"`
 
+	// OpencodeAddr is the address of the opencode server API.
+	OpencodeAddr string `mapstructure:"opencode_addr"`
+
 	// WorkingDir is the directory for agent workspaces.
 	WorkingDir string `mapstructure:"working_dir"`
 }
@@ -375,6 +378,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("agent.timeout", "30m")
 	v.SetDefault("agent.max_iterations", 3)
 	v.SetDefault("agent.mcp_addr", "127.0.0.1:8081")
+	v.SetDefault("agent.opencode_addr", "http://127.0.0.1:8000")
 	v.SetDefault("agent.working_dir", "") // Empty means disabled/no default; must be explicitly set
 }
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -3,6 +3,7 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/google/go-github/v73/github"
@@ -24,6 +25,34 @@ type DraftReviewComment struct {
 	Body      string
 }
 
+// PullRequestOptions contains options for creating a pull request.
+type PullRequestOptions struct {
+	Title string
+	Body  string
+	Head  string // Branch with changes
+	Base  string // Branch to merge into (default: "main")
+	Draft bool
+}
+
+// IssueOptions contains options for listing issues.
+type IssueOptions struct {
+	State    string // "open", "closed", "all" (default: "open")
+	Labels   []string
+	Assignee string
+	Limit    int // Max issues to return (default: 30)
+}
+
+// Issue represents a GitHub issue.
+type Issue struct {
+	Number    int
+	Title     string
+	Body      string
+	State     string
+	Labels    []string
+	Assignees []string
+	URL       string
+}
+
 // Client defines a set of operations for interacting with the GitHub API,
 // focusing on pull requests, comments, and check runs.
 //
@@ -36,6 +65,11 @@ type Client interface {
 	CreateReview(ctx context.Context, owner, repo string, number int, commitSHA, body string, comments []DraftReviewComment) error
 	CreateCheckRun(ctx context.Context, owner, repo string, opts github.CreateCheckRunOptions) (*github.CheckRun, error)
 	UpdateCheckRun(ctx context.Context, owner, repo string, checkRunID int64, opts github.UpdateCheckRunOptions) (*github.CheckRun, error)
+
+	// New methods for agent operations
+	CreatePullRequest(ctx context.Context, owner, repo string, opts PullRequestOptions) (*github.PullRequest, error)
+	ListIssues(ctx context.Context, owner, repo string, opts IssueOptions) ([]Issue, error)
+	GetIssue(ctx context.Context, owner, repo string, number int) (*Issue, error)
 }
 
 type gitHubClient struct {
@@ -184,4 +218,125 @@ func (g *gitHubClient) UpdateCheckRun(ctx context.Context, owner, repo string, c
 		g.logger.Error("failed to update check run", "owner", owner, "repo", repo, "checkRunID", checkRunID, "error", err)
 	}
 	return checkRun, err
+}
+
+// CreatePullRequest creates a new pull request.
+func (g *gitHubClient) CreatePullRequest(ctx context.Context, owner, repo string, opts PullRequestOptions) (*github.PullRequest, error) {
+	if opts.Base == "" {
+		opts.Base = "main"
+	}
+
+	prOpts := &github.NewPullRequest{
+		Title: &opts.Title,
+		Body:  &opts.Body,
+		Head:  &opts.Head,
+		Base:  &opts.Base,
+		Draft: &opts.Draft,
+	}
+
+	pr, _, err := g.client.PullRequests.Create(ctx, owner, repo, prOpts)
+	if err != nil {
+		g.logger.Error("failed to create pull request", "owner", owner, "repo", repo, "head", opts.Head, "error", err)
+		return nil, err
+	}
+
+	g.logger.Info("created pull request", "owner", owner, "repo", repo, "pr", pr.GetNumber(), "url", pr.GetHTMLURL())
+	return pr, nil
+}
+
+// ListIssues lists issues in a repository.
+func (g *gitHubClient) ListIssues(ctx context.Context, owner, repo string, opts IssueOptions) ([]Issue, error) {
+	if opts.State == "" {
+		opts.State = "open"
+	}
+	if opts.Limit == 0 {
+		opts.Limit = 30
+	}
+	if opts.Limit > 100 {
+		opts.Limit = 100
+	}
+
+	issueOpts := &github.IssueListByRepoOptions{
+		State: opts.State,
+		ListOptions: github.ListOptions{
+			PerPage: opts.Limit,
+		},
+	}
+
+	if len(opts.Labels) > 0 {
+		issueOpts.Labels = opts.Labels
+	}
+	if opts.Assignee != "" {
+		issueOpts.Assignee = opts.Assignee
+	}
+
+	issues, _, err := g.client.Issues.ListByRepo(ctx, owner, repo, issueOpts)
+	if err != nil {
+		g.logger.Error("failed to list issues", "owner", owner, "repo", repo, "error", err)
+		return nil, err
+	}
+
+	result := make([]Issue, 0, len(issues))
+	for _, issue := range issues {
+		if issue.PullRequestLinks != nil {
+			// Skip pull requests (they appear in issues list too)
+			continue
+		}
+
+		labels := make([]string, 0, len(issue.Labels))
+		for _, label := range issue.Labels {
+			labels = append(labels, label.GetName())
+		}
+
+		assignees := make([]string, 0, len(issue.Assignees))
+		for _, assignee := range issue.Assignees {
+			assignees = append(assignees, assignee.GetLogin())
+		}
+
+		result = append(result, Issue{
+			Number:    issue.GetNumber(),
+			Title:     issue.GetTitle(),
+			Body:      issue.GetBody(),
+			State:     issue.GetState(),
+			Labels:    labels,
+			Assignees: assignees,
+			URL:       issue.GetHTMLURL(),
+		})
+	}
+
+	return result, nil
+}
+
+// GetIssue retrieves a single issue by its number.
+func (g *gitHubClient) GetIssue(ctx context.Context, owner, repo string, number int) (*Issue, error) {
+	issue, _, err := g.client.Issues.Get(ctx, owner, repo, number)
+	if err != nil {
+		g.logger.Error("failed to get issue", "owner", owner, "repo", repo, "issue", number, "error", err)
+		return nil, err
+	}
+
+	// Check if it's actually a pull request
+	if issue.PullRequestLinks != nil {
+		return nil, fmt.Errorf("issue #%d is a pull request, not an issue", number)
+	}
+
+	labels := make([]string, 0, len(issue.Labels))
+	for _, label := range issue.Labels {
+		labels = append(labels, label.GetName())
+	}
+
+	assignees := make([]string, 0, len(issue.Assignees))
+	for _, assignee := range issue.Assignees {
+		assignees = append(assignees, assignee.GetLogin())
+	}
+
+	return &Issue{
+		Number:    issue.GetNumber(),
+		Title:     issue.GetTitle(),
+		Body:      issue.GetBody(),
+		State:     issue.GetState(),
+		Labels:    labels,
+		Assignees: assignees,
+		URL:       issue.GetHTMLURL(),
+	}, nil
 }

--- a/internal/jobs/review.go
+++ b/internal/jobs/review.go
@@ -163,6 +163,7 @@ func (j *ReviewJob) runImplementIssue(ctx context.Context, event *core.GitHubEve
 			Timeout:       timeout,
 			MaxIterations: j.cfg.Agent.MaxIterations,
 			MCPAddr:       j.cfg.Agent.MCPAddr,
+			OpencodeAddr:  j.cfg.Agent.OpencodeAddr,
 			WorkingDir:    j.cfg.Agent.WorkingDir,
 		},
 		j.logger,

--- a/internal/mcp/github_tools.go
+++ b/internal/mcp/github_tools.go
@@ -1,3 +1,6 @@
+// Package mcp provides GitHub-related MCP tools for agent operations.
+// These tools allow agents to interact with GitHub issues and pull requests
+// through the Model Context Protocol interface.
 package mcp
 
 import (
@@ -8,7 +11,8 @@ import (
 	"github.com/sevigo/code-warden/internal/github"
 )
 
-// CreatePRTool creates a pull request.
+// CreatePRTool creates a pull request in the repository.
+// It requires the agent to have write access to the repository.
 type CreatePRTool struct {
 	ghClient github.Client
 	repo     struct {

--- a/internal/mcp/github_tools.go
+++ b/internal/mcp/github_tools.go
@@ -1,0 +1,303 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/sevigo/code-warden/internal/github"
+)
+
+// CreatePRTool creates a pull request.
+type CreatePRTool struct {
+	ghClient github.Client
+	repo     struct {
+		owner string
+		name  string
+	}
+	logger *slog.Logger
+}
+
+// NewCreatePRTool creates a new CreatePRTool.
+func NewCreatePRTool(ghClient github.Client, owner, repo string, logger *slog.Logger) *CreatePRTool {
+	return &CreatePRTool{
+		ghClient: ghClient,
+		repo: struct {
+			owner string
+			name  string
+		}{owner: owner, name: repo},
+		logger: logger,
+	}
+}
+
+func (t *CreatePRTool) Name() string {
+	return "create_pull_request"
+}
+
+func (t *CreatePRTool) Description() string {
+	return `Create a pull request in the repository.
+Returns the PR number and URL.
+Use this after making changes and running tests/reviews.`
+}
+
+func (t *CreatePRTool) InputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"title": map[string]any{
+				"type":        "string",
+				"description": "The title of the pull request",
+			},
+			"body": map[string]any{
+				"type":        "string",
+				"description": "The body/description of the pull request",
+			},
+			"head": map[string]any{
+				"type":        "string",
+				"description": "The branch containing changes (e.g., 'feature/my-feature')",
+			},
+			"base": map[string]any{
+				"type":        "string",
+				"description": "The branch to merge into (default: 'main')",
+				"default":     "main",
+			},
+			"draft": map[string]any{
+				"type":        "boolean",
+				"description": "Whether to create as a draft PR",
+				"default":     false,
+			},
+		},
+		"required": []string{"title", "body", "head"},
+	}
+}
+
+func (t *CreatePRTool) Execute(ctx context.Context, args map[string]any) (any, error) {
+	title, ok := args["title"].(string)
+	if !ok || title == "" {
+		return nil, fmt.Errorf("title is required")
+	}
+	if len(title) > maxTitleLength {
+		return nil, fmt.Errorf("title exceeds maximum length of %d characters", maxTitleLength)
+	}
+
+	body, ok := args["body"].(string)
+	if !ok || body == "" {
+		return nil, fmt.Errorf("body is required")
+	}
+
+	head, ok := args["head"].(string)
+	if !ok || head == "" {
+		return nil, fmt.Errorf("head branch is required")
+	}
+
+	opts := github.PullRequestOptions{
+		Title: title,
+		Body:  body,
+		Head:  head,
+	}
+
+	if base, ok := args["base"].(string); ok && base != "" {
+		opts.Base = base
+	} else {
+		opts.Base = "main"
+	}
+
+	if draft, ok := args["draft"].(bool); ok {
+		opts.Draft = draft
+	}
+
+	t.logger.Info("create_pull_request: creating PR",
+		"owner", t.repo.owner,
+		"repo", t.repo.name,
+		"head", head,
+		"base", opts.Base)
+
+	pr, err := t.ghClient.CreatePullRequest(ctx, t.repo.owner, t.repo.name, opts)
+	if err != nil {
+		t.logger.Error("create_pull_request: failed", "error", err)
+		return nil, fmt.Errorf("failed to create pull request: %w", err)
+	}
+
+	return CreatePRResponse{
+		Number: pr.GetNumber(),
+		URL:    pr.GetHTMLURL(),
+		State:  pr.GetState(),
+	}, nil
+}
+
+// CreatePRResponse is the response for create_pull_request tool.
+type CreatePRResponse struct {
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+	State  string `json:"state"`
+}
+
+// ListIssuesTool lists issues in the repository.
+type ListIssuesTool struct {
+	ghClient github.Client
+	repo     struct {
+		owner string
+		name  string
+	}
+	logger *slog.Logger
+}
+
+// NewListIssuesTool creates a new ListIssuesTool.
+func NewListIssuesTool(ghClient github.Client, owner, repo string, logger *slog.Logger) *ListIssuesTool {
+	return &ListIssuesTool{
+		ghClient: ghClient,
+		repo: struct {
+			owner string
+			name  string
+		}{owner: owner, name: repo},
+		logger: logger,
+	}
+}
+
+func (t *ListIssuesTool) Name() string {
+	return "list_issues"
+}
+
+func (t *ListIssuesTool) Description() string {
+	return `List issues in the repository.
+Returns a list of issues with their numbers, titles, and status.
+Use this to find issues to work on or check issue status.`
+}
+
+func (t *ListIssuesTool) InputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"state": map[string]any{
+				"type":        "string",
+				"description": "Filter by state: 'open', 'closed', 'all'",
+				"default":     "open",
+				"enum":        []string{"open", "closed", "all"},
+			},
+			"labels": map[string]any{
+				"type":        "array",
+				"description": "Filter by labels (e.g., ['bug', 'enhancement'])",
+				"items": map[string]any{
+					"type": "string",
+				},
+			},
+			"limit": map[string]any{
+				"type":        "integer",
+				"description": "Maximum number of issues to return (default: 30, max: 100)",
+				"default":     30,
+			},
+		},
+	}
+}
+
+func (t *ListIssuesTool) Execute(ctx context.Context, args map[string]any) (any, error) {
+	opts := github.IssueOptions{
+		State: "open",
+		Limit: 30,
+	}
+
+	if state, ok := args["state"].(string); ok && state != "" {
+		opts.State = state
+	}
+
+	if limit, ok := args["limit"].(float64); ok {
+		opts.Limit = int(limit)
+	}
+
+	if labels, ok := args["labels"].([]any); ok {
+		for _, label := range labels {
+			if labelStr, ok := label.(string); ok {
+				opts.Labels = append(opts.Labels, labelStr)
+			}
+		}
+	}
+
+	t.logger.Info("list_issues: listing issues",
+		"owner", t.repo.owner,
+		"repo", t.repo.name,
+		"state", opts.State,
+		"limit", opts.Limit)
+
+	issues, err := t.ghClient.ListIssues(ctx, t.repo.owner, t.repo.name, opts)
+	if err != nil {
+		t.logger.Error("list_issues: failed", "error", err)
+		return nil, fmt.Errorf("failed to list issues: %w", err)
+	}
+
+	return ListIssuesResponse{
+		Count:  len(issues),
+		Issues: issues,
+	}, nil
+}
+
+// ListIssuesResponse is the response for list_issues tool.
+type ListIssuesResponse struct {
+	Count  int            `json:"count"`
+	Issues []github.Issue `json:"issues"`
+}
+
+// GetIssueTool gets details of a specific issue.
+type GetIssueTool struct {
+	ghClient github.Client
+	repo     struct {
+		owner string
+		name  string
+	}
+	logger *slog.Logger
+}
+
+// NewGetIssueTool creates a new GetIssueTool.
+func NewGetIssueTool(ghClient github.Client, owner, repo string, logger *slog.Logger) *GetIssueTool {
+	return &GetIssueTool{
+		ghClient: ghClient,
+		repo: struct {
+			owner string
+			name  string
+		}{owner: owner, name: repo},
+		logger: logger,
+	}
+}
+
+func (t *GetIssueTool) Name() string {
+	return "get_issue"
+}
+
+func (t *GetIssueTool) Description() string {
+	return `Get details of a specific issue by its number.
+Returns the issue title, body, labels, and assignees.
+Use this to understand what needs to be implemented for an issue.`
+}
+
+func (t *GetIssueTool) InputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"number": map[string]any{
+				"type":        "integer",
+				"description": "The issue number",
+			},
+		},
+		"required": []string{"number"},
+	}
+}
+
+func (t *GetIssueTool) Execute(ctx context.Context, args map[string]any) (any, error) {
+	number, ok := args["number"].(float64)
+	if !ok {
+		return nil, fmt.Errorf("issue number is required")
+	}
+	issueNum := int(number)
+
+	t.logger.Info("get_issue: fetching issue",
+		"owner", t.repo.owner,
+		"repo", t.repo.name,
+		"issue", issueNum)
+
+	issue, err := t.ghClient.GetIssue(ctx, t.repo.owner, t.repo.name, issueNum)
+	if err != nil {
+		t.logger.Error("get_issue: failed", "error", err)
+		return nil, fmt.Errorf("failed to get issue #%d: %w", issueNum, err)
+	}
+
+	return issue, nil
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -5,6 +5,7 @@ package mcp
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -295,8 +296,13 @@ func (s *Server) handleMessage(w http.ResponseWriter, r *http.Request) {
 			respBytes, _ := json.Marshal(resp)
 			select {
 			case session.messages <- respBytes:
-			default:
-				s.logger.Warn("session message channel full", "session_id", sessionID)
+				// Message sent successfully
+			case <-session.done:
+				// Session was closed, client disconnected
+				s.logger.Debug("session closed before message sent", "session_id", sessionID)
+			case <-time.After(5 * time.Second):
+				// Timeout to avoid blocking forever
+				s.logger.Warn("timeout sending message to session", "session_id", sessionID)
 			}
 		}
 	}
@@ -341,8 +347,11 @@ type jsonRPCError struct {
 func (s *Server) processRequest(ctx context.Context, req *Request) (any, *jsonRPCError) {
 	switch req.Method {
 	case "tools/list":
+		s.logger.Info("MCP tool call: tools/list")
+		tools := s.ListTools()
+		s.logger.Info("MCP tool response: tools/list", "tool_count", len(tools))
 		return map[string]any{
-			"tools": s.ListTools(),
+			"tools": tools,
 		}, nil
 
 	case "tools/call":
@@ -353,10 +362,13 @@ func (s *Server) processRequest(ctx context.Context, req *Request) (any, *jsonRP
 		if err := json.Unmarshal(req.Params, &params); err != nil {
 			return nil, &jsonRPCError{Code: -32602, Message: "invalid params"}
 		}
+		s.logger.Info("MCP tool call started", "tool", params.Name, "arguments", params.Arguments)
 		result, err := s.CallTool(ctx, params.Name, params.Arguments)
 		if err != nil {
+			s.logger.Error("MCP tool call failed", "tool", params.Name, "error", err)
 			return nil, &jsonRPCError{Code: -32603, Message: err.Error()}
 		}
+		s.logger.Info("MCP tool call completed", "tool", params.Name, "result_type", fmt.Sprintf("%T", result))
 		return map[string]any{
 			"content": []map[string]any{
 				{"type": "text", "text": mustMarshal(result)},
@@ -364,6 +376,7 @@ func (s *Server) processRequest(ctx context.Context, req *Request) (any, *jsonRP
 		}, nil
 
 	case "initialize":
+		s.logger.Info("MCP client initializing")
 		return map[string]any{
 			"protocolVersion": "2024-11-05",
 			"serverInfo": map[string]any{
@@ -376,9 +389,11 @@ func (s *Server) processRequest(ctx context.Context, req *Request) (any, *jsonRP
 		}, nil
 
 	case "ping":
+		s.logger.Debug("MCP ping received")
 		return map[string]any{}, nil
 
 	default:
+		s.logger.Warn("MCP unknown method", "method", req.Method)
 		return nil, &jsonRPCError{Code: -32601, Message: "method not found"}
 	}
 }
@@ -419,5 +434,8 @@ func mustMarshal(v any) string {
 
 // generateSessionID creates a unique session ID for SSE connections.
 func generateSessionID() string {
-	return fmt.Sprintf("sess_%d", time.Now().UnixNano())
+	b := make([]byte, 16)
+	// crypto/rand.Read always returns len(b), nil on supported platforms
+	_, _ = rand.Read(b)
+	return fmt.Sprintf("sess_%x", b)
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -119,6 +120,26 @@ func (s *Server) registerTools() {
 		repoConfig: s.repoConfig,
 		logger:     s.logger,
 	}
+
+	// Register GitHub tools if ghClient is available
+	if s.ghClient != nil && s.repo != nil {
+		// Parse owner/name from FullName
+		owner, name := parseRepoFullName(s.repo.FullName)
+		if owner != "" && name != "" {
+			s.tools["create_pull_request"] = NewCreatePRTool(s.ghClient, owner, name, s.logger)
+			s.tools["list_issues"] = NewListIssuesTool(s.ghClient, owner, name, s.logger)
+			s.tools["get_issue"] = NewGetIssueTool(s.ghClient, owner, name, s.logger)
+		}
+	}
+}
+
+// parseRepoFullName parses a "owner/name" string into owner and name.
+func parseRepoFullName(fullName string) (owner, name string) {
+	parts := strings.SplitN(fullName, "/", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "", fullName
 }
 
 // ListTools returns all available tools.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3,9 +3,11 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"sync"
@@ -305,8 +307,17 @@ func (s *Server) handleMessage(w http.ResponseWriter, r *http.Request) {
 
 // handleJSONRPC handles direct JSON-RPC requests (backwards compatibility).
 func (s *Server) handleJSONRPC(w http.ResponseWriter, r *http.Request) {
+	// Log all incoming requests for debugging
+	body, _ := io.ReadAll(r.Body)
+	r.Body = io.NopCloser(bytes.NewReader(body))
+
+	s.logger.Info("MCP JSON-RPC request received",
+		"method", r.Method,
+		"path", r.URL.Path,
+		"body", string(body))
+
 	var req Request
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&req); err != nil {
 		s.writeError(w, nil, -32700, "parse error")
 		return
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sync"
+	"time"
 
 	"github.com/sevigo/code-warden/internal/core"
 	"github.com/sevigo/code-warden/internal/github"
@@ -26,6 +28,17 @@ type Server struct {
 	projectRoot string
 	logger      *slog.Logger
 	tools       map[string]Tool
+
+	// SSE session management
+	sessionsMu sync.RWMutex
+	sessions   map[string]*sseSession
+}
+
+// sseSession represents an active SSE connection.
+type sseSession struct {
+	id       string
+	messages chan []byte
+	done     chan struct{}
 }
 
 // Tool represents an MCP tool that can be called by an agent.
@@ -69,6 +82,7 @@ func NewServer(
 		projectRoot: projectRoot,
 		logger:      logger,
 		tools:       make(map[string]Tool),
+		sessions:    make(map[string]*sseSession),
 	}
 
 	// Register default tools
@@ -156,11 +170,100 @@ type Error struct {
 }
 
 // ServeHTTP implements http.Handler for the MCP server.
+// It supports both SSE transport (GET /sse, POST /message) and direct JSON-RPC (POST /).
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/sse":
+		s.handleSSE(w, r)
+	case "/message":
+		s.handleMessage(w, r)
+	default:
+		// Direct JSON-RPC for backwards compatibility
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		s.handleJSONRPC(w, r)
+	}
+}
+
+// handleSSE handles SSE transport connections.
+func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Check if flusher is supported
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "SSE not supported", http.StatusInternalServerError)
+		return
+	}
+
+	// Set SSE headers
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	// Generate session ID
+	sessionID := generateSessionID()
+
+	// Create session
+	session := &sseSession{
+		id:       sessionID,
+		messages: make(chan []byte, 100),
+		done:     make(chan struct{}),
+	}
+
+	s.sessionsMu.Lock()
+	s.sessions[sessionID] = session
+	s.sessionsMu.Unlock()
+
+	defer func() {
+		s.sessionsMu.Lock()
+		delete(s.sessions, sessionID)
+		s.sessionsMu.Unlock()
+		close(session.done)
+	}()
+
+	// Send endpoint event - tells client where to send messages
+	endpointEvent := fmt.Sprintf("event: endpoint\ndata: /message?sessionId=%s\n\n", sessionID)
+	fmt.Fprint(w, endpointEvent)
+	flusher.Flush()
+
+	s.logger.Info("SSE client connected", "session_id", sessionID)
+
+	// Keep connection alive and send messages
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			s.logger.Info("SSE client disconnected", "session_id", sessionID)
+			return
+		case msg := <-session.messages:
+			fmt.Fprintf(w, "event: message\ndata: %s\n\n", msg)
+			flusher.Flush()
+		case <-ticker.C:
+			// Send keepalive comment
+			fmt.Fprint(w, ": keepalive\n\n")
+			flusher.Flush()
+		}
+	}
+}
+
+// handleMessage handles JSON-RPC messages from SSE clients.
+func (s *Server) handleMessage(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
+
+	// Get session ID from query
+	sessionID := r.URL.Query().Get("sessionId")
 
 	var req Request
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -168,35 +271,89 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var result any
-	var err error
+	// Process the request
+	result, err := s.processRequest(r.Context(), &req)
+	if err != nil {
+		s.writeError(w, req.ID, err.Code, err.Message)
+		return
+	}
 
+	// If we have a session, send response via SSE
+	if sessionID != "" {
+		s.sessionsMu.RLock()
+		session, ok := s.sessions[sessionID]
+		s.sessionsMu.RUnlock()
+
+		if ok {
+			resp := Response{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result:  result,
+			}
+			respBytes, _ := json.Marshal(resp)
+			select {
+			case session.messages <- respBytes:
+			default:
+				s.logger.Warn("session message channel full", "session_id", sessionID)
+			}
+		}
+	}
+
+	// Also send HTTP response for acknowledgement
+	s.writeResult(w, req.ID, result)
+}
+
+// handleJSONRPC handles direct JSON-RPC requests (backwards compatibility).
+func (s *Server) handleJSONRPC(w http.ResponseWriter, r *http.Request) {
+	var req Request
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeError(w, nil, -32700, "parse error")
+		return
+	}
+
+	result, err := s.processRequest(r.Context(), &req)
+	if err != nil {
+		s.writeError(w, req.ID, err.Code, err.Message)
+		return
+	}
+
+	s.writeResult(w, req.ID, result)
+}
+
+// jsonRPCError represents a JSON-RPC error.
+type jsonRPCError struct {
+	Code    int
+	Message string
+}
+
+// processRequest processes a JSON-RPC request and returns the result.
+func (s *Server) processRequest(ctx context.Context, req *Request) (any, *jsonRPCError) {
 	switch req.Method {
 	case "tools/list":
-		result = map[string]any{
+		return map[string]any{
 			"tools": s.ListTools(),
-		}
+		}, nil
+
 	case "tools/call":
 		var params struct {
 			Name      string         `json:"name"`
 			Arguments map[string]any `json:"arguments"`
 		}
 		if err := json.Unmarshal(req.Params, &params); err != nil {
-			s.writeError(w, req.ID, -32602, "invalid params")
-			return
+			return nil, &jsonRPCError{Code: -32602, Message: "invalid params"}
 		}
-		result, err = s.CallTool(r.Context(), params.Name, params.Arguments)
+		result, err := s.CallTool(ctx, params.Name, params.Arguments)
 		if err != nil {
-			s.writeError(w, req.ID, -32603, err.Error())
-			return
+			return nil, &jsonRPCError{Code: -32603, Message: err.Error()}
 		}
-		result = map[string]any{
+		return map[string]any{
 			"content": []map[string]any{
 				{"type": "text", "text": mustMarshal(result)},
 			},
-		}
+		}, nil
+
 	case "initialize":
-		result = map[string]any{
+		return map[string]any{
 			"protocolVersion": "2024-11-05",
 			"serverInfo": map[string]any{
 				"name":    "code-warden-mcp",
@@ -205,13 +362,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			"capabilities": map[string]any{
 				"tools": map[string]any{},
 			},
-		}
-	default:
-		s.writeError(w, req.ID, -32601, "method not found")
-		return
-	}
+		}, nil
 
-	s.writeResult(w, req.ID, result)
+	case "ping":
+		return map[string]any{}, nil
+
+	default:
+		return nil, &jsonRPCError{Code: -32601, Message: "method not found"}
+	}
 }
 
 func (s *Server) writeResult(w http.ResponseWriter, id any, result any) {
@@ -246,4 +404,9 @@ func (s *Server) writeError(w http.ResponseWriter, id any, code int, message str
 func mustMarshal(v any) string {
 	b, _ := json.MarshalIndent(v, "", "  ")
 	return string(b)
+}
+
+// generateSessionID creates a unique session ID for SSE connections.
+func generateSessionID() string {
+	return fmt.Sprintf("sess_%d", time.Now().UnixNano())
 }

--- a/internal/rag/rag_review.go
+++ b/internal/rag/rag_review.go
@@ -260,7 +260,7 @@ func (r *ragService) GenerateConsensusReview(ctx context.Context, repoConfig *co
 	chain := chains.NewMapReduceChain(
 		r.consensusMapFunc(event, promptData, &modelResults, &modelResultsMu, reviewsDir, timestamp),
 		r.consensusReduceFunc(repoConfig, event, contextString, changedFiles, contextBuildTime),
-		chains.WithMaxConcurrency[string, ComparisonResult, string](5),
+		chains.WithMaxConcurrency[string, ComparisonResult, string](2),
 		chains.WithQuorum[string, ComparisonResult, string](r.cfg.AI.ConsensusQuorum),
 	)
 

--- a/internal/wire/wire.go
+++ b/internal/wire/wire.go
@@ -39,7 +39,7 @@ func InitializeApp(ctx context.Context) (*app.App, func(), error) {
 	wire.Build(
 		app.NewApp,
 		server.NewServer,
-		config.LoadConfig,
+		provideValidatedConfig,
 		db.NewDatabase,
 		storage.NewStore,
 		repomanager.New,
@@ -61,6 +61,17 @@ func InitializeApp(ctx context.Context) (*app.App, func(), error) {
 		provideSQLXDB,
 	)
 	return &app.App{}, nil, nil
+}
+
+func provideValidatedConfig() (*config.Config, error) {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return nil, err
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid configuration: %w", err)
+	}
+	return cfg, nil
 }
 
 func provideSQLXDB(db *db.DB) *sqlx.DB {

--- a/internal/wire/wire_gen.go
+++ b/internal/wire/wire_gen.go
@@ -39,39 +39,39 @@ import (
 // Injectors from wire.go:
 
 func InitializeApp(ctx context.Context) (*app.App, func(), error) {
-	configConfig, err := config.LoadConfig()
+	config, err := provideValidatedConfig()
 	if err != nil {
 		return nil, nil, err
 	}
-	dbConfig := provideDBConfig(configConfig)
+	dbConfig := provideDBConfig(config)
 	dbDB, cleanup, err := db.NewDatabase(dbConfig)
 	if err != nil {
 		return nil, nil, err
 	}
 	sqlxDB := provideSQLXDB(dbDB)
 	store := storage.NewStore(sqlxDB)
-	loggerConfig := provideLoggerConfig(configConfig)
-	writer := provideLogWriter(configConfig)
+	loggerConfig := provideLoggerConfig(config)
+	writer := provideLogWriter(config)
 	logger := provideSlogLogger(loggerConfig, writer)
-	embedder, err := provideEmbedder(ctx, configConfig, logger)
+	embedder, err := provideEmbedder(ctx, config, logger)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	vectorStore := provideVectorStore(configConfig, embedder, logger)
+	vectorStore := provideVectorStore(config, embedder, logger)
 	client := gitutil.NewClient(logger)
-	repoManager := repomanager.New(configConfig, store, vectorStore, client, logger)
+	repoManager := repomanager.New(config, store, vectorStore, client, logger)
 	promptManager, err := llm.NewPromptManager()
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	model, err := provideGeneratorLLM(ctx, configConfig, logger)
+	model, err := provideGeneratorLLM(ctx, config, logger)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	reranker, err := provideReranker(ctx, configConfig, logger, promptManager)
+	reranker, err := provideReranker(ctx, config, logger, promptManager)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
@@ -86,21 +86,32 @@ func InitializeApp(ctx context.Context) (*app.App, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	service, err := rag.NewService(configConfig, promptManager, vectorStore, store, model, reranker, parserRegistry, textSplitter, logger)
+	service, err := rag.NewService(config, promptManager, vectorStore, store, model, reranker, parserRegistry, textSplitter, logger)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	job := jobs.NewReviewJob(configConfig, service, store, vectorStore, repoManager, logger)
-	jobDispatcher := jobs.NewDispatcher(ctx, job, configConfig, logger)
-	serverServer := server.NewServer(ctx, configConfig, jobDispatcher, logger)
-	appApp := app.NewApp(configConfig, dbDB, store, vectorStore, repoManager, jobDispatcher, service, serverServer, client, logger)
+	job := jobs.NewReviewJob(config, service, store, vectorStore, repoManager, logger)
+	jobDispatcher := jobs.NewDispatcher(ctx, job, config, logger)
+	serverServer := server.NewServer(ctx, config, jobDispatcher, logger)
+	appApp := app.NewApp(config, dbDB, store, vectorStore, repoManager, jobDispatcher, service, serverServer, client, logger)
 	return appApp, func() {
 		cleanup()
 	}, nil
 }
 
 // wire.go:
+
+func provideValidatedConfig() (*config.Config, error) {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return nil, err
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid configuration: %w", err)
+	}
+	return cfg, nil
+}
 
 func provideSQLXDB(db2 *db.DB) *sqlx.DB {
 	return db2.DB

--- a/mocks/mock_github_client.go
+++ b/mocks/mock_github_client.go
@@ -14,9 +14,8 @@ import (
 	reflect "reflect"
 
 	github "github.com/google/go-github/v73/github"
-	gomock "go.uber.org/mock/gomock"
-
 	github0 "github.com/sevigo/code-warden/internal/github"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockClient is a mock of Client interface.
@@ -72,6 +71,21 @@ func (mr *MockClientMockRecorder) CreateComment(ctx, owner, repo, number, body a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateComment", reflect.TypeOf((*MockClient)(nil).CreateComment), ctx, owner, repo, number, body)
 }
 
+// CreatePullRequest mocks base method.
+func (m *MockClient) CreatePullRequest(ctx context.Context, owner, repo string, opts github0.PullRequestOptions) (*github.PullRequest, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreatePullRequest", ctx, owner, repo, opts)
+	ret0, _ := ret[0].(*github.PullRequest)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreatePullRequest indicates an expected call of CreatePullRequest.
+func (mr *MockClientMockRecorder) CreatePullRequest(ctx, owner, repo, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePullRequest", reflect.TypeOf((*MockClient)(nil).CreatePullRequest), ctx, owner, repo, opts)
+}
+
 // CreateReview mocks base method.
 func (m *MockClient) CreateReview(ctx context.Context, owner, repo string, number int, commitSHA, body string, comments []github0.DraftReviewComment) error {
 	m.ctrl.T.Helper()
@@ -99,6 +113,21 @@ func (m *MockClient) GetChangedFiles(ctx context.Context, owner, repo string, nu
 func (mr *MockClientMockRecorder) GetChangedFiles(ctx, owner, repo, number any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChangedFiles", reflect.TypeOf((*MockClient)(nil).GetChangedFiles), ctx, owner, repo, number)
+}
+
+// GetIssue mocks base method.
+func (m *MockClient) GetIssue(ctx context.Context, owner, repo string, number int) (*github0.Issue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIssue", ctx, owner, repo, number)
+	ret0, _ := ret[0].(*github0.Issue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIssue indicates an expected call of GetIssue.
+func (mr *MockClientMockRecorder) GetIssue(ctx, owner, repo, number any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIssue", reflect.TypeOf((*MockClient)(nil).GetIssue), ctx, owner, repo, number)
 }
 
 // GetPullRequest mocks base method.
@@ -129,6 +158,21 @@ func (m *MockClient) GetPullRequestDiff(ctx context.Context, owner, repo string,
 func (mr *MockClientMockRecorder) GetPullRequestDiff(ctx, owner, repo, number any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPullRequestDiff", reflect.TypeOf((*MockClient)(nil).GetPullRequestDiff), ctx, owner, repo, number)
+}
+
+// ListIssues mocks base method.
+func (m *MockClient) ListIssues(ctx context.Context, owner, repo string, opts github0.IssueOptions) ([]github0.Issue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListIssues", ctx, owner, repo, opts)
+	ret0, _ := ret[0].([]github0.Issue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListIssues indicates an expected call of ListIssues.
+func (mr *MockClientMockRecorder) ListIssues(ctx, owner, repo, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIssues", reflect.TypeOf((*MockClient)(nil).ListIssues), ctx, owner, repo, opts)
 }
 
 // UpdateCheckRun mocks base method.


### PR DESCRIPTION
## Summary

- Adds configuration validation early in application initialization via `wire.InitializeApp()`
- Catches invalid configuration values before database connections or other resource initialization
- Ensures all entry points (server, CLI commands) validate config before use

## Changes

- Added `provideValidatedConfig()` provider in `internal/wire/wire.go` that loads and validates config
- Replaced direct `config.LoadConfig` in wire build with the new validated provider
- Generated `wire_gen.go` reflects the change

## Validation Rules (already implemented in `internal/config/config.go`)

- AI: `llm_provider` must be "ollama" or "gemini", `generator_model` and `embedder_model` required, Gemini API key check
- Server: `max_workers` must be positive (> 0)
- Database: host required, port must be 1-65535, database name and username required
- Storage: `qdrant_host` required

## Tests

All existing validation tests pass:
- `TestConfig_Validate` - base config validation tests
- `TestConfig_ValidateForServer` - server-specific validation (GitHub keys, etc.)
- `TestConfig_ValidateForCLI` - CLI validation

Both `make lint` and `make test` pass.

Fixes #147