### PR TITLE
fix: MCP server stability, context propagation, and validation

### DIFF
--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -140,7 +140,7 @@ func (o *Orchestrator) Start() error {
 		Addr:              o.config.MCPAddr,
 		Handler:           o.mcpServer,
 		ReadHeaderTimeout: 10 * time.Second,
-		WriteTimeout:      0, // Disable for long-lived SSE connections
+		WriteTimeout:      30 * time.Minute, // Sufficient for long-lived agent tasks
 		IdleTimeout:       120 * time.Second,
 	}
 
@@ -171,11 +171,9 @@ func (o *Orchestrator) Start() error {
 	// Wait for the server to be ready (with timeout)
 	select {
 	case <-ready:
-		// Small delay to ensure the server is fully ready
-		time.Sleep(100 * time.Millisecond)
 		o.logger.Info("MCP HTTP server is ready", "addr", o.config.MCPAddr)
 	case <-time.After(5 * time.Second):
-		return fmt.Errorf("timeout waiting for MCP server to start")
+		return fmt.Errorf("timeout waiting for MCP server to start on %s", o.config.MCPAddr)
 	}
 
 	// Start session cleanup goroutine
@@ -483,18 +481,24 @@ func (o *Orchestrator) runAgentCLI(ctx context.Context, session *Session, system
 	// Create session workspace
 	workspaceDir := filepath.Join(o.config.WorkingDir, session.ID)
 	if err := os.MkdirAll(workspaceDir, 0750); err != nil {
-		o.logger.Error("runAgentCLI: failed to create workspace directory", "session_id", session.ID, "dir", workspaceDir, "error", err)
+		o.logger.Error("runAgentCLI: failed to create workspace directory",
+			"session_id", session.ID,
+			"path", workspaceDir,
+			"error", err)
 		session.SetStatus(StatusFailed)
-		session.SetError(fmt.Sprintf("Failed to create workspace: %v", err))
+		session.SetError(fmt.Sprintf("failed to create workspace directory %s: %v", workspaceDir, err))
 		return
 	}
 
 	// Clone project into workspace
 	o.logger.Info("runAgentCLI: preparing workspace", "session_id", session.ID, "dir", workspaceDir)
 	if err := o.prepareWorkspace(ctx, workspaceDir); err != nil {
-		o.logger.Error("runAgentCLI: failed to prepare workspace", "session_id", session.ID, "error", err)
+		o.logger.Error("runAgentCLI: failed to prepare workspace",
+			"session_id", session.ID,
+			"path", workspaceDir,
+			"error", err)
 		session.SetStatus(StatusFailed)
-		session.SetError(fmt.Sprintf("Failed to prepare workspace: %v", err))
+		session.SetError(fmt.Sprintf("failed to prepare workspace at %s: %v", workspaceDir, err))
 		return
 	}
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -70,6 +70,7 @@ type Client interface {
 	CreatePullRequest(ctx context.Context, owner, repo string, opts PullRequestOptions) (*github.PullRequest, error)
 	ListIssues(ctx context.Context, owner, repo string, opts IssueOptions) ([]Issue, error)
 	GetIssue(ctx context.Context, owner, repo string, number int) (*Issue, error)
+	GetBranch(ctx context.Context, owner, repo, branch string) (*github.Branch, error)
 }
 
 type gitHubClient struct {
@@ -339,4 +340,14 @@ func (g *gitHubClient) GetIssue(ctx context.Context, owner, repo string, number 
 		Assignees: assignees,
 		URL:       issue.GetHTMLURL(),
 	}, nil
+}
+
+// GetBranch retrieves a single branch by its name.
+func (g *gitHubClient) GetBranch(ctx context.Context, owner, repo, branch string) (*github.Branch, error) {
+	b, _, err := g.client.Repositories.GetBranch(ctx, owner, repo, branch, 0)
+	if err != nil {
+		g.logger.Warn("failed to get branch", "owner", owner, "repo", repo, "branch", branch, "error", err)
+		return nil, err
+	}
+	return b, nil
 }

--- a/internal/mcp/github_tools.go
+++ b/internal/mcp/github_tools.go
@@ -109,22 +109,30 @@ func (t *CreatePRTool) Execute(ctx context.Context, args map[string]any) (any, e
 	if !ok || body == "" {
 		return nil, fmt.Errorf("body is required")
 	}
+	if len(body) > maxBodyLength {
+		return nil, fmt.Errorf("body exceeds maximum length of %d characters", maxBodyLength)
+	}
 
 	head, ok := args["head"].(string)
 	if !ok || head == "" {
 		return nil, fmt.Errorf("head branch is required")
 	}
 
+	base := "main"
+	if b, ok := args["base"].(string); ok && b != "" {
+		base = b
+	}
+
+	// Validate base branch exists
+	if _, err := t.ghClient.GetBranch(ctx, t.repo.owner, t.repo.name, base); err != nil {
+		return nil, fmt.Errorf("base branch %q does not exist: %w", base, err)
+	}
+
 	opts := github.PullRequestOptions{
 		Title: title,
 		Body:  body,
 		Head:  head,
-	}
-
-	if base, ok := args["base"].(string); ok && base != "" {
-		opts.Base = base
-	} else {
-		opts.Base = "main"
+		Base:  base,
 	}
 
 	if draft, ok := args["draft"].(bool); ok {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -41,6 +41,8 @@ type sseSession struct {
 	id       string
 	messages chan []byte
 	done     chan struct{}
+	ctx      context.Context
+	cancel   context.CancelFunc
 }
 
 // Tool represents an MCP tool that can be called by an agent.
@@ -233,11 +235,14 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	// Generate session ID
 	sessionID := generateSessionID()
 
-	// Create session
+	// Create a per-session context that is cancelled when the client disconnects
+	sessionCtx, sessionCancel := context.WithCancel(r.Context())
 	session := &sseSession{
 		id:       sessionID,
 		messages: make(chan []byte, 100),
 		done:     make(chan struct{}),
+		ctx:      sessionCtx,
+		cancel:   sessionCancel,
 	}
 
 	s.sessionsMu.Lock()
@@ -245,6 +250,7 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	s.sessionsMu.Unlock()
 
 	defer func() {
+		session.cancel() // Cancel context first
 		s.sessionsMu.Lock()
 		delete(s.sessions, sessionID)
 		s.sessionsMu.Unlock()
@@ -294,8 +300,32 @@ func (s *Server) handleMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Process the request
-	result, err := s.processRequest(r.Context(), &req)
+	// Process the request with a context that combines the POST request context
+	// and the long-lived SSE session context.
+	s.sessionsMu.RLock()
+	session, exists := s.sessions[sessionID]
+	s.sessionsMu.RUnlock()
+
+	var toolCtx context.Context
+	var cancel context.CancelFunc
+
+	if exists {
+		// Create a context that is cancelled if either the POST request ends
+		// OR the underlying SSE stream is closed.
+		toolCtx, cancel = context.WithCancel(r.Context())
+		defer cancel()
+		go func() {
+			select {
+			case <-session.ctx.Done():
+				cancel()
+			case <-toolCtx.Done():
+			}
+		}()
+	} else {
+		toolCtx = r.Context()
+	}
+
+	result, err := s.processRequest(toolCtx, &req)
 	if err != nil {
 		s.writeError(w, req.ID, err.Code, err.Message)
 		return

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -19,6 +19,7 @@ const (
 	minResultLimit   = 1
 	maxDiffLength    = 1000000 // 1MB max diff
 	maxTitleLength   = 500
+	maxBodyLength    = 65536 // GitHub limit is 64KB
 	maxSymbolLength  = 200
 	maxDirPathLength = 500
 )

--- a/mocks/mock_github_client.go
+++ b/mocks/mock_github_client.go
@@ -100,6 +100,21 @@ func (mr *MockClientMockRecorder) CreateReview(ctx, owner, repo, number, commitS
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateReview", reflect.TypeOf((*MockClient)(nil).CreateReview), ctx, owner, repo, number, commitSHA, body, comments)
 }
 
+// GetBranch mocks base method.
+func (m *MockClient) GetBranch(ctx context.Context, owner, repo, branch string) (*github.Branch, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBranch", ctx, owner, repo, branch)
+	ret0, _ := ret[0].(*github.Branch)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBranch indicates an expected call of GetBranch.
+func (mr *MockClientMockRecorder) GetBranch(ctx, owner, repo, branch any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBranch", reflect.TypeOf((*MockClient)(nil).GetBranch), ctx, owner, repo, branch)
+}
+
 // GetChangedFiles mocks base method.
 func (m *MockClient) GetChangedFiles(ctx context.Context, owner, repo string, number int) ([]github0.ChangedFile, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Changes (Part 2)

This PR addresses the remaining review points (10-14) for the MCP server and agent orchestrator:

- **Finite WriteTimeout**: Changed from 0 to 30m for safety.
- **Context Propagation**: Tools now properly cancel when the SSE stream is disconnected.
- **Improved Validation**: Added PR body length (64KB) and base branch existence checks.
- **Better Error Context**: Enhanced orchestrator logs with session IDs and paths.
- **Reduced Startup Latency**: Removed redundant 100ms sleep.
