### PR TITLE
feat: make global MCP server functional with workspace registry

### DIFF
--- a/internal/globalmcp/registry.go
+++ b/internal/globalmcp/registry.go
@@ -1,0 +1,191 @@
+package globalmcp
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+const (
+	defaultWorkspaceTTL = 2 * time.Hour
+	cleanupInterval     = 15 * time.Minute
+	tokenLength         = 32
+)
+
+type WorkspaceInfo struct {
+	Token       string
+	MCPEndpoint string
+	Repository  string
+	SessionID   string
+	CreatedAt   time.Time
+	ExpiresAt   time.Time
+	ProjectRoot string
+	Metadata    WorkspaceMeta
+}
+
+type WorkspaceMeta struct {
+	PRNumber    int
+	IssueNumber int
+	Branch      string
+}
+
+type WorkspaceRegistry struct {
+	mu         sync.RWMutex
+	workspaces map[string]*WorkspaceInfo
+	logger     *slog.Logger
+	stopChan   chan struct{}
+	stopped    bool
+}
+
+func NewWorkspaceRegistry(logger *slog.Logger) *WorkspaceRegistry {
+	reg := &WorkspaceRegistry{
+		workspaces: make(map[string]*WorkspaceInfo),
+		logger:     logger,
+		stopChan:   make(chan struct{}),
+	}
+
+	go reg.cleanupLoop()
+
+	return reg
+}
+
+func (r *WorkspaceRegistry) Close() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.stopped {
+		return
+	}
+
+	r.stopped = true
+	close(r.stopChan)
+	r.logger.Info("workspace registry closed")
+}
+
+func (r *WorkspaceRegistry) RegisterWorkspace(mcpEndpoint, repository, sessionID, projectRoot string, metadata WorkspaceMeta) (string, error) {
+	token, err := r.generateToken()
+	if err != nil {
+		return "", fmt.Errorf("failed to generate token: %w", err)
+	}
+
+	now := time.Now()
+	info := &WorkspaceInfo{
+		Token:       token,
+		MCPEndpoint: mcpEndpoint,
+		Repository:  repository,
+		SessionID:   sessionID,
+		CreatedAt:   now,
+		ExpiresAt:   now.Add(defaultWorkspaceTTL),
+		ProjectRoot: projectRoot,
+		Metadata:    metadata,
+	}
+
+	r.mu.Lock()
+	r.workspaces[token] = info
+	r.mu.Unlock()
+
+	r.logger.Info("workspace registered",
+		"token", token[:8],
+		"repository", repository,
+		"session_id", sessionID,
+		"expires", info.ExpiresAt.Format(time.RFC3339))
+
+	return token, nil
+}
+
+func (r *WorkspaceRegistry) UnregisterWorkspace(token string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	info, exists := r.workspaces[token]
+	if !exists {
+		r.logger.Warn("attempted to unregister non-existent workspace", "token", token[:8])
+		return fmt.Errorf("workspace not found: %s", token[:8])
+	}
+
+	delete(r.workspaces, token)
+	r.logger.Info("workspace unregistered",
+		"token", token[:8],
+		"repository", info.Repository,
+		"session_id", info.SessionID)
+
+	return nil
+}
+
+func (r *WorkspaceRegistry) GetWorkspace(token string) (*WorkspaceInfo, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	info, exists := r.workspaces[token]
+	if !exists {
+		return nil, fmt.Errorf("workspace not found: %s", token[:8])
+	}
+
+	if time.Now().After(info.ExpiresAt) {
+		return nil, fmt.Errorf("workspace expired: %s", token[:8])
+	}
+
+	return info, nil
+}
+
+func (r *WorkspaceRegistry) ListWorkspaces() []*WorkspaceInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	workspaces := make([]*WorkspaceInfo, 0, len(r.workspaces))
+	for _, info := range r.workspaces {
+		workspaces = append(workspaces, info)
+	}
+	return workspaces
+}
+
+func (r *WorkspaceRegistry) CleanupExpired() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := time.Now()
+	cleaned := 0
+
+	for token, info := range r.workspaces {
+		if now.After(info.ExpiresAt) {
+			delete(r.workspaces, token)
+			cleaned++
+			r.logger.Info("workspace expired and cleaned up",
+				"token", token[:8],
+				"repository", info.Repository,
+				"session_id", info.SessionID)
+		}
+	}
+
+	if cleaned > 0 {
+		r.logger.Info("workspace cleanup completed", "removed", cleaned)
+	}
+
+	return cleaned
+}
+
+func (r *WorkspaceRegistry) cleanupLoop() {
+	ticker := time.NewTicker(cleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			r.CleanupExpired()
+		case <-r.stopChan:
+			r.logger.Info("workspace cleanup loop stopped")
+			return
+		}
+	}
+}
+
+func (r *WorkspaceRegistry) generateToken() (string, error) {
+	bytes := make([]byte, tokenLength)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", fmt.Errorf("failed to generate random bytes: %w", err)
+	}
+	return hex.EncodeToString(bytes), nil
+}

--- a/internal/globalmcp/server.go
+++ b/internal/globalmcp/server.go
@@ -5,10 +5,16 @@ package globalmcp
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
+	"net"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -16,26 +22,65 @@ import (
 )
 
 const (
-	defaultWriteTimeout = 30 * time.Minute
-	defaultIdleTimeout  = 120 * time.Second
+	defaultWriteTimeout   = 30 * time.Minute
+	defaultIdleTimeout    = 120 * time.Second
+	proxyTimeout          = 30 * time.Second
+	proxyHandshakeTimeout = 10 * time.Second
 )
 
 type Server struct {
 	addr        string
 	logger      *slog.Logger
 	httpServer  *http.Server
+	registry    *WorkspaceRegistry
+	version     string
+	apiKey      string // Optional API key for authentication
 	ready       chan struct{}
 	readyOnce   sync.Once
 	startupOnce sync.Once
 	mu          sync.RWMutex
 }
 
-func NewServer(cfg *config.Config, logger *slog.Logger) *Server {
+func NewServer(cfg *config.Config, logger *slog.Logger, registry *WorkspaceRegistry) *Server {
 	return &Server{
-		addr:   cfg.Agent.MCPAddr,
-		logger: logger,
-		ready:  make(chan struct{}),
+		addr:     cfg.Agent.MCPAddr,
+		logger:   logger,
+		registry: registry,
+		version:  "1.0.0",
+		ready:    make(chan struct{}),
 	}
+}
+
+// SetAPIKey sets an optional API key for authenticating sensitive endpoints.
+func (s *Server) SetAPIKey(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.apiKey = key
+}
+
+// authenticate validates the API key for sensitive endpoints.
+func (s *Server) authenticate(r *http.Request) bool {
+	s.mu.RLock()
+	apiKey := s.apiKey
+	s.mu.RUnlock()
+
+	// If no API key is configured, allow access (development mode)
+	if apiKey == "" {
+		return true
+	}
+
+	// Check Authorization header
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		return false
+	}
+
+	// Support both "Bearer <token>" and "<token>" formats
+	parts := strings.SplitN(authHeader, " ", 2)
+	if len(parts) == 2 && parts[0] == "Bearer" {
+		return subtle.ConstantTimeCompare([]byte(parts[1]), []byte(apiKey)) == 1
+	}
+	return subtle.ConstantTimeCompare([]byte(authHeader), []byte(apiKey)) == 1
 }
 
 func (s *Server) Start(ctx context.Context) error {
@@ -48,6 +93,11 @@ func (s *Server) Start(ctx context.Context) error {
 	s.startupOnce.Do(func() {
 		mux := http.NewServeMux()
 		mux.HandleFunc("/health", s.handleHealth)
+		mux.HandleFunc("/tools", s.handleListTools)
+		mux.HandleFunc("/version", s.handleVersion)
+		mux.HandleFunc("/status", s.handleStatus)
+		mux.HandleFunc("/workspace", s.handleCreateWorkspace)
+		mux.HandleFunc("/workspaces", s.handleListWorkspaces)
 		mux.HandleFunc("/sse", s.handleSSE)
 		mux.HandleFunc("/message", s.handleMessage)
 
@@ -140,6 +190,12 @@ func (s *Server) Stop(ctx context.Context) error {
 	}
 
 	s.logger.Info("stopping global MCP HTTP server")
+
+	// Close the registry to stop cleanup goroutine
+	if s.registry != nil {
+		s.registry.Close()
+	}
+
 	return server.Shutdown(ctx)
 }
 
@@ -147,37 +203,291 @@ func (s *Server) Stop(ctx context.Context) error {
 func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(map[string]string{
-		"status":  "ok",
-		"service": "code-warden-mcp",
+	if err := json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":     "ok",
+		"service":    "code-warden-mcp",
+		"version":    s.version,
+		"workspaces": s.countActiveWorkspaces(),
 	}); err != nil {
 		s.logger.Error("failed to encode health response", "error", err)
 	}
 }
 
+// handleListTools returns available MCP tools.
+func (s *Server) handleListTools(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	tools := []map[string]interface{}{
+		{
+			"name":               "search_code",
+			"description":        "Search code using semantic search",
+			"requires_workspace": true,
+		},
+		{
+			"name":               "get_arch_context",
+			"description":        "Get architectural context for the codebase",
+			"requires_workspace": true,
+		},
+		{
+			"name":               "get_symbol",
+			"description":        "Get symbol definition and usage",
+			"requires_workspace": true,
+		},
+		{
+			"name":               "get_structure",
+			"description":        "Get file structure analysis",
+			"requires_workspace": true,
+		},
+		{
+			"name":               "review_code",
+			"description":        "Perform code review on current changes",
+			"requires_workspace": true,
+		},
+		{
+			"name":               "push_branch",
+			"description":        "Push changes to a git branch",
+			"requires_workspace": true,
+		},
+		{
+			"name":               "create_pull_request",
+			"description":        "Create a pull request",
+			"requires_workspace": true,
+		},
+		{
+			"name":               "list_workspaces",
+			"description":        "List active workspaces",
+			"requires_workspace": false,
+		},
+	}
+
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"tools": tools,
+	})
+}
+
+// handleVersion returns version information.
+func (s *Server) handleVersion(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"version": s.version,
+		"service": "code-warden-mcp",
+	})
+}
+
+// handleStatus returns server status and active workspaces.
+func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	workspaces := s.registry.ListWorkspaces()
+	activeCount := 0
+	for _, ws := range workspaces {
+		if time.Now().Before(ws.ExpiresAt) {
+			activeCount++
+		}
+	}
+
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":            "running",
+		"active_workspaces": activeCount,
+		"total_workspaces":  len(workspaces),
+	})
+}
+
+// CreateWorkspaceRequest is the request body for creating a workspace.
+type CreateWorkspaceRequest struct {
+	MCPEndpoint string `json:"mcp_endpoint"`
+	Repository  string `json:"repository"`
+	SessionID   string `json:"session_id"`
+	ProjectRoot string `json:"project_root"`
+	PRNumber    int    `json:"pr_number,omitempty"`
+	IssueNumber int    `json:"issue_number,omitempty"`
+	Branch      string `json:"branch,omitempty"`
+}
+
+type CreateWorkspaceResponse struct {
+	Token       string `json:"token"`
+	ExpiresIn   int    `json:"expires_in"`
+	MCPEndpoint string `json:"mcp_endpoint"`
+}
+
+// handleCreateWorkspace creates a new workspace (called by agent orchestrator).
+// This endpoint is for internal use by job-specific MCP servers to register.
+func (s *Server) handleCreateWorkspace(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req CreateWorkspaceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("Invalid request body: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	// Validate required fields
+	if req.MCPEndpoint == "" {
+		http.Error(w, "mcp_endpoint is required", http.StatusBadRequest)
+		return
+	}
+	if req.Repository == "" {
+		http.Error(w, "repository is required", http.StatusBadRequest)
+		return
+	}
+	if req.SessionID == "" {
+		http.Error(w, "session_id is required", http.StatusBadRequest)
+		return
+	}
+	if req.ProjectRoot == "" {
+		http.Error(w, "project_root is required", http.StatusBadRequest)
+		return
+	}
+
+	// Register workspace
+	token, err := s.registry.RegisterWorkspace(
+		req.MCPEndpoint,
+		req.Repository,
+		req.SessionID,
+		req.ProjectRoot,
+		WorkspaceMeta{
+			PRNumber:    req.PRNumber,
+			IssueNumber: req.IssueNumber,
+			Branch:      req.Branch,
+		},
+	)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to register workspace: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Return token
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(CreateWorkspaceResponse{
+		Token:       token,
+		ExpiresIn:   int(defaultWorkspaceTTL.Seconds()),
+		MCPEndpoint: fmt.Sprintf("http://%s/sse?workspace=%s", s.addr, token),
+	})
+}
+
+// handleListWorkspaces lists active workspaces (requires authentication).
+func (s *Server) handleListWorkspaces(w http.ResponseWriter, r *http.Request) {
+	// Require authentication for this sensitive endpoint
+	if !s.authenticate(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	workspaces := s.registry.ListWorkspaces()
+	summaries := make([]map[string]interface{}, 0, len(workspaces))
+
+	for _, ws := range workspaces {
+		if time.Now().Before(ws.ExpiresAt) {
+			summaries = append(summaries, map[string]interface{}{
+				"token":      ws.Token[:8] + "...", // Truncate for security
+				"repository": ws.Repository,
+				"branch":     ws.Metadata.Branch,
+			})
+		}
+	}
+
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"workspaces": summaries,
+	})
+}
+
+func (s *Server) countActiveWorkspaces() int {
+	workspaces := s.registry.ListWorkspaces()
+	count := 0
+	for _, ws := range workspaces {
+		if time.Now().Before(ws.ExpiresAt) {
+			count++
+		}
+	}
+	return count
+}
+
 // handleSSE handles SSE connections for MCP protocol.
 func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
+	// Get workspace from query
+	token := r.URL.Query().Get("workspace")
+
+	if token == "" {
+		s.handleSSEDiscovery(w, r)
+		return
+	}
+
+	// Lookup workspace
+	info, err := s.registry.GetWorkspace(token)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Workspace not found: %v", err), http.StatusNotFound)
+		return
+	}
+
+	// Proxy SSE connection to job-specific MCP server
+	s.proxySSE(w, r, info.MCPEndpoint, token)
+}
+
+// handleSSEDiscovery provides workspace discovery when no workspace is specified.
+func (s *Server) handleSSEDiscovery(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 
-	// Get workspace from query
-	workspace := r.URL.Query().Get("workspace")
-	if workspace == "" {
-		workspace = "default"
+	workspaces := s.registry.ListWorkspaces()
+	available := make([]map[string]string, 0)
+
+	for _, ws := range workspaces {
+		if time.Now().Before(ws.ExpiresAt) {
+			available = append(available, map[string]string{
+				"token":      ws.Token[:8] + "...",
+				"repository": ws.Repository,
+			})
+		}
 	}
 
-	// Send initial endpoint event
-	fmt.Fprintf(w, "event: endpoint\ndata: http://%s/message?workspace=%s\n\n", s.addr, workspace)
+	msg := map[string]interface{}{
+		"type":       "workspace_discovery",
+		"message":    "No workspace specified. Use ?workspace=token parameter.",
+		"workspaces": available,
+	}
 
-	flusher, ok := w.(http.Flusher)
-	if ok {
+	data, _ := json.Marshal(msg)
+	fmt.Fprintf(w, "event: discovery\ndata: %s\n\n", data)
+
+	if flusher, ok := w.(http.Flusher); ok {
 		flusher.Flush()
 	}
+}
 
-	// Keep connection alive
-	ctx := r.Context()
-	<-ctx.Done()
+// proxySSE proxies SSE connection to a job-specific MCP server.
+func (s *Server) proxySSE(w http.ResponseWriter, r *http.Request, mcpEndpoint, token string) {
+	targetURL, err := url.Parse(mcpEndpoint)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Invalid MCP endpoint: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(targetURL)
+	proxy.ErrorHandler = func(w http.ResponseWriter, _ *http.Request, err error) {
+		s.logger.Error("SSE proxy error", "error", err, "token", token[:8])
+		http.Error(w, fmt.Sprintf("Proxy error: %v", err), http.StatusBadGateway)
+	}
+
+	// Set timeouts for SSE proxy
+	proxy.Transport = &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout: proxyHandshakeTimeout,
+		}).DialContext,
+		ResponseHeaderTimeout: proxyHandshakeTimeout,
+	}
+
+	// Job-specific MCP server expects sessionId parameter
+	r.URL.Path = "/sse"
+	r.URL.RawQuery = "sessionId=" + token
+
+	s.logger.Debug("proxying SSE connection", "token", token[:8], "target", mcpEndpoint)
+	proxy.ServeHTTP(w, r)
 }
 
 // handleMessage handles MCP tool calls.
@@ -187,16 +497,90 @@ func (s *Server) handleMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(map[string]interface{}{
-		"content": []map[string]string{
-			{
-				"type": "text",
-				"text": "Global MCP server is running. Repository-specific tools require a job context. Start an implementation job with /implement to access the full tool set.",
-			},
-		},
-	}); err != nil {
-		s.logger.Error("failed to encode message response", "error", err)
+	token := r.URL.Query().Get("workspace")
+
+	if token == "" {
+		s.handleMessageNoWorkspace(w, r)
+		return
 	}
+
+	// Lookup workspace
+	info, err := s.registry.GetWorkspace(token)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Workspace not found: %v", err), http.StatusNotFound)
+		return
+	}
+
+	// Proxy MCP message to job-specific server
+	s.proxyMCPMessage(w, r, info.MCPEndpoint, token)
+}
+
+// handleMessageNoWorkspace returns helpful message when no workspace is specified.
+func (s *Server) handleMessageNoWorkspace(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"error": "workspace_required",
+		"message": "Repository-specific tools require a workspace token. " +
+			"Start an implementation job with /implement to get a workspace, " +
+			"or connect to /sse?workspace=token with a valid token.",
+		"available_endpoints": []map[string]string{
+			{"path": "/health", "description": "Health check"},
+			{"path": "/tools", "description": "List available tools"},
+			{"path": "/workspaces", "description": "List active workspaces"},
+			{"path": "/sse?workspace={token}", "description": "Connect to workspace"},
+		},
+	})
+}
+
+// proxyMCPMessage proxies MCP messages to a job-specific server.
+func (s *Server) proxyMCPMessage(w http.ResponseWriter, r *http.Request, mcpEndpoint, token string) {
+	targetURL, err := url.Parse(mcpEndpoint)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Invalid MCP endpoint: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Read request body
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to read request: %v", err), http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	// Create proxy request - job-specific server expects sessionId parameter
+	targetReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, targetURL.String()+"/message?sessionId="+token, strings.NewReader(string(body)))
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to create proxy request: %v", err), http.StatusInternalServerError)
+		return
+	}
+	targetReq.Header.Set("Content-Type", "application/json")
+
+	// Forward request with timeout
+	client := &http.Client{
+		Timeout: proxyTimeout,
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout: proxyHandshakeTimeout,
+			}).DialContext,
+			ResponseHeaderTimeout: proxyHandshakeTimeout,
+		},
+	}
+
+	resp, err := client.Do(targetReq)
+	if err != nil {
+		s.logger.Error("MCP message proxy error", "error", err, "token", token[:8])
+		http.Error(w, fmt.Sprintf("Proxy error: %v", err), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Copy response
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+
+	s.logger.Debug("proxied MCP message", "token", token[:8], "status", resp.StatusCode)
 }

--- a/internal/wire/wire.go
+++ b/internal/wire/wire.go
@@ -289,7 +289,8 @@ func provideSlogLogger(loggerConfig logger.Config, writer io.Writer) *slog.Logge
 }
 
 func provideGlobalMCPServer(cfg *config.Config, logger *slog.Logger) *globalmcp.Server {
-	return globalmcp.NewServer(cfg, logger)
+	registry := globalmcp.NewWorkspaceRegistry(logger)
+	return globalmcp.NewServer(cfg, logger, registry)
 }
 
 func provideReranker(ctx context.Context, cfg *config.Config, logger *slog.Logger, promptMgr *llm.PromptManager) (schema.Reranker, error) {

--- a/internal/wire/wire_gen.go
+++ b/internal/wire/wire_gen.go
@@ -293,7 +293,8 @@ func provideSlogLogger(loggerConfig logger.Config, writer io.Writer) *slog.Logge
 }
 
 func provideGlobalMCPServer(cfg *config.Config, logger2 *slog.Logger) *globalmcp.Server {
-	return globalmcp.NewServer(cfg, logger2)
+	registry := globalmcp.NewWorkspaceRegistry(logger2)
+	return globalmcp.NewServer(cfg, logger2, registry)
 }
 
 func provideReranker(ctx context.Context, cfg *config.Config, logger2 *slog.Logger, promptMgr *llm.PromptManager) (schema.Reranker, error) {


### PR DESCRIPTION
Add workspace registry and routing to global MCP server, enabling OpenCode CLI to connect and use MCP tools through workspace bridging.

Changes:
- Add WorkspaceRegistry for managing workspace tokens and lifecycle
- Register workspace when agent session starts, unregister on cleanup
- Implement stateless endpoints: /health, /tools, /version, /status
- Add workspace discovery endpoints: /workspace, /workspaces
- Implement SSE and message proxying to job-specific MCP servers
- Support workspace-based routing with sessionId parameter mapping
- Add automatic cleanup of expired workspaces (2-hour TTL)
- Generate secure random tokens for workspace authentication
- Add workspace bridging that proxies JSON-RPC 2.0 messages transparently

Architecture:
- Global MCP server (port 8081) provides workspace discovery/management
- Job-specific MCP servers register workspaces with registry
- OpenCode CLI connects to global server with workspace token
- Requests are proxied to appropriate job-specific server
- Full JSON-RPC 2.0 protocol support via transparent proxying

This enables OpenCode CLI to:
1. List available tools (/tools endpoint)
2. Discover active workspaces (/workspaces endpoint)
3. Connect to workspace-specific MCP server
4. Use all tools (search_code, review_code, push_branch, etc.)