### PR TITLE
test: add hello endpoint for health check

### DIFF
--- a/internal/server/handler/hello.go
+++ b/internal/server/handler/hello.go
@@ -1,0 +1,29 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+type HelloHandler struct{}
+
+func NewHelloHandler() *HelloHandler {
+	return &HelloHandler{}
+}
+
+type HelloResponse struct {
+	Message   string `json:"message"`
+	Timestamp string `json:"timestamp"`
+}
+
+func (h *HelloHandler) Handle(w http.ResponseWriter, _ *http.Request) {
+	response := HelloResponse{
+		Message:   "Hello from Code-Warden!",
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(response)
+}

--- a/internal/server/handler/hello_test.go
+++ b/internal/server/handler/hello_test.go
@@ -1,0 +1,34 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHelloHandler_Handle(t *testing.T) {
+	handler := NewHelloHandler()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/hello", nil)
+	recorder := httptest.NewRecorder()
+
+	handler.Handle(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, recorder.Code)
+	}
+
+	var response HelloResponse
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Message != "Hello from Code-Warden!" {
+		t.Errorf("expected message %q, got %q", "Hello from Code-Warden!", response.Message)
+	}
+
+	if _, err := time.Parse(time.RFC3339, response.Timestamp); err != nil {
+		t.Errorf("timestamp is not in ISO8601 format: %v", err)
+	}
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -32,6 +32,9 @@ func NewRouter(cfg *config.Config, dispatcher core.JobDispatcher, logger *slog.L
 
 	// API routes
 	r.Route("/api/v1", func(r chi.Router) {
+		helloHandler := handler.NewHelloHandler()
+		r.Get("/hello", helloHandler.Handle)
+
 		webhookHandler := handler.NewWebhookHandler(cfg, dispatcher, logger)
 		r.Post("/webhook/github", webhookHandler.Handle)
 	})


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/hello` endpoint that returns a JSON greeting
- Response includes message "Hello from Code-Warden!" and ISO8601 timestamp
- Add comprehensive test for the endpoint
- All acceptance criteria met: endpoint returns 200 OK with correct JSON format, includes current timestamp, and test passes