### PR TITLE
refactor(rag): extract detect package

### DIFF
--- a/internal/rag/TODO.md
+++ b/internal/rag/TODO.md
@@ -153,9 +153,11 @@ Each step is a standalone PR that compiles and passes tests.
 - [ ] Define `ContextBuilder` interface, make `ragService.GenerateReview` call it
 - [ ] Verify: `make lint && make test`
 
-#### Phase 2: Move `detect/` and `question/` (already self-contained)
-- [ ] Move `ReuseDetector` + types → `internal/rag/detect/reuse.go`
-- [ ] Move `snippetValidator` → `internal/rag/detect/validator.go`
+#### Phase 2: ~~Move `detect/` and `question/`~~ ✅
+### ~~Extract `detect/` Package~~ ✅
+- [x] Move `ReuseDetector` + types → `internal/rag/detect/reuse.go`
+- [x] Move `snippetValidator` → `internal/rag/detect/validator.go`
+- [x] Easy first step: they are completely self-contained, no cyclic dependencies
 - [ ] Move `AnswerQuestion`, `answerWithValidation`, `answerWithoutValidation` → `internal/rag/question/qa.go`
 - [ ] Update imports in callers
 - [ ] Verify: `make lint && make test`

--- a/internal/rag/detect/reuse.go
+++ b/internal/rag/detect/reuse.go
@@ -1,4 +1,4 @@
-package rag
+package detect
 
 import (
 	"context"

--- a/internal/rag/detect/reuse_test.go
+++ b/internal/rag/detect/reuse_test.go
@@ -1,4 +1,4 @@
-package rag
+package detect
 
 import (
 	"log/slog"

--- a/internal/rag/detect/validator.go
+++ b/internal/rag/detect/validator.go
@@ -1,4 +1,4 @@
-package rag
+package detect
 
 import (
 	"context"
@@ -11,15 +11,15 @@ import (
 	"github.com/sevigo/code-warden/internal/llm"
 )
 
-// snippetValidator validates code snippet relevance to a PR via batch LLM calls.
-type snippetValidator struct {
+// SnippetValidator validates code snippet relevance to a PR via batch LLM calls.
+type SnippetValidator struct {
 	validatorLLM llms.Model
 	promptMgr    *llm.PromptManager
 }
 
-// newSnippetValidator creates a new [snippetValidator].
-func newSnippetValidator(validatorLLM llms.Model, promptMgr *llm.PromptManager) *snippetValidator {
-	return &snippetValidator{
+// NewSnippetValidator creates a new [SnippetValidator].
+func NewSnippetValidator(validatorLLM llms.Model, promptMgr *llm.PromptManager) *SnippetValidator {
+	return &SnippetValidator{
 		validatorLLM: validatorLLM,
 		promptMgr:    promptMgr,
 	}
@@ -28,8 +28,8 @@ func newSnippetValidator(validatorLLM llms.Model, promptMgr *llm.PromptManager) 
 // batchValidationResult maps snippet index (as string) to relevance boolean.
 type batchValidationResult map[string]bool
 
-// validateBatch validates all snippets in a single LLM call, returning relevance per index.
-func (v *snippetValidator) validateBatch(ctx context.Context, snippets []string, prContext string) map[int]bool {
+// ValidateBatch validates all snippets in a single LLM call, returning relevance per index.
+func (v *SnippetValidator) ValidateBatch(ctx context.Context, snippets []string, prContext string) map[int]bool {
 	result := make(map[int]bool, len(snippets))
 	for i := range snippets {
 		result[i] = true // fail-open default
@@ -60,7 +60,7 @@ func (v *snippetValidator) validateBatch(ctx context.Context, snippets []string,
 }
 
 // buildBatchPrompt constructs the prompt for batch snippet validation.
-func (v *snippetValidator) buildBatchPrompt(snippets []string, prContext string) (string, error) {
+func (v *SnippetValidator) buildBatchPrompt(snippets []string, prContext string) (string, error) {
 	var snippetList strings.Builder
 	for i, s := range snippets {
 		preview := s

--- a/internal/rag/rag_context.go
+++ b/internal/rag/rag_context.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	internalgithub "github.com/sevigo/code-warden/internal/github"
+	"github.com/sevigo/code-warden/internal/rag/detect"
 	"github.com/sevigo/code-warden/internal/storage"
 )
 
@@ -595,8 +596,8 @@ func (r *ragService) filterValidDescriptionDocs(ctx context.Context, descKeys ma
 	if len(snippets) > 0 && prDescription != "" {
 		validatorLLM, err := r.getOrCreateLLM(ctx, r.cfg.AI.FastModel)
 		if err == nil {
-			v := newSnippetValidator(validatorLLM, r.promptMgr)
-			relevanceMap = v.validateBatch(ctx, snippets, prDescription)
+			v := detect.NewSnippetValidator(validatorLLM, r.promptMgr)
+			relevanceMap = v.ValidateBatch(ctx, snippets, prDescription)
 		} else {
 			for i := range snippets {
 				relevanceMap[i] = true


### PR DESCRIPTION
## Summary
Extracted the completely self-contained  and  from the root `rag` package into a new `internal/rag/detect` sub-package as part of Phase 2 of the RAG architectural split.

- Moved `reuse_detector.go` -> `detect/reuse.go`
- Moved `snippet_validator.go` -> `detect/validator.go`
- Moved `reuse_detector_test.go` -> `detect/reuse_test.go`
- Updated imports in `rag_context.go`

Testing:
- `make lint` passes
- `make test` passes