### PR TITLE
feat: add file-level summaries to improve RAG retrieval

### DIFF
--- a/internal/llm/prompt_manager.go
+++ b/internal/llm/prompt_manager.go
@@ -19,6 +19,7 @@ const (
 	CodeGenerationPrompt        PromptKey = "code_generation"
 	ReReviewPrompt              PromptKey = "rereview"
 	ArchSummaryPrompt           PromptKey = "arch_summary"
+	FileSummaryPrompt           PromptKey = "file_summary"
 	QuestionPrompt              PromptKey = "question"
 	HyDEPrompt                  PromptKey = "hyde_code"
 	ConsensusReviewPrompt       PromptKey = "consensus_review"

--- a/internal/llm/prompts/file_summary.prompt
+++ b/internal/llm/prompts/file_summary.prompt
@@ -1,0 +1,25 @@
+You are an expert code analyst. Generate a concise summary for the following code file that will be indexed for semantic search.
+
+**File:** {{.Path}}
+
+```{{.Language}}
+{{.Content}}
+```
+
+Generate a brief summary (2-3 sentences max) that includes:
+
+1. **Purpose**: What does this file do?
+2. **Key exports**: Main functions, types, or constants (limit to 5)
+3. **Keywords**: Important concepts, events, APIs, or patterns for search (limit to 10)
+
+Format your response as:
+PURPOSE: <one sentence>
+EXPORTS: <comma-separated list>
+KEYWORDS: <comma-separated list of important terms for semantic search>
+
+Be specific and include technical terms that would help retrieve this file. Example:
+- For webhook handlers: include "webhook", "event", specific event types like "issue_comment", "pull_request"
+- For parsers: include format types, parsing strategies
+- For storage: include database names, collection types, key operations
+
+Focus on terms developers would search for when looking for this code.

--- a/internal/rag/index/indexer.go
+++ b/internal/rag/index/indexer.go
@@ -14,11 +14,13 @@ import (
 
 	"github.com/sevigo/goframe/documentloaders"
 	"github.com/sevigo/goframe/embeddings/sparse"
+	"github.com/sevigo/goframe/llms"
 	"github.com/sevigo/goframe/parsers"
 	"github.com/sevigo/goframe/schema"
 	"github.com/sevigo/goframe/textsplitter"
 
 	"github.com/sevigo/code-warden/internal/core"
+	"github.com/sevigo/code-warden/internal/llm"
 	"github.com/sevigo/code-warden/internal/storage"
 )
 
@@ -30,6 +32,8 @@ type Config struct {
 	Splitter       textsplitter.TextSplitter
 	Logger         *slog.Logger
 	EmbedderModel  string
+	LLM            llms.Model
+	PromptMgr      *llm.PromptManager
 }
 
 // Indexer handles document ingestion and semantic chunking.
@@ -451,6 +455,7 @@ func (i *Indexer) UpdateRepoContext(ctx context.Context, repoConfig *core.RepoCo
 
 // ProcessFile reads, parses, and chunks a single file for indexing.
 // Returns code chunks and definition chunks.
+// Chunks are enriched with a file-level summary for better semantic retrieval.
 //
 //nolint:funlen,gocognit
 func (i *Indexer) ProcessFile(ctx context.Context, repoPath, file string) []schema.Document {
@@ -477,6 +482,12 @@ func (i *Indexer) ProcessFile(ctx context.Context, repoPath, file string) []sche
 
 	ext := strings.ToLower(filepath.Ext(file))
 
+	// Generate file-level summary for better retrieval (LLM call, cached by content hash)
+	var fileSummary string
+	if i.cfg.LLM != nil && i.cfg.PromptMgr != nil {
+		fileSummary = i.generateFileSummary(ctx, file, validContent)
+	}
+
 	// Build line offset map for computing line numbers
 	lineOffsets := buildLineOffsets(validContent)
 
@@ -493,6 +504,13 @@ func (i *Indexer) ProcessFile(ctx context.Context, repoPath, file string) []sche
 	splitDocs = filtered
 
 	for idx := range splitDocs {
+		// Enrich chunk content with file summary for better semantic retrieval
+		// This allows both dense and sparse search to find keywords from the summary
+		if fileSummary != "" {
+			splitDocs[idx].PageContent = splitDocs[idx].PageContent + "\n\n[File Summary: " + fileSummary + "]"
+			splitDocs[idx].Metadata["file_summary"] = fileSummary
+		}
+
 		// Ensure sparse vectors are generated for hybrid search if possible
 		sparseVec, err := sparse.GenerateSparseVector(ctx, splitDocs[idx].PageContent)
 		if err == nil {
@@ -733,4 +751,75 @@ func isCodeKeyword(sym string) bool {
 		"fmt": true, "strings": true, "errors": true, "json": true, "http": true,
 	}
 	return keywords[sym]
+}
+
+// fileSummaryCache stores file summaries to avoid regenerating for the same content.
+type fileSummaryCache struct {
+	mu    sync.RWMutex
+	cache map[string]string // contentHash -> summary
+}
+
+var globalFileSummaryCache = &fileSummaryCache{
+	cache: make(map[string]string),
+}
+
+// generateFileSummary generates an LLM-based summary for a file.
+// Results are cached by content hash to avoid redundant LLM calls.
+func (i *Indexer) generateFileSummary(ctx context.Context, filePath, content string) string {
+	if i.cfg.LLM == nil || i.cfg.PromptMgr == nil {
+		return ""
+	}
+
+	// Check cache first
+	contentHash := hashContent(content)
+	globalFileSummaryCache.mu.RLock()
+	if summary, ok := globalFileSummaryCache.cache[contentHash]; ok {
+		globalFileSummaryCache.mu.RUnlock()
+		return summary
+	}
+	globalFileSummaryCache.mu.RUnlock()
+
+	// Truncate content if too long (LLMs have context limits)
+	maxContent := 8000
+	if len(content) > maxContent {
+		content = content[:maxContent]
+	}
+
+	ext := strings.ToLower(filepath.Ext(filePath))
+
+	promptData := map[string]string{
+		"Path":     filePath,
+		"Language": ext[1:], // Remove leading dot
+		"Content":  content,
+	}
+
+	prompt, err := i.cfg.PromptMgr.Render(llm.FileSummaryPrompt, promptData)
+	if err != nil {
+		i.cfg.Logger.Debug("failed to render file summary prompt", "file", filePath, "error", err)
+		return ""
+	}
+
+	summary, err := llms.GenerateFromSinglePrompt(ctx, i.cfg.LLM, prompt)
+	if err != nil {
+		i.cfg.Logger.Debug("failed to generate file summary", "file", filePath, "error", err)
+		return ""
+	}
+
+	// Cache result
+	globalFileSummaryCache.mu.Lock()
+	globalFileSummaryCache.cache[contentHash] = summary
+	globalFileSummaryCache.mu.Unlock()
+
+	i.cfg.Logger.Debug("generated file summary", "file", filePath, "length", len(summary))
+
+	return summary
+}
+
+// hashContent generates a simple hash for content caching.
+func hashContent(content string) string {
+	// Simple hash for caching - use first/last chars and length
+	if len(content) < 100 {
+		return fmt.Sprintf("%d:%s", len(content), content)
+	}
+	return fmt.Sprintf("%d:%s...%s", len(content), content[:50], content[len(content)-50:])
 }

--- a/internal/rag/service.go
+++ b/internal/rag/service.go
@@ -186,6 +186,8 @@ func NewService(
 		Splitter:       splitter,
 		Logger:         logger,
 		EmbedderModel:  cfg.AI.EmbedderModel,
+		LLM:            gen,
+		PromptMgr:      promptMgr,
 	}
 
 	r := &ragService{


### PR DESCRIPTION
- Add LLM-generated file summaries during indexing
- Enrich each code chunk with summary containing purpose, exports, and keywords
- Cache summaries by content hash to avoid redundant LLM calls
- Store summary in both page content (for embedding) and metadata

File summaries provide:
- PURPOSE: What the file does
- EXPORTS: Main functions/types
- KEYWORDS: Important terms for semantic search

This improves retrieval accuracy by embedding searchable keywords like 'webhook', 'issue_comment', 'github events' directly in chunk content.