### PR TITLE
fix: pass MCP config via OPENCODE_CONFIG env instead of workspace file

### DIFF
--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -422,7 +422,7 @@ func (o *Orchestrator) runAgentCLI(ctx context.Context, session *Session, system
 	defer ws.logFile.Close()
 	defer o.mcpServer.UnregisterWorkspace(session.ID)
 
-	cmd, cleanup := o.buildOpenCodeCommand(ctx, session.Issue, systemPrompt, branch)
+	cmd, cleanup := o.buildOpenCodeCommand(ctx, session.Issue, systemPrompt, branch, session.ID)
 	defer cleanup()
 	cmd.Dir = ws.dir
 	cmd.Stdout = ws.logFile
@@ -608,7 +608,7 @@ func (o *Orchestrator) getVerifyCommands() []string {
 }
 
 // buildOpenCodeCommand creates the command to run OpenCode and returns a cleanup function.
-func (o *Orchestrator) buildOpenCodeCommand(ctx context.Context, issue Issue, systemPrompt, branch string) (*exec.Cmd, func()) {
+func (o *Orchestrator) buildOpenCodeCommand(ctx context.Context, issue Issue, systemPrompt, branch, sessionID string) (*exec.Cmd, func()) {
 	// OpenCode CLI usage: opencode run [message..]
 	// The prompt is passed as positional arguments after "run"
 	//nolint:gosec // G204: Subprocess launched with variable arguments - intentional for agent execution
@@ -619,8 +619,8 @@ func (o *Orchestrator) buildOpenCodeCommand(ctx context.Context, issue Issue, sy
 		systemPrompt,
 	)
 
-	// Create OpenCode config with MCP timeout
-	configPath, err := o.createOpenCodeConfig()
+	// Create OpenCode config with MCP server and timeout
+	configPath, err := o.createOpenCodeConfig(sessionID)
 	cleanup := func() {
 		if configPath != "" {
 			_ = os.Remove(configPath)
@@ -648,12 +648,22 @@ func (o *Orchestrator) buildOpenCodeCommand(ctx context.Context, issue Issue, sy
 	return cmd, cleanup
 }
 
-// createOpenCodeConfig creates a temporary OpenCode config file with MCP timeout settings.
-func (o *Orchestrator) createOpenCodeConfig() (string, error) {
+// createOpenCodeConfig creates a temporary OpenCode config file with MCP server and timeout settings.
+func (o *Orchestrator) createOpenCodeConfig(sessionID string) (string, error) {
 	// OpenCode expects timeout in milliseconds
 	timeoutMs := o.config.MCPTimeout.Milliseconds()
 
+	// Build MCP server URL with workspace query parameter for per-session routing
+	mcpURL := fmt.Sprintf("http://%s/sse?workspace=%s", o.config.MCPAddr, sessionID)
+
 	config := map[string]any{
+		"mcp": map[string]any{
+			"code-warden": map[string]any{
+				"type":    "remote",
+				"url":     mcpURL,
+				"enabled": true,
+			},
+		},
 		"experimental": map[string]any{
 			"mcp_timeout": timeoutMs,
 		},

--- a/internal/agent/workspace.go
+++ b/internal/agent/workspace.go
@@ -18,8 +18,8 @@ type agentWorkspace struct {
 }
 
 // prepareAgentWorkspace creates the workspace directory, clones the project,
-// writes the opencode config, registers it with the MCP server, and opens the
-// log file. The caller is responsible for closing logFile and calling
+// registers it with the MCP server, and opens the log file.
+// The caller is responsible for closing logFile and calling
 // mcpServer.UnregisterWorkspace.
 func (o *Orchestrator) prepareAgentWorkspace(ctx context.Context, session *Session) (*agentWorkspace, error) {
 	workspaceDir := filepath.Join(o.config.WorkingDir, session.ID)
@@ -52,10 +52,6 @@ func (o *Orchestrator) prepareAgentWorkspace(ctx context.Context, session *Sessi
 	}
 	o.logger.Info("workspace origin set to GitHub upstream", "url", logURL)
 
-	if err := o.writeOpencodeConfig(workspaceDir, session.ID); err != nil {
-		return nil, fmt.Errorf("failed to write opencode config: %w", err)
-	}
-
 	o.mcpServer.RegisterWorkspace(session.ID, workspaceDir)
 
 	logPath := filepath.Join(workspaceDir, "agent.log")
@@ -83,33 +79,6 @@ func (o *Orchestrator) prepareWorkspace(ctx context.Context, destDir string) err
 	}
 
 	return nil
-}
-
-// writeOpencodeConfig writes opencode.json into the workspace directory so
-// OpenCode discovers the per-session MCP server via working directory config.
-func (o *Orchestrator) writeOpencodeConfig(workspaceDir, sessionID string) error {
-	config := fmt.Sprintf(`{
-  "mcp": {
-    "code-warden": {
-      "type": "remote",
-      "url": "http://%s/sse?workspace=%s",
-      "enabled": true
-    }
-  }
-}`, o.config.MCPAddr, sessionID)
-
-	path := filepath.Join(workspaceDir, "opencode.json")
-	if err := os.WriteFile(path, []byte(config), 0600); err != nil {
-		return err
-	}
-
-	// Write .gitignore to exclude workspace-specific files from commits
-	gitignore := `# Agent workspace files - do not commit
-agent.log
-opencode.json
-`
-	gitignorePath := filepath.Join(workspaceDir, ".gitignore")
-	return os.WriteFile(gitignorePath, []byte(gitignore), 0600)
 }
 
 // cleanupWorkspace removes the session's isolated workspace directory.


### PR DESCRIPTION
## Summary

- Removes `writeOpencodeConfig` function that wrote `opencode.json` and `.gitignore` files directly into the cloned workspace repository
- Moves MCP server configuration to the existing temporary config file passed via `OPENCODE_CONFIG` environment variable
- The temporary config file now includes both MCP server URL (with session ID) and timeout settings
- Auto-cleanup of the temp file after agent finishes

## Problem

Previously, the agent orchestrator wrote `opencode.json` and modified `.gitignore` directly in the cloned workspace repository. This:
- Polluted the repo with config files that shouldn't be there
- Could conflict with existing `.gitignore` rules
- Left files behind even after cleanup

## Solution

Use the existing `OPENCODE_CONFIG` environment variable mechanism to pass all OpenCode configuration via a temporary file that:
- Includes the per-session MCP server URL
- Auto-cleans after agent finishes
- Does not modify the cloned repository

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Code compiles (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)