### PR TITLE
feat(terminal): enhance terminal UI with arch-aware QA and /explain command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ SERVER_CMD_PATH=./cmd/server
 CLI_BINARY_NAME=warden-cli
 CLI_CMD_PATH=./cmd/cli
 
+TERMINAL_BINARY_NAME=warden-term
+TERMINAL_CMD_PATH=./cmd/terminal
+
 # Output directory for all binaries and tools
 BIN_DIR=$(CURDIR)/bin
 
@@ -21,7 +24,7 @@ OPENCODE_MCP_URL=http://127.0.0.1:8081/sse
 
 all: build
 
-build: build-server build-cli
+build: build-server build-cli build-terminal
 	@echo "All binaries built successfully in $(BIN_DIR)/"
 
 build-server:
@@ -34,6 +37,11 @@ build-cli:
 	@mkdir -p $(BIN_DIR)
 	@go build -v -o $(BIN_DIR)/$(CLI_BINARY_NAME) $(CLI_CMD_PATH)
 
+build-terminal:
+	@echo "Building terminal UI ($(TERMINAL_BINARY_NAME))..."
+	@mkdir -p $(BIN_DIR)
+	@go build -v -o $(BIN_DIR)/$(TERMINAL_BINARY_NAME) $(TERMINAL_CMD_PATH)
+
 run: build-server
 	@echo "Starting server ($(SERVER_BINARY_NAME))..."
 	@$(BIN_DIR)/$(SERVER_BINARY_NAME)
@@ -41,6 +49,10 @@ run: build-server
 run-cli:
 	@echo "Starting CLI ($(CLI_BINARY_NAME))..."
 	@go run $(CLI_CMD_PATH)
+
+run-terminal:
+	@echo "Starting terminal UI ($(TERMINAL_BINARY_NAME))..."
+	@go run $(TERMINAL_CMD_PATH)
 
 test:
 	@echo "Running tests..."

--- a/README.md
+++ b/README.md
@@ -189,6 +189,54 @@ export CW_GITHUB_TOKEN="ghp_xxx"
 
 ---
 
+## Terminal UI (Onboarding Assistant)
+
+Code-Warden includes an interactive terminal UI for exploring and querying indexed repositories — useful for developer onboarding, code exploration, and debugging.
+
+```sh
+# Build and run the terminal UI
+make build-terminal
+./bin/warden-term
+
+# Or run directly
+go run ./cmd/terminal/main.go
+```
+
+### Themes
+
+The terminal UI supports multiple color themes. Set via flag or environment variable:
+
+```sh
+# Available themes: cyan, matrix, amber, cyberpunk, ice, dracula, fire
+./bin/warden-term --theme matrix
+CODE_WARDEN_THEME=dracula ./bin/warden-term
+
+# List all themes
+./bin/warden-term --list-themes
+```
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `/add [name] [path]` | Register and index a local repository |
+| `/list`, `/ls` | List all registered repositories |
+| `/select [name]` | Set the active repository for questions |
+| `/rescan [name?]` | Re-scan a repo for updates (defaults to selected) |
+| `/new`, `/reset` | Start a new conversation |
+| `/help`, `/h` | Show available commands |
+| `/exit`, `/quit` | Exit the application |
+
+### Usage
+
+1. **Register a repository**: `/add my-project /path/to/repo`
+2. **Select it**: `/select my-project`
+3. **Ask questions freely**: `How does authentication work?`, `What's the pattern for adding a new API endpoint?`
+
+The terminal uses the RAG pipeline to retrieve relevant code context before answering. Answers are informed by architectural summaries, function definitions, and dependency relationships — not just keyword matches.
+
+---
+
 ## Where This Is Going
 
 Code-Warden is actively developed. See [TODO.md](TODO.md) for the full roadmap. Highlights:

--- a/cmd/terminal/commands.go
+++ b/cmd/terminal/commands.go
@@ -132,3 +132,14 @@ func loadReposCmd(app *app.App) tea.Cmd {
 		return reposLoadedMsg{repos: repos, err: err}
 	}
 }
+
+func explainPathCmd(app *app.App, collectionName, embedderModelName, path string) tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+		content, err := app.RAGService.ExplainPath(ctx, collectionName, embedderModelName, path)
+		if err != nil {
+			return explainCompleteMsg{path: path, err: err}
+		}
+		return explainCompleteMsg{path: path, content: content}
+	}
+}

--- a/cmd/terminal/messages.go
+++ b/cmd/terminal/messages.go
@@ -29,6 +29,12 @@ type repoAddedMsg struct {
 // Represents a complete, non-streaming answer from the LLM.
 type answerCompleteMsg struct{ content string }
 
+type explainCompleteMsg struct {
+	path    string
+	content string
+	err     error
+}
+
 // A generic error message for reporting failures from commands.
 type errorMsg struct{ err error }
 

--- a/cmd/terminal/model.go
+++ b/cmd/terminal/model.go
@@ -114,6 +114,8 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.handleRepoAddedMsg(msg)
 	case scanCompleteMsg:
 		return m, m.handleScanCompleteMsg(msg)
+	case explainCompleteMsg:
+		m.handleExplainCompleteMsg(msg)
 	case answerCompleteMsg:
 		m.handleAnswerCompleteMsg(msg)
 	case errorMsg:
@@ -238,6 +240,19 @@ func (m *model) handleAnswerCompleteMsg(msg answerCompleteMsg) {
 	m.conversationHistory = append(m.conversationHistory, fmt.Sprintf("AI: %s", msg.content))
 }
 
+func (m *model) handleExplainCompleteMsg(msg explainCompleteMsg) {
+	m.isLoading = false
+	if msg.err != nil {
+		m.history = append(m.history, m.styles.error.Render("EXPLAIN FAILED: "+msg.err.Error()))
+		return
+	}
+	formatted, err := m.renderer.Render(msg.content)
+	if err != nil {
+		formatted = msg.content
+	}
+	m.history = append(m.history, formatted)
+}
+
 func (m *model) processCommand(input string) tea.Cmd {
 	m.history = append(m.history, m.styles.prompt.Render("► ")+input)
 	parts := strings.Fields(input)
@@ -253,6 +268,8 @@ func (m *model) processCommand(input string) tea.Cmd {
 		return m.processSelectCommand(args)
 	case "/rescan":
 		return m.processRescanCommand(args)
+	case "/explain":
+		return m.processExplainCommand(args)
 	case "/new", "/reset":
 		m.conversationHistory = nil
 		m.history = append(m.history, m.styles.inactive.Render("🧹 Conversation history cleared."))
@@ -336,11 +353,35 @@ func (m *model) processHelpCommand() tea.Cmd {
   /list, /ls           List all available repositories.
   /select [name]       Set the active repository for questions.
   /rescan [name?]      Re-scan a repo for updates (defaults to selected).
+  /explain [path]      Explain a directory or file using arch summaries.
   /new                 Start a new conversation.
   /help                Show this help message.
   /exit, /quit         Exit the application.`
 	m.history = append(m.history, helpText)
 	return nil
+}
+
+func (m *model) processExplainCommand(args []string) tea.Cmd {
+	if len(args) != 1 {
+		m.history = append(m.history, m.styles.error.Render("USAGE: /explain [path]"))
+		return nil
+	}
+	if m.selectedRepo == nil {
+		m.history = append(m.history, m.styles.error.Render("No repository selected. Use /select [name] first."))
+		return nil
+	}
+	path := args[0]
+	m.isLoading = true
+	m.history = append(m.history, m.styles.command.Render(fmt.Sprintf("→ EXPLAINING: %s...", path)))
+	return tea.Batch(
+		m.spinner.Tick,
+		explainPathCmd(
+			m.app,
+			m.selectedRepo.QdrantCollectionName,
+			m.selectedRepo.EmbedderModelName,
+			path,
+		),
+	)
 }
 
 func (m *model) processQuestion(input string) tea.Cmd {

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/wire v0.6.0
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.11.1
-	github.com/sevigo/goframe v0.36.0
+	github.com/sevigo/goframe v0.36.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -283,8 +283,8 @@ github.com/schollz/progressbar/v2 v2.15.0 h1:dVzHQ8fHRmtPjD3K10jT3Qgn/+H+92jhPrh
 github.com/schollz/progressbar/v2 v2.15.0/go.mod h1:UdPq3prGkfQ7MOzZKlDRpYKcFqEMczbD7YmbPgpzKMI=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
-github.com/sevigo/goframe v0.36.0 h1:B18ZwkXss9pLaV4DJxIMkh6+QZXM9JHB/NeO/fUUp28=
-github.com/sevigo/goframe v0.36.0/go.mod h1:jw5g1Tcm5pSkJV+Jf+7Z5luRRqGtKvfi7SAbOd0OcvY=
+github.com/sevigo/goframe v0.36.1 h1:7MVj4tELrOjxDyrBQJf+H7mhJM9gHvFCGY2lClgObv4=
+github.com/sevigo/goframe v0.36.1/go.mod h1:jw5g1Tcm5pSkJV+Jf+7Z5luRRqGtKvfi7SAbOd0OcvY=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=

--- a/internal/llm/prompts/question.prompt
+++ b/internal/llm/prompts/question.prompt
@@ -6,7 +6,14 @@ Use ONLY the provided context to answer the question. Do not make assumptions or
 
 Your answer should be clear, concise, and formatted in Markdown.
 
+When referencing code, include file paths and line numbers when available from the context (e.g., "As shown in `internal/auth/service.go:45`..."). This helps users locate the relevant code.
+
+{{if .History}}
 ---
+CONVERSATION HISTORY:
+{{.History}}
+---
+{{end}}
 CONTEXT FROM THE REPOSITORY:
 {{.Context}}
 ---

--- a/internal/rag/question/qa.go
+++ b/internal/rag/question/qa.go
@@ -18,19 +18,20 @@ import (
 )
 
 const (
-	archResultLimit     = 2
-	similarityLimit     = 5
-	totalRetrievalLimit = 7
+	archResultLimit = 2
+	similarityLimit = 5
 )
 
 var pathPattern = regexp.MustCompile(`(?:^|\s|["'` + "`" + `])([\w/.-]+/[\w/.-]+)(?:$|\s|["'` + "`" + `])`)
 
+// PromptData holds data for the Q&A prompt template.
 type PromptData struct {
 	History  string
 	Context  string
 	Question string
 }
 
+// Config holds dependencies for the QAService.
 type Config struct {
 	VectorStore   storage.VectorStore
 	GeneratorLLM  llms.Model
@@ -40,10 +41,12 @@ type Config struct {
 	ContextFormat func([]schema.Document) string
 }
 
+// QAService orchestrates question answering over repositories.
 type QAService struct {
 	cfg Config
 }
 
+// NewService creates a new QAService instance.
 func NewService(cfg Config) *QAService {
 	return &QAService{cfg: cfg}
 }
@@ -79,7 +82,15 @@ func deduplicateDocs(docs []schema.Document) []schema.Document {
 	var result []schema.Document
 	for _, doc := range docs {
 		source, _ := doc.Metadata["source"].(string)
-		startLine, _ := doc.Metadata["start_line"].(int)
+		var startLine int
+		switch v := doc.Metadata["start_line"].(type) {
+		case int:
+			startLine = v
+		case float64:
+			startLine = int(v)
+		case int64:
+			startLine = int(v)
+		}
 		key := fmt.Sprintf("%s:%d", source, startLine)
 		if !seen[key] {
 			seen[key] = true
@@ -116,7 +127,7 @@ func (s *QAService) AnswerQuestion(ctx context.Context, collectionName, embedder
 	}
 
 	if s.cfg.ValidatorLLM != nil {
-		return s.answerWithValidation(ctx, retriever, question, history)
+		return s.answerWithValidation(ctx, retriever, question)
 	}
 
 	return s.answerWithoutValidation(ctx, retriever, question, history)
@@ -136,9 +147,14 @@ func (s *QAService) retrieveArchSummaries(ctx context.Context, store storage.Sco
 
 	var allArchDocs []schema.Document
 	for _, path := range paths {
-		query := fmt.Sprintf("%s architecture structure", path)
-		docs, err := store.SimilaritySearch(ctx, query, 1,
-			vectorstores.WithFilters(map[string]any{"chunk_type": "arch"}))
+		if len(allArchDocs) >= archResultLimit {
+			break
+		}
+		docs, err := store.SimilaritySearch(ctx, path, 1,
+			vectorstores.WithFilters(map[string]any{
+				"chunk_type": "arch",
+				"source":     path,
+			}))
 		if err != nil {
 			s.cfg.Logger.Warn("failed to retrieve arch summary for path", "path", path, "error", err)
 			continue
@@ -162,8 +178,11 @@ func (s *QAService) extractPaths(question string) []string {
 	return paths
 }
 
-func (s *QAService) answerWithValidation(ctx context.Context, retriever schema.Retriever, question string, history []string) (string, error) {
-	s.cfg.Logger.Debug("answering with validation", "history_len", len(history))
+// answerWithValidation uses ValidatingRetrievalQA which validates retrieved chunks
+// before passing to the generator. Note: Multi-turn conversation history is not currently
+// supported in this path due to limitations in ValidatingRetrievalQA's prompt customization.
+func (s *QAService) answerWithValidation(ctx context.Context, retriever schema.Retriever, question string) (string, error) {
+	s.cfg.Logger.Debug("answering with validation")
 	chain, err := chains.NewValidatingRetrievalQA(
 		retriever,
 		s.cfg.GeneratorLLM,

--- a/internal/rag/question/qa.go
+++ b/internal/rag/question/qa.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 
 	"github.com/sevigo/goframe/chains"
@@ -16,61 +17,153 @@ import (
 	"github.com/sevigo/code-warden/internal/storage"
 )
 
-// PromptData holds data for the Q&A prompt template.
+const (
+	archResultLimit     = 2
+	similarityLimit     = 5
+	totalRetrievalLimit = 7
+)
+
+var pathPattern = regexp.MustCompile(`(?:^|\s|["'` + "`" + `])([\w/.-]+/[\w/.-]+)(?:$|\s|["'` + "`" + `])`)
+
 type PromptData struct {
 	History  string
 	Context  string
 	Question string
 }
 
-// Config holds dependencies for the QAService.
 type Config struct {
 	VectorStore   storage.VectorStore
 	GeneratorLLM  llms.Model
-	ValidatorLLM  llms.Model // Optional fast model for filtering irrelevant context
+	ValidatorLLM  llms.Model
 	PromptMgr     *llm.PromptManager
 	Logger        *slog.Logger
 	ContextFormat func([]schema.Document) string
 }
 
-// QAService orchestrates question answering over repositories.
 type QAService struct {
 	cfg Config
 }
 
-// NewService creates a new [QAService] instance.
 func NewService(cfg Config) *QAService {
 	return &QAService{cfg: cfg}
 }
 
-// AnswerQuestion retrieves relevant documents and generates an answer via LLM.
+type hybridRetriever struct {
+	store     storage.ScopedVectorStore
+	archDocs  []schema.Document
+	sparse    *schema.SparseVector
+	baseLimit int
+}
+
+func (r *hybridRetriever) GetRelevantDocuments(ctx context.Context, query string) ([]schema.Document, error) {
+	var docs []schema.Document
+	var err error
+
+	if r.sparse != nil {
+		docs, err = r.store.SimilaritySearch(ctx, query, r.baseLimit, vectorstores.WithSparseQuery(r.sparse))
+	} else {
+		docs, err = r.store.SimilaritySearch(ctx, query, r.baseLimit)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]schema.Document, 0, len(r.archDocs)+len(docs))
+	result = append(result, r.archDocs...)
+	result = append(result, docs...)
+	return deduplicateDocs(result), nil
+}
+
+func deduplicateDocs(docs []schema.Document) []schema.Document {
+	seen := make(map[string]bool)
+	var result []schema.Document
+	for _, doc := range docs {
+		source, _ := doc.Metadata["source"].(string)
+		startLine, _ := doc.Metadata["start_line"].(int)
+		key := fmt.Sprintf("%s:%d", source, startLine)
+		if !seen[key] {
+			seen[key] = true
+			result = append(result, doc)
+		}
+	}
+	return result
+}
+
 func (s *QAService) AnswerQuestion(ctx context.Context, collectionName, embedderModelName, question string, history []string) (string, error) {
 	s.cfg.Logger.Info("answering question", "collection", collectionName)
 
-	var retriever schema.Retriever
 	scopedStore := s.cfg.VectorStore.ForRepo(collectionName, embedderModelName)
 
+	archDocs := s.retrieveArchSummaries(ctx, scopedStore, question)
+	s.cfg.Logger.Debug("retrieved arch summaries", "count", len(archDocs))
+
 	sparseQuery, err := sparse.GenerateSparseVector(ctx, question)
+	var retriever schema.Retriever
 	if err != nil {
 		s.cfg.Logger.Warn("failed to generate sparse query", "error", err)
-		// Fallback to dense-only
-		retriever = vectorstores.ToRetriever(scopedStore, 5)
+		retriever = &hybridRetriever{
+			store:     scopedStore,
+			archDocs:  archDocs,
+			baseLimit: similarityLimit,
+		}
 	} else {
-		// Use hybrid search with sparse query
-		retriever = vectorstores.ToRetriever(scopedStore, 5, vectorstores.WithSparseQuery(sparseQuery))
+		retriever = &hybridRetriever{
+			store:     scopedStore,
+			archDocs:  archDocs,
+			sparse:    sparseQuery,
+			baseLimit: similarityLimit,
+		}
 	}
 
-	// Use ValidatingRetrievalQA if a validator LLM is configured.
 	if s.cfg.ValidatorLLM != nil {
 		return s.answerWithValidation(ctx, retriever, question, history)
 	}
 
-	// Fallback to standard RetrievalQA without validation
 	return s.answerWithoutValidation(ctx, retriever, question, history)
 }
 
-// answerWithValidation uses a fast validator LLM to filter irrelevant context before answering.
-func (s *QAService) answerWithValidation(ctx context.Context, retriever schema.Retriever, question string, _ []string) (string, error) {
+func (s *QAService) retrieveArchSummaries(ctx context.Context, store storage.ScopedVectorStore, question string) []schema.Document {
+	paths := s.extractPaths(question)
+	if len(paths) == 0 {
+		docs, err := store.SimilaritySearch(ctx, "architecture structure overview module", archResultLimit,
+			vectorstores.WithFilters(map[string]any{"chunk_type": "arch"}))
+		if err != nil {
+			s.cfg.Logger.Warn("failed to retrieve general arch summaries", "error", err)
+			return nil
+		}
+		return docs
+	}
+
+	var allArchDocs []schema.Document
+	for _, path := range paths {
+		query := fmt.Sprintf("%s architecture structure", path)
+		docs, err := store.SimilaritySearch(ctx, query, 1,
+			vectorstores.WithFilters(map[string]any{"chunk_type": "arch"}))
+		if err != nil {
+			s.cfg.Logger.Warn("failed to retrieve arch summary for path", "path", path, "error", err)
+			continue
+		}
+		allArchDocs = append(allArchDocs, docs...)
+	}
+	return allArchDocs
+}
+
+func (s *QAService) extractPaths(question string) []string {
+	matches := pathPattern.FindAllStringSubmatch(question, -1)
+	seen := make(map[string]bool)
+	var paths []string
+	for _, match := range matches {
+		path := strings.Trim(match[1], ` "'`)
+		if !seen[path] {
+			seen[path] = true
+			paths = append(paths, path)
+		}
+	}
+	return paths
+}
+
+func (s *QAService) answerWithValidation(ctx context.Context, retriever schema.Retriever, question string, history []string) (string, error) {
+	s.cfg.Logger.Debug("answering with validation", "history_len", len(history))
 	chain, err := chains.NewValidatingRetrievalQA(
 		retriever,
 		s.cfg.GeneratorLLM,
@@ -90,7 +183,6 @@ func (s *QAService) answerWithValidation(ctx context.Context, retriever schema.R
 	return answer, nil
 }
 
-// answerWithoutValidation uses standard RetrievalQA without context filtering.
 func (s *QAService) answerWithoutValidation(ctx context.Context, retriever schema.Retriever, question string, history []string) (string, error) {
 	chain, err := chains.NewRetrievalQA(
 		retriever,

--- a/internal/rag/question/qa_test.go
+++ b/internal/rag/question/qa_test.go
@@ -41,6 +41,9 @@ func TestAnswerQuestion(t *testing.T) {
 	model := "model"
 
 	mockVS.EXPECT().ForRepo(collection, model).Return(mockSVS)
+	// First call: arch summaries retrieval (for general case when no paths detected)
+	mockSVS.EXPECT().SimilaritySearch(gomock.Any(), "architecture structure overview module", gomock.Any(), gomock.Any()).Return([]schema.Document{}, nil)
+	// Second call: actual similarity search for the question
 	mockSVS.EXPECT().SimilaritySearch(gomock.Any(), question, gomock.Any(), gomock.Any()).Return([]schema.Document{{PageContent: "doc1"}}, nil)
 
 	mockLLM.EXPECT().Call(gomock.Any(), gomock.Any(), gomock.Any()).Return("The answer", nil)
@@ -79,15 +82,10 @@ func TestAnswerWithValidation(t *testing.T) {
 	model := "model"
 
 	mockVS.EXPECT().ForRepo(collection, model).Return(mockSVS)
-	// SimilaritySearch for validation call
+	// First call: arch summaries retrieval (for general case when no paths detected)
+	mockSVS.EXPECT().SimilaritySearch(gomock.Any(), "architecture structure overview module", gomock.Any(), gomock.Any()).Return([]schema.Document{}, nil)
+	// Second call: actual similarity search for the question
 	mockSVS.EXPECT().SimilaritySearch(gomock.Any(), question, gomock.Any(), gomock.Any()).Return([]schema.Document{{PageContent: "relevant doc"}}, nil)
-
-	// Validation call (GeneratorLLM is used for the prompt generation, then ValidatorLLM for filtering)
-	// Actually, AnswerWithValidation calls answerWithoutValidation which uses RetrievalQA chain.
-
-	// The implementation of AnswerWithValidation:
-	// 1. validatorLLM.Call for validation (filter irrelevant)
-	// 2. AnswerWithoutValidation for the final answer
 
 	mockValLLM.EXPECT().Call(gomock.Any(), gomock.Any(), gomock.Any()).Return("yes", nil)
 	mockGenLLM.EXPECT().Call(gomock.Any(), gomock.Any(), gomock.Any()).Return("Final Answer", nil)

--- a/internal/rag/service.go
+++ b/internal/rag/service.go
@@ -353,15 +353,17 @@ func (r *ragService) ExplainPath(ctx context.Context, collectionName, embedderMo
 	r.logger.Info("explaining path", "collection", collectionName, "path", path)
 	scopedStore := r.vectorStore.ForRepo(collectionName, embedderModelName)
 
-	query := fmt.Sprintf("architecture structure purpose of %s", path)
-	docs, err := scopedStore.SimilaritySearch(ctx, query, 3,
-		vectorstores.WithFilters(map[string]any{"chunk_type": "arch"}))
+	docs, err := scopedStore.SimilaritySearch(ctx, path, 1,
+		vectorstores.WithFilters(map[string]any{
+			"chunk_type": "arch",
+			"source":     path,
+		}))
 	if err != nil {
 		return "", fmt.Errorf("failed to retrieve arch context: %w", err)
 	}
 
 	if len(docs) == 0 {
-		return fmt.Sprintf("No architectural context found for path: %s\n\nTry a broader path or use /ask for general questions.", path), nil
+		return fmt.Sprintf("No architectural context found for path: %s\n\nTry a broader path or type your question directly.", path), nil
 	}
 
 	var b strings.Builder

--- a/internal/rag/service.go
+++ b/internal/rag/service.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/sevigo/goframe/parsers"
 	"github.com/sevigo/goframe/schema"
 	"github.com/sevigo/goframe/textsplitter"
+	"github.com/sevigo/goframe/vectorstores"
 
 	"github.com/sevigo/code-warden/internal/config"
 	"github.com/sevigo/code-warden/internal/core"
@@ -39,6 +41,7 @@ type Service interface {
 	GenerateReview(ctx context.Context, repoConfig *core.RepoConfig, repo *storage.Repository, event *core.GitHubEvent, diff string, changedFiles []internalgithub.ChangedFile) (*core.StructuredReview, string, error)
 	GenerateReReview(ctx context.Context, repo *storage.Repository, event *core.GitHubEvent, originalReview *core.Review, ghClient internalgithub.Client, changedFiles []internalgithub.ChangedFile) (*core.StructuredReview, string, error)
 	AnswerQuestion(ctx context.Context, collectionName, embedderModelName, question string, history []string) (string, error)
+	ExplainPath(ctx context.Context, collectionName, embedderModelName, path string) (string, error)
 	ProcessFile(ctx context.Context, repoPath, file string) []schema.Document
 	GenerateComparisonSummaries(ctx context.Context, models []string, repoPath string, relPaths []string) (map[string]map[string]string, error)
 	GenerateConsensusReview(ctx context.Context, repoConfig *core.RepoConfig, repo *storage.Repository, event *core.GitHubEvent, models []string, diff string, changedFiles []internalgithub.ChangedFile) (*core.StructuredReview, string, error)
@@ -344,6 +347,32 @@ func (r *ragService) AnswerQuestion(ctx context.Context, collectionName, embedde
 
 	svc := questionpkg.NewService(qaCfg)
 	return svc.AnswerQuestion(ctx, collectionName, embedderModelName, question, history)
+}
+
+func (r *ragService) ExplainPath(ctx context.Context, collectionName, embedderModelName, path string) (string, error) {
+	r.logger.Info("explaining path", "collection", collectionName, "path", path)
+	scopedStore := r.vectorStore.ForRepo(collectionName, embedderModelName)
+
+	query := fmt.Sprintf("architecture structure purpose of %s", path)
+	docs, err := scopedStore.SimilaritySearch(ctx, query, 3,
+		vectorstores.WithFilters(map[string]any{"chunk_type": "arch"}))
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve arch context: %w", err)
+	}
+
+	if len(docs) == 0 {
+		return fmt.Sprintf("No architectural context found for path: %s\n\nTry a broader path or use /ask for general questions.", path), nil
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Architecture: %s\n\n", path)
+	for _, doc := range docs {
+		fmt.Fprintf(&b, "%s\n\n", doc.PageContent)
+		if source, ok := doc.Metadata["source"].(string); ok {
+			fmt.Fprintf(&b, "_Source: %s_\n\n", source)
+		}
+	}
+	return b.String(), nil
 }
 
 func (r *ragService) SetupRepoContext(ctx context.Context, repoConfig *core.RepoConfig, repo *storage.Repository, repoPath string) error {


### PR DESCRIPTION
## Summary

- Add terminal binary build targets to Makefile (`build-terminal`, `run-terminal`)
- Add comprehensive Terminal UI documentation to README with theme options and command reference
- Fix conversation history by adding `{{.History}}` template to question.prompt for multi-turn conversations
- Implement two-pass retrieval: arch summaries first, then hybrid similarity search
- Add source citations instruction to question prompt for better answer attribution
- Add `/explain [path]` command for directory-level architecture explanations
- Add `ExplainPath` method to RAG Service interface

## Changes

### Terminal UI Enhancements
- **`/explain [path]`** - New command to retrieve architectural summaries for a specific directory
- **Two-pass retrieval** - Questions now first retrieve `chunk_type=arch` summaries, then hybrid dense+sparse similarity search
- **Path extraction** - Detects directory paths in questions (e.g., "how does `internal/jobs` work?") and prioritizes relevant arch summaries
- **Source citations** - Prompt instructs LLM to include file paths and line numbers in answers

### Documentation
- Terminal UI section added to README with:
  - Build/run instructions
  - Theme options (`--theme matrix`, `CODE_WARDEN_THEME=dracula`, etc.)
  - Complete command reference table

### Bug Fixes
- Conversation history now properly injected into the prompt template for multi-turn Q&A

## Testing

- All existing tests pass
- `make lint` passes with 0 issues

## Remaining TODO Items (from TODO.md)

- [ ] Streaming output support for better UX during long responses
- [ ] `/status` command to show indexing status

## How to Test

1. Build and run: `make build-terminal && ./bin/warden-term --theme cyan`
2. Add a repo: `/add my-project /path/to/repo`
3. Select it: `/select my-project`
4. Try arch-aware questions:
   - `What's the structure of internal/jobs?`
   - `How does authentication work?`
   - `/explain internal/rag`