### PR TITLE
fix: webhook context propagation and multi-line suggestion validation

### DIFF
--- a/internal/github/status.go
+++ b/internal/github/status.go
@@ -124,18 +124,10 @@ func (s *statusUpdater) PostStructuredReview(ctx context.Context, event *core.Gi
 			continue
 		}
 
-		// Enforce sane line ordering: startLine must be <= LineNumber
+		// Use validated StartLine (normalized by validator if it was invalid)
 		startLine := sug.StartLine
-		if startLine == 0 || startLine > sug.LineNumber {
-			if startLine > sug.LineNumber {
-				s.logger.Warn("normalizing invalid line range",
-					"file", sug.FilePath,
-					"start_line", startLine,
-					"line_number", sug.LineNumber,
-					"normalized_to", sug.LineNumber,
-				)
-			}
-			startLine = sug.LineNumber // treat as single-line at sug.LineNumber
+		if startLine == 0 {
+			startLine = sug.LineNumber
 		}
 		comments = append(comments, DraftReviewComment{
 			Path:      sug.FilePath,

--- a/internal/jobs/dispatcher.go
+++ b/internal/jobs/dispatcher.go
@@ -87,13 +87,13 @@ func (d *dispatcher) processEvent(ctx context.Context, workerID int, event *core
 }
 
 // Dispatch queues a GitHub event for processing by a worker.
+// The provided context carries the HTTP request deadline and should be used
+// for any blocking operations during queue submission.
 func (d *dispatcher) Dispatch(ctx context.Context, event *core.GitHubEvent) error {
 	d.logger.Info("queuing code review job", "repo", event.RepoFullName, "pr", event.PRNumber)
 
-	jobCtx := d.mainCtx
-
 	select {
-	case d.jobQueue <- &jobPayload{ctx: jobCtx, event: event}:
+	case d.jobQueue <- &jobPayload{ctx: ctx, event: event}:
 		return nil
 	default:
 		d.logger.Warn("ALERT: Job queue is full, dropping review job",

--- a/internal/rag/review/validator.go
+++ b/internal/rag/review/validator.go
@@ -158,6 +158,7 @@ func (f *SuggestionFilter) FilterAndRank(
 
 		validateLineNumber(sug, validator, f.ValidateLineNums, logFunc)
 		validateSourceCitation(sug, validator, f.ValidateSources, logFunc)
+		validateStartLine(sug, logFunc)
 
 		if f.Deduplicate {
 			key := makeDedupKey(sug)
@@ -186,6 +187,22 @@ func shouldSkip(sug *core.Suggestion, minConfidence int, logFunc func(msg string
 		return true
 	}
 	return false
+}
+
+func validateStartLine(sug *core.Suggestion, logFunc func(msg string, args ...any)) {
+	if sug.StartLine <= 0 {
+		return // Single-line suggestion, nothing to validate
+	}
+	if sug.StartLine > sug.LineNumber {
+		if logFunc != nil {
+			logFunc("normalizing invalid start_line > line_number",
+				"file", sug.FilePath,
+				"start_line", sug.StartLine,
+				"line_number", sug.LineNumber,
+			)
+		}
+		sug.StartLine = 0 // Fall back to single-line
+	}
 }
 
 func validateLineNumber(sug *core.Suggestion, validator *SuggestionValidator, shouldValidate bool, logFunc func(msg string, args ...any)) {


### PR DESCRIPTION
## Summary
Fixes 2 critical bugs in the review pipeline identified during code review audit.

### Fixed

**Issue 1: Webhook context discarded**
- `dispatcher.go:93` was using `d.mainCtx` instead of the passed `ctx` parameter
- Webhook HTTP deadlines were ignored; jobs ran with server lifetime context
- Fixed by passing through the context from the webhook request

**Issue 5: Multi-line suggestions collapsed**
- `status.go:128-139` was collapsing invalid `StartLine > LineNumber` to single-line
- The fix belongs in the validator at parse time, not the output formatter
- Added `validateStartLine()` to normalize invalid ranges, preserving valid multi-line suggestions

### Not Fixed (require architectural changes)

**Issue 2: Non-atomic Qdrant/SHA update**
- Crash between SyncRepoIndex and UpdateRepoSHA leaves vector store ahead of DB
- Would require: transaction wrapping, recovery on startup, or idempotent re-index detection
- Current behavior: error is logged as CRITICAL and propagated

**Issue 4: Stuck check runs on crash**
- Job state is in-memory; server restart leaves GitHub check run as `in_progress`
- Would require: DB table for in-progress check runs, cleanup on startup
- Current behavior: GitHub eventually times out the check

### Not Valid Issues

| Issue | Why Not Valid |
|-------|---------------|
| 3 | Error IS returned to webhook handler → HTTP 500 |
| 6 | `context:`, `inference:`, `external:` are valid source markers by design |
| 7 | Error IS propagated from `CreateInstallationClient` (line 126) |

## Testing
- All tests pass
- Linter passes with 0 issues