### PR TITLE
fix: critical bugs in RAG pipeline

### DIFF
--- a/internal/rag/contextpkg/format.go
+++ b/internal/rag/contextpkg/format.go
@@ -264,10 +264,11 @@ func (b *builderImpl) formatSplitDocs(allDocs []schema.Document, descKeys map[st
 		}
 
 		content := b.getDocContent(doc)
+		escapedContent := escapeCodeFences(content)
 		if _, isDesc := descKeys[source]; isDesc && prDescription != "" {
-			fmt.Fprintf(&descBuilder, "File: %s\n```\n%s\n```\n\n", source, content)
+			fmt.Fprintf(&descBuilder, "File: %s\n```\n%s\n```\n\n", source, escapedContent)
 		} else {
-			fmt.Fprintf(&impactBuilder, "**%s**:\n```\n%s\n```\n\n", source, content)
+			fmt.Fprintf(&impactBuilder, "**%s**:\n```\n%s\n```\n\n", source, escapedContent)
 		}
 	}
 

--- a/internal/rag/contextpkg/hyde.go
+++ b/internal/rag/contextpkg/hyde.go
@@ -224,9 +224,10 @@ func (b *builderImpl) retrieveHyDEDocsForFile(ctx context.Context, reranker vect
 // generateHyDESnippetForFile generates a hypothetical post-patch code snippet for
 // a specific file. The language and file path are injected into the prompt so the
 // LLM produces idiomatic, context-aware code rather than generic output.
-// Cache key includes the file path to prevent cross-file cache collisions.
+// Cache key uses null byte separators to prevent collision since null bytes cannot
+// appear in file paths or model names.
 func (b *builderImpl) generateHyDESnippetForFile(ctx context.Context, patch, filePath, language string) (string, error) {
-	cacheKey := b.hashPatch(filePath + ":" + patch)
+	cacheKey := b.hashPatch(b.cfg.AIConfig.FastModel + "\x00" + filePath + "\x00" + patch)
 
 	if b.cfg.HyDECache != nil {
 		if cached, ok := b.cfg.HyDECache.Load(cacheKey); ok {
@@ -353,9 +354,17 @@ func (b *builderImpl) buildHyDEContent(hyde [][]schema.Document, indices []int, 
 				continue
 			}
 			seenKeys[key] = struct{}{}
-			fmt.Fprintf(&builder, "## Related to: %s\n```\n%s\n```\n\n", filePath, b.getDocContent(doc))
+			escapedContent := escapeCodeFences(b.getDocContent(doc))
+			fmt.Fprintf(&builder, "## Related to: %s\n```\n%s\n```\n\n", filePath, escapedContent)
 		}
 	}
 
 	return builder.String()
+}
+
+func escapeCodeFences(content string) string {
+	if strings.Contains(content, "```") {
+		return strings.ReplaceAll(content, "```", "` ` `")
+	}
+	return content
 }

--- a/internal/rag/contextpkg/hyde_test.go
+++ b/internal/rag/contextpkg/hyde_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	"github.com/sevigo/goframe/schema"
+
+	"github.com/sevigo/code-warden/internal/config"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -73,14 +76,17 @@ func (c *simpleCache) Store(key string, value any) {
 // TestGenerateHyDESnippetForFile_CacheHit verifies that a pre-populated cache
 // entry is returned without calling the LLM.
 func TestGenerateHyDESnippetForFile_CacheHit(t *testing.T) {
-	b := &builderImpl{cfg: Config{Logger: slog.Default()}}
+	b := &builderImpl{cfg: Config{
+		Logger:    slog.Default(),
+		AIConfig:  config.AIConfig{FastModel: "test-model"},
+		HyDECache: &simpleCache{m: make(map[string]any)},
+	}}
 
-	cache := &simpleCache{m: make(map[string]any)}
-	b.cfg.HyDECache = cache
-
+	cache := b.cfg.HyDECache.(*simpleCache)
 	patch := "+func Process() error { return nil }"
 	filePath := "internal/service.go"
-	cacheKey := b.hashPatch(filePath + ":" + patch)
+	// Cache key format: model\x00filePath\x00patch
+	cacheKey := b.hashPatch(b.cfg.AIConfig.FastModel + "\x00" + filePath + "\x00" + patch)
 	cache.Store(cacheKey, "cached hypothetical snippet")
 
 	// GeneratorLLM is nil — if the cache miss path were taken, this would panic.

--- a/internal/rag/contextpkg/symbols.go
+++ b/internal/rag/contextpkg/symbols.go
@@ -141,13 +141,23 @@ func filterRemovedLines(patch string) string {
 	return strings.Join(removed, "\n")
 }
 
+func filterContextLines(patch string) string {
+	lines := strings.Split(patch, "\n")
+	var context []string
+	for _, line := range lines {
+		if strings.HasPrefix(line, " ") && len(line) > 1 {
+			context = append(context, line[1:]) // Strip the leading ' '
+		}
+	}
+	return strings.Join(context, "\n")
+}
+
 func extractSymbolsFromPatch(patch string) []string {
 	symbols := make(map[string]struct{})
 
-	// Extract from both added and removed lines.
-	// Deleted or renamed symbols are equally important: the reviewer needs
-	// to know what depended on a symbol that was removed or changed.
-	sources := []string{filterAddedLines(patch), filterRemovedLines(patch)}
+	// Extract from added, removed, and context lines.
+	// Context lines contain unchanged code that may reference important symbols.
+	sources := []string{filterAddedLines(patch), filterRemovedLines(patch), filterContextLines(patch)}
 
 	patterns := []*regexp.Regexp{
 		symbolTypeDefRegex,

--- a/internal/rag/contextpkg/test_coverage.go
+++ b/internal/rag/contextpkg/test_coverage.go
@@ -173,8 +173,6 @@ func (b *builderImpl) searchTestChunksForSymbol(
 }
 
 // extractSymbolsFromDefinitions extracts symbol names from the definitions context.
-//
-//nolint:gocognit
 func extractSymbolsFromDefinitions(definitionsContext string) map[string]bool {
 	symbols := make(map[string]bool)
 
@@ -198,20 +196,9 @@ func extractSymbolsFromDefinitions(definitionsContext string) map[string]bool {
 	// Also extract from diff if present (patterns like "func Foo", "type Foo")
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
-		// Match function definitions
 		if strings.HasPrefix(line, "func ") {
-			parts := strings.Fields(line)
-			if len(parts) >= 2 {
-				// Handle method receivers: func (r *Receiver) Method
-				if strings.HasPrefix(parts[1], "(") && len(parts) >= 4 {
-					symbols[parts[3]] = true
-				} else {
-					symbols[parts[1]] = true
-				}
-			}
-		}
-		// Match type definitions
-		if strings.HasPrefix(line, "type ") {
+			extractFuncSymbol(line, symbols)
+		} else if strings.HasPrefix(line, "type ") {
 			parts := strings.Fields(line)
 			if len(parts) >= 2 {
 				symbols[parts[1]] = true
@@ -222,7 +209,27 @@ func extractSymbolsFromDefinitions(definitionsContext string) map[string]bool {
 	return symbols
 }
 
-// isTestFilePath checks if a path is a test file.
+func extractFuncSymbol(line string, symbols map[string]bool) {
+	parts := strings.Fields(line)
+	if len(parts) < 2 {
+		return
+	}
+	// Handle method receivers: func (r *Receiver) Method
+	if strings.HasPrefix(parts[1], "(") && len(parts) >= 4 {
+		name := parts[3]
+		if idx := strings.IndexByte(name, '('); idx >= 0 {
+			name = name[:idx]
+		}
+		symbols[name] = true
+	} else {
+		name := parts[1]
+		if idx := strings.IndexByte(name, '('); idx >= 0 {
+			name = name[:idx]
+		}
+		symbols[name] = true
+	}
+}
+
 func isTestFilePath(path string) bool {
 	return strings.HasSuffix(path, "_test.go") ||
 		strings.HasSuffix(path, ".test.ts") ||

--- a/internal/rag/review/review.go
+++ b/internal/rag/review/review.go
@@ -103,21 +103,23 @@ func (s *Service) checkCodeDuplication(ctx context.Context, collectionName strin
 	var duplicates strings.Builder
 	foundCount := 0
 
-	for i, chunk := range allChunks {
-		results, err := scopedStore.SimilaritySearchWithScores(ctx, chunk, 1)
+	for _, chunk := range allChunks {
+		// Query multiple results to find all potential duplicates, not just the closest
+		results, err := scopedStore.SimilaritySearchWithScores(ctx, chunk, 5)
 		if err != nil || len(results) == 0 {
 			continue
 		}
 
-		topMatch := results[0]
-		if topMatch.Score > duplicationSimilarityThreshold {
-			source, _ := topMatch.Document.Metadata["source"].(string)
-			line := metadata.ExtractLineNumber(topMatch.Document.Metadata)
+		for _, match := range results {
+			if match.Score > duplicationSimilarityThreshold {
+				source, _ := match.Document.Metadata["source"].(string)
+				line := metadata.ExtractLineNumber(match.Document.Metadata)
 
-			fmt.Fprintf(&duplicates, "### Potential Duplicate %d (Similarity Score: %.2f)\n", i+1, topMatch.Score)
-			fmt.Fprintf(&duplicates, "**Newly Added Code:**\n```\n%s\n```\n", chunk)
-			fmt.Fprintf(&duplicates, "**Existing Code Found in `%s` (Line %d):**\n```\n%s\n```\n\n", source, line, topMatch.Document.PageContent)
-			foundCount++
+				fmt.Fprintf(&duplicates, "### Potential Duplicate %d (Similarity Score: %.2f)\n", foundCount+1, match.Score)
+				fmt.Fprintf(&duplicates, "**Newly Added Code:**\n```\n%s\n```\n", chunk)
+				fmt.Fprintf(&duplicates, "**Existing Code Found in `%s` (Line %d):**\n```\n%s\n```\n\n", source, line, match.Document.PageContent)
+				foundCount++
+			}
 		}
 	}
 

--- a/internal/rag/review/validator.go
+++ b/internal/rag/review/validator.go
@@ -216,7 +216,7 @@ func validateSourceCitation(sug *core.Suggestion, validator *SuggestionValidator
 }
 
 func makeDedupKey(sug *core.Suggestion) string {
-	return strings.ToLower(sug.FilePath + ":" + categoryKey(sug.Comment) + ":" + sug.Category)
+	return strings.ToLower(sug.FilePath + ":" + strconv.Itoa(sug.LineNumber) + ":" + categoryKey(sug.Comment) + ":" + sug.Category)
 }
 
 func sortBySeverityAndConfidence(suggestions []core.Suggestion) {


### PR DESCRIPTION
## Summary
Fixes 6 critical bugs in the RAG context retrieval and review pipeline.

### Bug Fixes

1. **HyDE Cache Key Collision** (`hyde.go:229`)
   - Cache key was using `:` separator which can appear in file paths (e.g., Go import paths like `github.com/owner/repo:v2`)
   - Changed to null byte separator (`\x00`) and added model name to key
   - Prevents cross-file and cross-model cache collisions

2. **Code Fence Injection** (`format.go`, `hyde.go`)
   - Triple backticks in source code content would close markdown fences prematurely
   - Added `escapeCodeFences()` helper to escape `\`\`\`` sequences

3. **Function Name Extraction Bug** (`test_coverage.go`)
   - `strings.Fields()` doesn't split on parentheses, so `FooBar(ctx` was extracted as symbol
   - Now strips text before `(` to get clean symbol names

4. **Missing Context Symbols** (`symbols.go`)
   - Symbol extraction only looked at added/removed lines, not context lines
   - Context lines show unchanged code that references important symbols
   - Added `filterContextLines()` to include context in extraction

5. **Single Result for Duplication Detection** (`review.go`)
   - Only queried top-1 result, missing other duplicates
   - Now queries top-5 to find all similar code, not just closest

6. **Dedup Key Missing Line Number** (`validator.go`)
   - Two different issues on same file with same keyword category would be deduplicated
   - Line number now included in dedup key

## Testing
- All RAG tests pass
- Linter passes with 0 issues