### PR TITLE
fix: resolve 10 code review issues across MCP server, agent, and docs

### DIFF
--- a/docs/IMPLEMENT_ARCHITECTURE.md
+++ b/docs/IMPLEMENT_ARCHITECTURE.md
@@ -126,7 +126,6 @@ Manages the agent lifecycle:
 | `runAgentCLI()` | Execute via OpenCode CLI binary |
 | `buildSystemPrompt()` | Constructs instructions for the agent |
 | `prepareWorkspace()` | Clones repo to isolated directory |
-| `verifyMCPConfig()` | Validates MCP server connectivity |
 
 **Configuration (`internal/config/config.go`)**:
 

--- a/docs/opencode-config.md
+++ b/docs/opencode-config.md
@@ -109,6 +109,7 @@ When connected, the agent has access to these MCP tools:
 
 | Tool | Description |
 |------|-------------|
+| `push_branch` | Push local branch to remote origin |
 | `create_pull_request` | Create a pull request with title, body, and branch |
 | `list_issues` | List repository issues with filtering options |
 | `get_issue` | Get detailed information about a specific issue |

--- a/internal/agent/opencode_client.go
+++ b/internal/agent/opencode_client.go
@@ -16,46 +16,25 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"regexp"
 	"strings"
 	"time"
+
+	"github.com/sevigo/code-warden/internal/gitutil"
 )
 
 // Input validation constants.
 const (
-	// maxBranchNameLength is the maximum length for git branch names (git limit is 255 bytes).
-	maxBranchNameLength = 255
 	// DefaultAgent is the default OpenCode agent type.
 	DefaultAgent = "build"
 )
 
-// safeBranchNameRegex validates that branch names contain only safe characters.
-// This prevents shell injection and ensures valid git branch names.
-var safeBranchNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._/-]*$`)
+// validateBranchName delegates to the shared gitutil implementation.
+var validateBranchName = gitutil.ValidateBranchName
 
 // shellQuote safely quotes a string for shell execution by wrapping in single quotes
 // and escaping any existing single quotes.
 func shellQuote(s string) string {
-	// Replace single quotes with '\'' (end quote, escaped quote, start quote)
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
-}
-
-// validateBranchName checks if a branch name is safe for shell execution.
-func validateBranchName(name string) error {
-	if name == "" {
-		return fmt.Errorf("branch name cannot be empty")
-	}
-	if len(name) > maxBranchNameLength {
-		return fmt.Errorf("branch name exceeds maximum length of %d bytes", maxBranchNameLength)
-	}
-	if !safeBranchNameRegex.MatchString(name) {
-		return fmt.Errorf("invalid branch name: contains unsafe characters")
-	}
-	// Check for consecutive dots which could lead to directory traversal
-	if strings.Contains(name, "..") {
-		return fmt.Errorf("branch name cannot contain consecutive dots")
-	}
-	return nil
 }
 
 // APIError represents an error response from the OpenCode API.

--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -13,12 +13,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"sync"
 	"time"
 
 	"github.com/sevigo/code-warden/internal/core"
 	"github.com/sevigo/code-warden/internal/github"
+	"github.com/sevigo/code-warden/internal/gitutil"
 	"github.com/sevigo/code-warden/internal/mcp"
 	"github.com/sevigo/code-warden/internal/rag"
 	"github.com/sevigo/code-warden/internal/storage"
@@ -38,6 +38,9 @@ type Orchestrator struct {
 
 	sessions   map[string]*Session
 	sessionsMu sync.RWMutex
+
+	// done is closed when the orchestrator is shutting down.
+	done chan struct{}
 }
 
 // Config holds configuration for the agent orchestrator.
@@ -126,6 +129,7 @@ func NewOrchestrator(
 		projectRoot: absRoot,
 		sessions:    make(map[string]*Session),
 		sessionsMu:  sync.RWMutex{},
+		done:        make(chan struct{}),
 	}
 }
 
@@ -187,6 +191,7 @@ func (o *Orchestrator) Shutdown(ctx context.Context) error {
 	o.logger.Info("shutting down agent orchestrator")
 
 	// Cancel all running sessions
+	close(o.done) // Signal cleanupLoop to stop
 	o.sessionsMu.Lock()
 	for _, session := range o.sessions {
 		if session.cancel != nil {
@@ -212,8 +217,13 @@ func (o *Orchestrator) cleanupLoop() {
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 
-	for range ticker.C {
-		o.cleanupOldSessions()
+	for {
+		select {
+		case <-o.done:
+			return
+		case <-ticker.C:
+			o.cleanupOldSessions()
+		}
 	}
 }
 
@@ -373,12 +383,11 @@ func (o *Orchestrator) SpawnAgent(ctx context.Context, issue Issue) (*Session, e
 		return nil, fmt.Errorf("agent functionality is disabled")
 	}
 
-	// Check concurrent session limit
-	o.sessionsMu.RLock()
+	// Check concurrent session limit and insert atomically
+	o.sessionsMu.Lock()
 	activeCount := len(o.sessions)
-	o.sessionsMu.RUnlock()
-
 	if activeCount >= o.config.MaxConcurrentSessions {
+		o.sessionsMu.Unlock()
 		return nil, fmt.Errorf("maximum concurrent sessions reached (%d), please retry later", o.config.MaxConcurrentSessions)
 	}
 
@@ -389,8 +398,6 @@ func (o *Orchestrator) SpawnAgent(ctx context.Context, issue Issue) (*Session, e
 		status:    StatusPending,
 		StartedAt: time.Now(),
 	}
-
-	o.sessionsMu.Lock()
 	o.sessions[sessionID] = session
 	o.sessionsMu.Unlock()
 
@@ -465,7 +472,7 @@ func (o *Orchestrator) runAgent(ctx context.Context, session *Session) {
 		"prompt_length", len(systemPrompt))
 
 	// Create branch name (sanitize for git safety)
-	branch := sanitizeBranch(fmt.Sprintf("agent/%s", session.ID))
+	branch := gitutil.SanitizeBranch(fmt.Sprintf("agent/%s", session.ID))
 	o.logger.Info("runAgent: created branch name",
 		"session_id", session.ID,
 		"branch", branch)
@@ -502,13 +509,12 @@ func (o *Orchestrator) runAgentCLI(ctx context.Context, session *Session, system
 		return
 	}
 
-	o.mcpServer.ProjectRoot = workspaceDir
-	defer func() {
-		o.mcpServer.ProjectRoot = o.projectRoot // Restore original after session
-	}()
+	// Register per-session workspace so MCP tools use the correct project root
+	o.mcpServer.RegisterWorkspace(session.ID, workspaceDir)
+	defer o.mcpServer.UnregisterWorkspace(session.ID)
 
 	// Build OpenCode command
-	cmd := o.buildOpenCodeCommand(ctx, session.Issue, systemPrompt, branch)
+	cmd := o.buildOpenCodeCommand(ctx, session.ID, session.Issue, systemPrompt, branch)
 	cmd.Dir = workspaceDir // Run in the isolated workspace
 
 	o.logger.Info("runAgentCLI: starting OpenCode process",
@@ -632,7 +638,7 @@ Work in the current isolated workspace. Create a branch named 'agent/%s' for you
 }
 
 // buildOpenCodeCommand creates the command to run OpenCode.
-func (o *Orchestrator) buildOpenCodeCommand(ctx context.Context, issue Issue, systemPrompt, branch string) *exec.Cmd {
+func (o *Orchestrator) buildOpenCodeCommand(ctx context.Context, sessionID string, issue Issue, systemPrompt, branch string) *exec.Cmd {
 	// OpenCode CLI usage: opencode run [message..]
 	// The prompt is passed as positional arguments after "run"
 	//nolint:gosec // G204: Subprocess launched with variable arguments - intentional for agent execution
@@ -646,7 +652,7 @@ func (o *Orchestrator) buildOpenCodeCommand(ctx context.Context, issue Issue, sy
 	// Command construction (cmd.Dir is set by the caller)
 
 	// Dynamically configure MCP server for this run
-	mcpConfig := fmt.Sprintf(`{"mcp": {"code-warden": {"type": "remote", "url": "http://%s/sse", "enabled": true}}}`, o.config.MCPAddr)
+	mcpConfig := fmt.Sprintf(`{"mcp": {"code-warden": {"type": "remote", "url": "http://%s/sse?workspace=%s", "enabled": true}}}`, o.config.MCPAddr, sessionID)
 
 	// Set environment variables for MCP and iteration config
 	cmd.Env = append(os.Environ(),
@@ -707,29 +713,6 @@ func truncateString(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen] + "..."
-}
-
-// sanitizeBranch sanitizes a string to be a valid git branch name.
-// Git branch names cannot contain spaces, ~, ^, :, *, ?, [, \\, or start with -.
-func sanitizeBranch(name string) string {
-	// Replace invalid characters with hyphens
-	re := regexp.MustCompile(`[\s~^:?*\[\\]`)
-	sanitized := re.ReplaceAllString(name, "-")
-
-	// Remove leading/trailing hyphens and dots
-	for len(sanitized) > 0 && (sanitized[0] == '-' || sanitized[0] == '.') {
-		sanitized = sanitized[1:]
-	}
-	for len(sanitized) > 0 && (sanitized[len(sanitized)-1] == '-' || sanitized[len(sanitized)-1] == '.') {
-		sanitized = sanitized[:len(sanitized)-1]
-	}
-
-	// Limit length to 200 characters
-	if len(sanitized) > 200 {
-		sanitized = sanitized[:200]
-	}
-
-	return sanitized
 }
 
 // cleanupWorkspace removes the session's isolated workspace directory.

--- a/internal/gitutil/branch.go
+++ b/internal/gitutil/branch.go
@@ -1,0 +1,59 @@
+package gitutil
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Branch name validation constants.
+const (
+	// MaxBranchNameLength is the maximum length for git branch names (git limit is 255 bytes).
+	MaxBranchNameLength = 255
+)
+
+// validBranchName matches safe Git branch names: alphanumeric, slashes, hyphens, underscores, dots.
+// Rejects empty strings, double dots (..), and requires alphanumeric start/end.
+var validBranchName = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9/_\-\.]*[a-zA-Z0-9])?$`)
+
+// sanitizeBranchRegex matches invalid git branch name characters.
+var sanitizeBranchRegex = regexp.MustCompile(`[\s~^:?*\[\\]`)
+
+// ValidateBranchName checks that a branch name is safe for shell execution and valid for git.
+func ValidateBranchName(name string) error {
+	if name == "" {
+		return fmt.Errorf("branch name cannot be empty")
+	}
+	if len(name) > MaxBranchNameLength {
+		return fmt.Errorf("branch name exceeds maximum length of %d bytes", MaxBranchNameLength)
+	}
+	if !validBranchName.MatchString(name) {
+		return fmt.Errorf("branch name %q contains invalid characters", name)
+	}
+	// Check for consecutive dots which could lead to directory traversal
+	if strings.Contains(name, "..") {
+		return fmt.Errorf("branch name cannot contain consecutive dots")
+	}
+	return nil
+}
+
+// SanitizeBranch sanitizes a string to be a valid git branch name.
+// Git branch names cannot contain spaces, ~, ^, :, *, ?, [, \\, or start with -.
+func SanitizeBranch(name string) string {
+	sanitized := sanitizeBranchRegex.ReplaceAllString(name, "-")
+
+	// Remove leading/trailing hyphens and dots
+	for len(sanitized) > 0 && (sanitized[0] == '-' || sanitized[0] == '.') {
+		sanitized = sanitized[1:]
+	}
+	for len(sanitized) > 0 && (sanitized[len(sanitized)-1] == '-' || sanitized[len(sanitized)-1] == '.') {
+		sanitized = sanitized[:len(sanitized)-1]
+	}
+
+	// Limit length to 200 characters
+	if len(sanitized) > 200 {
+		sanitized = sanitized[:200]
+	}
+
+	return sanitized
+}

--- a/internal/gitutil/branch_test.go
+++ b/internal/gitutil/branch_test.go
@@ -1,0 +1,68 @@
+package gitutil
+
+import (
+	"testing"
+)
+
+func TestValidateBranchName(t *testing.T) {
+	tests := []struct {
+		name    string
+		branch  string
+		wantErr bool
+	}{
+		{"valid simple", "feature/login", false},
+		{"valid with dots", "release/v1.2.3", false},
+		{"valid with hyphens", "fix/issue-42", false},
+		{"valid single char", "a", false},
+		{"valid alphanumeric", "abc123", false},
+		{"empty", "", true},
+		{"starts with hyphen", "-bad", true},
+		{"starts with dot", ".bad", true},
+		{"ends with hyphen", "bad-", true},
+		{"ends with dot", "bad.", true},
+		{"contains spaces", "bad name", true},
+		{"contains consecutive dots", "bad..name", true},
+		{"contains tilde", "bad~name", true},
+		{"contains caret", "bad^name", true},
+		{"contains colon", "bad:name", true},
+		{"contains backslash", "bad\\name", true},
+		{"too long", string(make([]byte, 256)), true},
+		{"max length", string(make([]byte, 255)), true}, // all zero bytes are invalid chars
+		{"valid agent branch", "agent/issue-123-1234567890", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateBranchName(tt.branch)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateBranchName(%q) error = %v, wantErr %v", tt.branch, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSanitizeBranch(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"clean name", "feature/login", "feature/login"},
+		{"spaces to hyphens", "feature login", "feature-login"},
+		{"tilde removed", "feature~test", "feature-test"},
+		{"leading hyphen stripped", "-feature", "feature"},
+		{"trailing hyphen stripped", "feature-", "feature"},
+		{"leading dot stripped", ".feature", "feature"},
+		{"trailing dot stripped", "feature.", "feature"},
+		{"multiple invalid chars", "feat~ure^test:name", "feat-ure-test-name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeBranch(tt.input)
+			if got != tt.want {
+				t.Errorf("SanitizeBranch(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/mcp/github_tools.go
+++ b/internal/mcp/github_tools.go
@@ -8,29 +8,14 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
-	"regexp"
 	"strings"
 
 	"github.com/sevigo/code-warden/internal/github"
+	"github.com/sevigo/code-warden/internal/gitutil"
 )
 
-// validBranchName matches safe Git branch names: alphanumeric, slashes, hyphens, underscores, dots.
-// Rejects empty strings, double dots (..), and leading or trailing slashes.
-var validBranchName = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9/_\-\.]*[a-zA-Z0-9])?$`)
-
 // validateBranchName checks that a branch name is safe to pass to exec.CommandContext.
-func validateBranchName(name string) error {
-	if name == "" {
-		return fmt.Errorf("branch name cannot be empty")
-	}
-	if len(name) > 255 {
-		return fmt.Errorf("branch name too long (max 255 chars)")
-	}
-	if !validBranchName.MatchString(name) {
-		return fmt.Errorf("branch name %q contains invalid characters", name)
-	}
-	return nil
-}
+var validateBranchName = gitutil.ValidateBranchName
 
 // CreatePRTool creates a pull request in the repository.
 // It requires the agent to have write access to the repository.
@@ -116,6 +101,9 @@ func (t *CreatePRTool) Execute(ctx context.Context, args map[string]any) (any, e
 	head, ok := args["head"].(string)
 	if !ok || head == "" {
 		return nil, fmt.Errorf("head branch is required")
+	}
+	if err := validateBranchName(head); err != nil {
+		return nil, fmt.Errorf("invalid head branch: %w", err)
 	}
 
 	base := "main"
@@ -410,8 +398,12 @@ func (t *PushBranchTool) Execute(ctx context.Context, args map[string]any) (any,
 
 // ensureBranch checks out or creates the target branch if not already on it.
 func (t *PushBranchTool) ensureBranch(ctx context.Context, branch string) error {
+	projectRoot := ProjectRootFromContext(ctx)
+	if projectRoot == "" {
+		projectRoot = t.projectRoot
+	}
 	cmd := exec.CommandContext(ctx, "git", "branch", "--show-current")
-	cmd.Dir = t.projectRoot
+	cmd.Dir = projectRoot
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to get current branch: %w", err)
@@ -426,10 +418,10 @@ func (t *PushBranchTool) ensureBranch(ctx context.Context, branch string) error 
 
 	// Try existing branch first, then create
 	checkout := exec.CommandContext(ctx, "git", "checkout", branch)
-	checkout.Dir = t.projectRoot
+	checkout.Dir = projectRoot
 	if _, err := checkout.CombinedOutput(); err != nil {
 		create := exec.CommandContext(ctx, "git", "checkout", "-b", branch)
-		create.Dir = t.projectRoot
+		create.Dir = projectRoot
 		if out, err := create.CombinedOutput(); err != nil {
 			return fmt.Errorf("failed to create branch '%s': %w (output: %s)", branch, err, string(out))
 		}
@@ -439,8 +431,12 @@ func (t *PushBranchTool) ensureBranch(ctx context.Context, branch string) error 
 
 // commitPendingChanges stages and commits any uncommitted changes.
 func (t *PushBranchTool) commitPendingChanges(ctx context.Context) error {
+	projectRoot := ProjectRootFromContext(ctx)
+	if projectRoot == "" {
+		projectRoot = t.projectRoot
+	}
 	statusCmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
-	statusCmd.Dir = t.projectRoot
+	statusCmd.Dir = projectRoot
 	out, err := statusCmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to check git status: %w", err)
@@ -451,14 +447,14 @@ func (t *PushBranchTool) commitPendingChanges(ctx context.Context) error {
 
 	t.logger.Info("push_branch: committing uncommitted changes")
 
-	addCmd := exec.CommandContext(ctx, "git", "add", "-A")
-	addCmd.Dir = t.projectRoot
+	addCmd := exec.CommandContext(ctx, "git", "add", "-u")
+	addCmd.Dir = projectRoot
 	if out, err := addCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to add changes: %w (output: %s)", err, string(out))
 	}
 
 	commitCmd := exec.CommandContext(ctx, "git", "commit", "-m", "Automated commit from code-warden agent")
-	commitCmd.Dir = t.projectRoot
+	commitCmd.Dir = projectRoot
 	if out, err := commitCmd.CombinedOutput(); err != nil {
 		if !strings.Contains(string(out), "nothing to commit") {
 			return fmt.Errorf("failed to commit changes: %w (output: %s)", err, string(out))
@@ -469,13 +465,17 @@ func (t *PushBranchTool) commitPendingChanges(ctx context.Context) error {
 
 // pushToOrigin pushes the branch to the remote origin.
 func (t *PushBranchTool) pushToOrigin(ctx context.Context, branch string, force bool) (string, error) {
+	projectRoot := ProjectRootFromContext(ctx)
+	if projectRoot == "" {
+		projectRoot = t.projectRoot
+	}
 	args := []string{"push", "-u", "origin", branch}
 	if force {
 		args = append(args, "--force")
 	}
 
 	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Dir = t.projectRoot
+	cmd.Dir = projectRoot
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to push branch '%s': %w (output: %s)", branch, err, string(out))

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -19,6 +20,25 @@ import (
 	"github.com/sevigo/code-warden/internal/storage"
 )
 
+// contextKey is an unexported type for context keys in this package.
+type contextKey string
+
+const projectRootKey contextKey = "projectRoot"
+
+// ProjectRootFromContext returns the per-session project root from context,
+// or empty string if not set.
+func ProjectRootFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(projectRootKey).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// withProjectRoot returns a context with the given project root.
+func withProjectRoot(ctx context.Context, root string) context.Context {
+	return context.WithValue(ctx, projectRootKey, root)
+}
+
 // Server implements an MCP server for code-warden.
 type Server struct {
 	store       storage.Store
@@ -27,22 +47,27 @@ type Server struct {
 	ghClient    github.Client
 	repo        *storage.Repository
 	repoConfig  *core.RepoConfig
-	ProjectRoot string
+	projectRoot string
 	logger      *slog.Logger
 	tools       map[string]Tool
 
 	// SSE session management
 	sessionsMu sync.RWMutex
 	sessions   map[string]*sseSession
+
+	// Per-session workspace overrides (maps workspace token -> project root path)
+	workspacesMu sync.RWMutex
+	workspaces   map[string]string
 }
 
 // sseSession represents an active SSE connection.
 type sseSession struct {
-	id       string
-	messages chan []byte
-	done     chan struct{}
-	ctx      context.Context
-	cancel   context.CancelFunc
+	id          string
+	messages    chan []byte
+	done        chan struct{}
+	ctx         context.Context
+	cancel      context.CancelFunc
+	projectRoot string // per-session workspace root
 }
 
 // Tool represents an MCP tool that can be called by an agent.
@@ -83,10 +108,11 @@ func NewServer(
 		ghClient:    ghClient,
 		repo:        repo,
 		repoConfig:  repoConfig,
-		ProjectRoot: projectRoot,
+		projectRoot: projectRoot,
 		logger:      logger,
 		tools:       make(map[string]Tool),
 		sessions:    make(map[string]*sseSession),
+		workspaces:  make(map[string]string),
 	}
 
 	// Register default tools
@@ -111,7 +137,7 @@ func (s *Server) registerTools() {
 	}
 	s.tools["get_structure"] = &GetStructureTool{
 		vectorStore: s.vectorStore,
-		projectRoot: s.ProjectRoot,
+		projectRoot: s.projectRoot,
 		logger:      s.logger,
 	}
 	s.tools["review_code"] = &ReviewCodeTool{
@@ -129,7 +155,7 @@ func (s *Server) registerTools() {
 			s.tools["create_pull_request"] = NewCreatePRTool(s.ghClient, owner, name, s.logger)
 			s.tools["list_issues"] = NewListIssuesTool(s.ghClient, owner, name, s.logger)
 			s.tools["get_issue"] = NewGetIssueTool(s.ghClient, owner, name, s.logger)
-			s.tools["push_branch"] = NewPushBranchTool(s.ProjectRoot, s.logger)
+			s.tools["push_branch"] = NewPushBranchTool(s.projectRoot, s.logger)
 		}
 	}
 }
@@ -143,7 +169,24 @@ func parseRepoFullName(fullName string) (owner, name string) {
 	return "", fullName
 }
 
-// ListTools returns all available tools.
+// RegisterWorkspace associates a workspace token with a project root path.
+// The token is passed by the agent via the SSE connection URL.
+func (s *Server) RegisterWorkspace(token, projectRoot string) {
+	s.workspacesMu.Lock()
+	s.workspaces[token] = projectRoot
+	s.workspacesMu.Unlock()
+	s.logger.Info("workspace registered", "token", token, "project_root", projectRoot)
+}
+
+// UnregisterWorkspace removes a workspace association.
+func (s *Server) UnregisterWorkspace(token string) {
+	s.workspacesMu.Lock()
+	delete(s.workspaces, token)
+	s.workspacesMu.Unlock()
+	s.logger.Debug("workspace unregistered", "token", token)
+}
+
+// ListTools returns all available tools in deterministic order.
 func (s *Server) ListTools() []ToolInfo {
 	tools := make([]ToolInfo, 0, len(s.tools))
 	for name, tool := range s.tools {
@@ -153,6 +196,9 @@ func (s *Server) ListTools() []ToolInfo {
 			InputSchema: tool.InputSchema(),
 		})
 	}
+	sort.Slice(tools, func(i, j int) bool {
+		return tools[i].Name < tools[j].Name
+	})
 	return tools
 }
 
@@ -235,14 +281,27 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	// Generate session ID
 	sessionID := generateSessionID()
 
+	// Resolve per-session project root from workspace token
+	workspaceToken := r.URL.Query().Get("workspace")
+	projectRoot := s.projectRoot // default
+	if workspaceToken != "" {
+		s.workspacesMu.RLock()
+		if override, ok := s.workspaces[workspaceToken]; ok {
+			projectRoot = override
+		}
+		s.workspacesMu.RUnlock()
+		s.logger.Debug("SSE session workspace resolved", "session_id", sessionID, "workspace", workspaceToken, "project_root", projectRoot)
+	}
+
 	// Create a per-session context that is cancelled when the client disconnects
 	sessionCtx, sessionCancel := context.WithCancel(r.Context())
 	session := &sseSession{
-		id:       sessionID,
-		messages: make(chan []byte, 100),
-		done:     make(chan struct{}),
-		ctx:      sessionCtx,
-		cancel:   sessionCancel,
+		id:          sessionID,
+		messages:    make(chan []byte, 100),
+		done:        make(chan struct{}),
+		ctx:         sessionCtx,
+		cancel:      sessionCancel,
+		projectRoot: projectRoot,
 	}
 
 	s.sessionsMu.Lock()
@@ -321,6 +380,10 @@ func (s *Server) handleMessage(w http.ResponseWriter, r *http.Request) {
 			case <-toolCtx.Done():
 			}
 		}()
+		// Inject per-session project root into tool context
+		if session.projectRoot != "" {
+			toolCtx = withProjectRoot(toolCtx, session.projectRoot)
+		}
 	} else {
 		toolCtx = r.Context()
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -346,6 +346,11 @@ func (t *GetStructureTool) InputSchema() map[string]any {
 }
 
 func (t *GetStructureTool) Execute(ctx context.Context, _ map[string]any) (any, error) {
+	projectRoot := ProjectRootFromContext(ctx)
+	if projectRoot == "" {
+		projectRoot = t.projectRoot
+	}
+
 	// Get root-level architectural summary
 	query := "project structure architecture overview main directories"
 	docs, err := t.vectorStore.SimilaritySearch(ctx, query, 10,
@@ -380,7 +385,7 @@ func (t *GetStructureTool) Execute(ctx context.Context, _ map[string]any) (any, 
 	}
 
 	return StructureResponse{
-		ProjectRoot: t.projectRoot,
+		ProjectRoot: projectRoot,
 		Directories: directories,
 	}, nil
 }


### PR DESCRIPTION
Critical: Fix ProjectRoot race condition with per-session workspace registry
Critical: Make session limit check atomic with insert in SpawnAgent
High: Add head branch validation in CreatePRTool
High: Use git add -u instead of -A in commitPendingChanges
Medium: Sort ListTools output for deterministic ordering
Medium: Extract shared ValidateBranchName/SanitizeBranch to gitutil
Medium: Make cleanupLoop stoppable via done channel
Docs: Add push_branch to tool table in opencode-config.md
Docs: Remove non-existent verifyMCPConfig reference