### PR TITLE
feat(agent): real-time output streaming and extended tests

### DIFF
--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -510,7 +510,9 @@ func (o *Orchestrator) runAgentCLI(ctx context.Context, session *Session, system
 	cmd := o.buildOpenCodeCommand(ctx, session.ID, session.Issue, systemPrompt, branch)
 	cmd.Dir = workspaceDir // Run in the isolated workspace
 
-	// Setup log file for streaming
+	// Setup log file for streaming.
+	// Note: We open the file here for writing, and readLogFile opens it again for reading.
+	// This is safe on Unix-like systems (macOS/Linux) as the OS handles concurrent access.
 	logPath := filepath.Join(workspaceDir, "agent.log")
 	logFile, err := os.Create(logPath)
 	if err != nil {
@@ -543,7 +545,9 @@ func (o *Orchestrator) runAgentCLI(ctx context.Context, session *Session, system
 
 	if err != nil {
 		session.SetStatus(StatusFailed)
-		// Include tail of output in the session error for context
+		// Include tail of output in the session error for context.
+		// We use truncateTail here to capture the most recent (failure-related) output,
+		// while truncateString below captures the early logs for the internal logger.
 		tail := truncateTail(output, 2000)
 		session.SetError(fmt.Sprintf("Agent failed: %v\nTail of output:\n%s", err, tail))
 		session.mu.Lock()
@@ -784,14 +788,12 @@ func truncateTail(s string, maxLen int) string {
 }
 
 // readLogFile reads the content of a file up to maxBytes.
+// If the file exceeds maxBytes, it reads the *last* maxBytes to ensure
+// the AGENT_RESULT: sentinel (typically at the end) is captured.
 func (o *Orchestrator) readLogFile(path string, maxBytes int64) ([]byte, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, err
-	}
-
-	if info.Size() > maxBytes {
-		o.logger.Warn("readLogFile: log file exceeds size cap, truncating read", "path", path, "size", info.Size(), "cap", maxBytes)
 	}
 
 	f, err := os.Open(path)
@@ -800,9 +802,19 @@ func (o *Orchestrator) readLogFile(path string, maxBytes int64) ([]byte, error) 
 	}
 	defer f.Close()
 
-	readSize := info.Size()
-	if readSize > maxBytes {
+	size := info.Size()
+	var offset int64
+	readSize := size
+
+	if size > maxBytes {
+		o.logger.Warn("readLogFile: log file exceeds size cap, truncating read from the end",
+			"path", path, "size", size, "cap", maxBytes)
+		offset = size - maxBytes
 		readSize = maxBytes
+
+		if _, err := f.Seek(offset, io.SeekStart); err != nil {
+			return nil, fmt.Errorf("failed to seek in log file: %w", err)
+		}
 	}
 
 	// Read up to readSize

--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -508,34 +510,61 @@ func (o *Orchestrator) runAgentCLI(ctx context.Context, session *Session, system
 	cmd := o.buildOpenCodeCommand(ctx, session.ID, session.Issue, systemPrompt, branch)
 	cmd.Dir = workspaceDir // Run in the isolated workspace
 
+	// Setup log file for streaming
+	logPath := filepath.Join(workspaceDir, "agent.log")
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		o.logger.Error("runAgentCLI: failed to create log file", "session_id", session.ID, "path", logPath, "error", err)
+		session.SetStatus(StatusFailed)
+		session.SetError(fmt.Sprintf("failed to create log file: %v", err))
+		return
+	}
+	defer logFile.Close()
+
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
 	o.logger.Info("runAgentCLI: starting OpenCode process",
 		"session_id", session.ID,
 		"command", cmd.String(),
 		"working_dir", cmd.Dir,
+		"log_file", logPath,
 		"timeout", o.config.Timeout)
 
 	// Run the agent
-	output, err := cmd.CombinedOutput()
+	err = cmd.Run()
+
+	// Read log file (capped at 10MB)
+	outputBytes, readErr := o.readLogFile(logPath, 10*1024*1024)
+	if readErr != nil {
+		o.logger.Warn("runAgentCLI: failed to read log file", "session_id", session.ID, "path", logPath, "error", readErr)
+	}
+	output := string(outputBytes)
+
 	if err != nil {
 		session.SetStatus(StatusFailed)
-		session.SetError(fmt.Sprintf("Agent failed: %v\nOutput: %s", err, string(output)))
+		// Include tail of output in the session error for context
+		tail := truncateTail(output, 2000)
+		session.SetError(fmt.Sprintf("Agent failed: %v\nTail of output:\n%s", err, tail))
 		session.mu.Lock()
 		session.CompletedAt = time.Now()
 		session.mu.Unlock()
 		o.logger.Error("runAgentCLI: agent process failed",
 			"session_id", session.ID,
 			"error", err,
+			"log_file", logPath,
 			"output_length", len(output),
-			"output_preview", truncateString(string(output), 500))
+			"output_preview", truncateString(output, 500))
 		return
 	}
 
 	o.logger.Info("runAgentCLI: agent process completed successfully",
 		"session_id", session.ID,
+		"log_file", logPath,
 		"output_length", len(output))
 
-	// Parse result
-	result := o.parseAgentOutput(string(output), branch)
+	// Parse result from the streamed output
+	result := o.parseAgentOutput(output, branch)
 
 	session.SetResult(result)
 	session.SetStatus(StatusCompleted)
@@ -744,6 +773,46 @@ func truncateString(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen] + "..."
+}
+
+// truncateTail returns the last maxLen characters of a string.
+func truncateTail(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return "... [truncated] ...\n" + s[len(s)-maxLen:]
+}
+
+// readLogFile reads the content of a file up to maxBytes.
+func (o *Orchestrator) readLogFile(path string, maxBytes int64) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if info.Size() > maxBytes {
+		o.logger.Warn("readLogFile: log file exceeds size cap, truncating read", "path", path, "size", info.Size(), "cap", maxBytes)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	readSize := info.Size()
+	if readSize > maxBytes {
+		readSize = maxBytes
+	}
+
+	// Read up to readSize
+	buf := make([]byte, readSize)
+	_, err = io.ReadFull(f, buf)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return nil, err
+	}
+
+	return buf, nil
 }
 
 // cleanupWorkspace removes the session's isolated workspace directory.

--- a/internal/agent/orchestrator_test.go
+++ b/internal/agent/orchestrator_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -238,5 +239,37 @@ func TestCleanupOldSessions(t *testing.T) {
 	// Verify workspace cleanup
 	if _, err := os.Stat(oldWorkspace); !os.IsNotExist(err) {
 		t.Errorf("cleanupOldSessions() failed to remove old workspace directory")
+	}
+}
+
+func TestReadLogFile_Capping(t *testing.T) {
+	o := &Orchestrator{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "large.log")
+
+	// Create a log file larger than the cap
+	capSize := int64(50)
+	sentinel := "AGENT_RESULT: {\"pr_number\": 123}"
+	// Total size will be 100 + len(sentinel)
+	content := strings.Repeat("A", 100) + sentinel
+	err := os.WriteFile(logPath, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("failed to create mock log file: %v", err)
+	}
+
+	got, err := o.readLogFile(logPath, capSize)
+	if err != nil {
+		t.Fatalf("readLogFile() error: %v", err)
+	}
+
+	if int64(len(got)) != capSize {
+		t.Errorf("readLogFile() expected length %d, got %d", capSize, len(got))
+	}
+
+	// Verify it contains the end of the sentinel which was at the end of the file
+	if !strings.Contains(string(got), "AGENT_RESULT:") {
+		t.Errorf("readLogFile() failed to capture trailing sentinel. Content: %s", string(got))
 	}
 }


### PR DESCRIPTION
This PR introduces real-time streaming for agent output, expands the test coverage for the orchestrator, and ensures robust result parsing for large logs:

### 1. Real-time Output Streaming
- Replaced `CombinedOutput()` with streaming to an `agent.log` file in the session workspace.
- Implemented capped log reading (10MB limit) for result parsing.
- **Robustness Fix**: The orchestrator now seeks to the end of the log file when it exceeds the cap, ensuring the trailing `AGENT_RESULT:` sentinel is always captured even in huge runs.
- Enhanced error reporting: on process failure, the session error now includes the tail of the log file for better context.

### 2. Extended Test Coverage
Added unit tests for core `Orchestrator` session management:
- `TestSpawnAgent`: Verifies enabled checks and concurrency limits.
- `TestCancelSession`: Verifies context cancellation and status updates.
- `TestCleanupOldSessions`: Verifies automated removal of old sessions and workspace cleanup.
- `TestGetSession`: Verifies session retrieval logic.
- `TestReadLogFile_Capping`: Specifically verifies the seek-to-end logic for large log files.

### 3. Cleanup & Fixes
- Fixed `errorlint` warnings by using `errors.Is`.
- Improved log messages to include full log file paths for post-mortem debugging.
- Added clarifying comments on truncation strategies and concurrent file access safety.

Verified with `make lint` and `make test`. (Builds on top of PR #176 improvements).
