### PR TITLE
fix: simplify MCP server handleJSONRPC body reading

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3,12 +3,10 @@
 package mcp
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -335,20 +333,15 @@ func (s *Server) handleMessage(w http.ResponseWriter, r *http.Request) {
 
 // handleJSONRPC handles direct JSON-RPC requests (backwards compatibility).
 func (s *Server) handleJSONRPC(w http.ResponseWriter, r *http.Request) {
-	// Log all incoming requests for debugging
-	body, _ := io.ReadAll(r.Body)
-	r.Body = io.NopCloser(bytes.NewReader(body))
-
-	s.logger.Info("MCP JSON-RPC request received",
-		"method", r.Method,
-		"path", r.URL.Path,
-		"body", string(body))
-
 	var req Request
-	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&req); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		s.writeError(w, nil, -32700, "parse error")
 		return
 	}
+
+	s.logger.Info("MCP JSON-RPC request received",
+		"method", req.Method,
+		"id", req.ID)
 
 	result, err := s.processRequest(r.Context(), &req)
 	if err != nil {


### PR DESCRIPTION
## Changes

- **handleJSONRPC**: Remove unnecessary double-read of HTTP body. Decode JSON directly from `r.Body` instead of `io.ReadAll` + `bytes.NewReader` roundtrip. Log parsed JSON-RPC `method`/`id` instead of raw body (cleaner, avoids leaking large payloads into logs).
