### PR TITLE
fix: use Qdrant $in operator for array filters in delete operations

### DIFF
--- a/internal/rag/index/indexer.go
+++ b/internal/rag/index/indexer.go
@@ -290,7 +290,7 @@ func (i *Indexer) SetupRepoContext(ctx context.Context, repoConfig *core.RepoCon
 		// Actually `processFilesParallel` handles UPSERT.
 		// Deleting from Qdrant requires `DeleteDocumentsByFilter` ("source" in pathsToDelete).
 		if len(pathsToDelete) > 0 && repo.QdrantCollectionName != "" {
-			if err := i.cfg.VectorStore.DeleteDocumentsFromCollectionByFilter(ctx, repo.QdrantCollectionName, repo.EmbedderModelName, map[string]any{"source": pathsToDelete}); err != nil {
+			if err := i.cfg.VectorStore.DeleteDocumentsFromCollectionByFilter(ctx, repo.QdrantCollectionName, repo.EmbedderModelName, map[string]any{"source": map[string]any{"$in": pathsToDelete}}); err != nil {
 				i.cfg.Logger.Warn("failed to delete vectors for removed files", "error", err)
 			}
 		}

--- a/internal/storage/vectorstore.go
+++ b/internal/storage/vectorstore.go
@@ -356,7 +356,7 @@ func (q *qdrantVectorStore) DeleteDocumentsFromCollection(ctx context.Context, c
 		return err
 	}
 
-	filters := map[string]any{"source": documentIDs}
+	filters := map[string]any{"source": map[string]any{"$in": documentIDs}}
 	return store.DeleteDocumentsByFilter(ctx, filters)
 }
 


### PR DESCRIPTION
## Summary
- Fix Qdrant filter syntax for deleting documents by array of sources
- Changed `{"source": paths}` to `{"source": {"$in": paths}}` in two places:
  - `internal/storage/vectorstore.go:359` - `DeleteDocumentsFromCollection`
  - `internal/rag/index/indexer.go:293` - setup cleanup

## Bug
Previously, when files were deleted from a repository, their vectors were NOT removed from Qdrant because the filter was malformed. This caused:
- Stale vectors accumulating in the database
- Incorrect search results including deleted files
- Memory/storage bloat