### PR TITLE
fix: use SSLMode from config and remove redundant rows.Close()

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -30,8 +30,8 @@ type DB struct {
 // NewDatabase creates a new database connection.
 func NewDatabase(cfg *config.DBConfig) (*DB, func(), error) {
 	// Construct DSN from config fields
-	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
-		cfg.Host, cfg.Port, cfg.Username, cfg.Password, cfg.Database)
+	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
+		cfg.Host, cfg.Port, cfg.Username, cfg.Password, cfg.Database, cfg.SSLMode)
 
 	// Open connection (sqlx.Connect opens and pings)
 	conn, err := sqlx.Connect("postgres", dsn)

--- a/internal/storage/database.go
+++ b/internal/storage/database.go
@@ -258,11 +258,7 @@ func (s *postgresStore) GetFilesForRepo(ctx context.Context, repoID int64) (map[
 	if err != nil {
 		return nil, fmt.Errorf("failed to list files for repo %d: %w", repoID, err)
 	}
-	defer func() {
-		if err := rows.Close(); err != nil {
-			slog.ErrorContext(ctx, "failed to close rows in GetFilesForRepo", "error", err)
-		}
-	}()
+	defer rows.Close()
 
 	files := make(map[string]FileRecord)
 	for rows.Next() {
@@ -278,13 +274,6 @@ func (s *postgresStore) GetFilesForRepo(ctx context.Context, repoID int64) (map[
 
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("failed iterating file records for repo %d: %w", repoID, err)
-	}
-
-	if err := rows.Close(); err != nil {
-		// Only log if context wasn't already canceled to avoid masking cancellation
-		if ctx.Err() == nil {
-			slog.ErrorContext(ctx, "failed to close rows in GetFilesForRepo", "error", err)
-		}
 	}
 
 	return files, nil


### PR DESCRIPTION
## Summary
- Fix DSN construction to use `cfg.SSLMode` instead of hardcoded `'disable'`
- Remove redundant manual `rows.Close()` call that was already handled by `defer`

## Details
1. **SSLMode fix**: The DSN was hardcoded to `sslmode=disable` even though the config struct has an SSLMode field. This fix properly uses the configured value.

2. **Double Close fix**: `GetFilesForRepo` had both a `defer rows.Close()` and a manual `rows.Close()` call at the end. The manual call is redundant since `defer` already handles cleanup, and could potentially cause issues with double-close scenarios.