### PR TITLE
fix: critical bugs in repomanager, agent orchestrator, and webui

### DIFF
--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -360,7 +360,9 @@ func (o *Orchestrator) SpawnAgent(ctx context.Context, issue Issue) (*Session, e
 	// Create context with timeout
 	//nolint:gosec // G118: cancel stored in session for cleanup in runAgentCLI/runAgentSDK
 	ctx, cancel := context.WithTimeout(ctx, o.config.Timeout)
+	session.mu.Lock()
 	session.cancel = cancel
+	session.mu.Unlock()
 
 	// Start agent in background
 	go o.runAgent(ctx, session)
@@ -383,8 +385,12 @@ func (o *Orchestrator) SpawnAgent(ctx context.Context, issue Issue) (*Session, e
 			o.logger.Error("failed to register workspace with global MCP registry",
 				"session_id", sessionID, "error", err)
 		} else {
+			tokenDisplay := token
+			if len(token) > 8 {
+				tokenDisplay = token[:8] + "..."
+			}
 			o.logger.Info("registered workspace with global MCP registry",
-				"session_id", sessionID, "token", token[:8]+"...", "mcp_endpoint", mcpEndpoint)
+				"session_id", sessionID, "token", tokenDisplay, "mcp_endpoint", mcpEndpoint)
 		}
 	}
 
@@ -415,9 +421,11 @@ func (o *Orchestrator) CancelSession(id string) error {
 		return fmt.Errorf("session not found: %s", id)
 	}
 
+	session.mu.Lock()
 	if session.cancel != nil {
 		session.cancel()
 	}
+	session.mu.Unlock()
 
 	session.SetStatus(StatusCancelled)
 	session.mu.Lock()

--- a/internal/repomanager/sync.go
+++ b/internal/repomanager/sync.go
@@ -83,6 +83,7 @@ func (m *manager) cloneAndIndex(
 		FullName:             ev.RepoFullName,
 		ClonePath:            clonePath,
 		QdrantCollectionName: GenerateCollectionName(ev.RepoFullName),
+		InstallationID:       ev.InstallationID,
 	}
 
 	if existing != nil {

--- a/internal/server/handler/webui.go
+++ b/internal/server/handler/webui.go
@@ -509,6 +509,7 @@ func (h *WebUIHandler) json(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(v); err != nil {
 		h.logger.Error("failed to encode JSON response", "error", err)
+		http.Error(w, "failed to encode response", http.StatusInternalServerError)
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixes 4 critical bugs identified in code review:

1. **`repomanager/sync.go`**: `InstallationID` not set on new Repository records, causing GitHub API failures for installations
2. **`agent/orchestrator.go`**: `token[:8]` panics on short tokens when logging
3. **`agent/orchestrator.go`**: Race condition - `session.cancel` written without mutex protection
4. **`server/handler/webui.go`**: JSON encode errors not returned to HTTP client (now returns 500)

## Details

### Bug 1: Missing InstallationID
When creating a new repository record in `cloneAndIndex()`, the `InstallationID` field was not being set from the event. This would cause subsequent GitHub API calls that require installation context to fail.

### Bug 2: Token Truncation Panic  
The expression `token[:8]+"..."` would panic if `token` has fewer than 8 characters. Fixed with a length check before truncation.

### Bug 3: Race Condition on session.cancel
The `session.cancel` field was being written from `StartSession` without holding `session.mu`, while `CancelSession` reads it with the mutex. This is a classic race condition. Both reads and writes now hold the mutex.

### Bug 4: Silent JSON Error
When `json.Encode` fails, the HTTP client receives an incomplete response with status 200. Now properly returns HTTP 500 with error message.

## Testing
- All unit tests pass
- Linter passes with 0 issues