### PR TITLE
feat: retrieve package and relations context in code review flow

### DIFF
--- a/internal/rag/contextpkg/arch.go
+++ b/internal/rag/contextpkg/arch.go
@@ -382,6 +382,106 @@ func (b *builderImpl) gatherArchContextSafe(ctx context.Context, store storage.S
 	return ac, nil
 }
 
+// gatherPackageContextSafe retrieves package-level summaries for directories containing changed files.
+//
+//nolint:unparam // error always nil but signature required for errgroup
+func (b *builderImpl) gatherPackageContextSafe(ctx context.Context, store storage.ScopedVectorStore, files []internalgithub.ChangedFile) (string, error) {
+	b.cfg.Logger.Info("stage started", "name", "PackageContext")
+	pc := b.getPackageContext(ctx, store, files)
+	b.cfg.Logger.Info("stage completed", "name", "PackageContext")
+	return pc, nil
+}
+
+func (b *builderImpl) getPackageContext(ctx context.Context, scopedStore storage.ScopedVectorStore, files []internalgithub.ChangedFile) string {
+	dirs := make(map[string]struct{})
+	for _, f := range files {
+		dir := path.Dir(strings.ReplaceAll(f.Filename, "\\", "/"))
+		if dir == "." {
+			dir = rootDir
+		}
+		dirs[dir] = struct{}{}
+	}
+
+	if len(dirs) == 0 {
+		return ""
+	}
+
+	var pkgContext strings.Builder
+	seenDirs := make(map[string]struct{})
+
+	for dir := range dirs {
+		if _, seen := seenDirs[dir]; seen {
+			continue
+		}
+
+		pkgSearchOpts := []vectorstores.Option{
+			vectorstores.WithFilters(map[string]any{
+				"chunk_type": "package",
+				"source":     dir,
+			}),
+		}
+		docs, err := scopedStore.SimilaritySearch(ctx, dir, 1, pkgSearchOpts...)
+		if err != nil {
+			b.cfg.Logger.Debug("failed to search package summaries", "dir", dir, "error", err)
+			continue
+		}
+
+		if len(docs) > 0 {
+			fmt.Fprintf(&pkgContext, "## Package: %s\n%s\n\n", dir, docs[0].PageContent)
+			seenDirs[dir] = struct{}{}
+		}
+	}
+
+	b.cfg.Logger.Debug("package context assembled", "dirs_found", len(seenDirs), "dirs_queried", len(dirs))
+	return pkgContext.String()
+}
+
+// gatherRelationsContextSafe retrieves cross-file relationship summaries for changed files.
+//
+//nolint:unparam // error always nil but signature required for errgroup
+func (b *builderImpl) gatherRelationsContextSafe(ctx context.Context, store storage.ScopedVectorStore, files []internalgithub.ChangedFile) (string, error) {
+	b.cfg.Logger.Info("stage started", "name", "RelationsContext")
+	rc := b.getRelationsContext(ctx, store, files)
+	b.cfg.Logger.Info("stage completed", "name", "RelationsContext")
+	return rc, nil
+}
+
+func (b *builderImpl) getRelationsContext(ctx context.Context, scopedStore storage.ScopedVectorStore, files []internalgithub.ChangedFile) string {
+	if len(files) == 0 {
+		return ""
+	}
+
+	var relContext strings.Builder
+	seenFiles := make(map[string]struct{})
+
+	for _, f := range files {
+		file := strings.ReplaceAll(f.Filename, "\\", "/")
+		if _, seen := seenFiles[file]; seen {
+			continue
+		}
+
+		relSearchOpts := []vectorstores.Option{
+			vectorstores.WithFilters(map[string]any{
+				"chunk_type": "relations",
+				"source":     file,
+			}),
+		}
+		docs, err := scopedStore.SimilaritySearch(ctx, file, 1, relSearchOpts...)
+		if err != nil {
+			b.cfg.Logger.Debug("failed to search relation summaries", "file", file, "error", err)
+			continue
+		}
+
+		if len(docs) > 0 {
+			fmt.Fprintf(&relContext, "## %s\n%s\n\n", file, docs[0].PageContent)
+			seenFiles[file] = struct{}{}
+		}
+	}
+
+	b.cfg.Logger.Debug("relations context assembled", "files_found", len(seenFiles), "files_queried", len(files))
+	return relContext.String()
+}
+
 func (b *builderImpl) getArchContext(ctx context.Context, scopedStore storage.ScopedVectorStore, files []internalgithub.ChangedFile) string {
 	filePaths := make([]string, len(files))
 	for i, f := range files {

--- a/internal/rag/contextpkg/builder.go
+++ b/internal/rag/contextpkg/builder.go
@@ -2,6 +2,7 @@ package contextpkg
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	"github.com/sevigo/goframe/schema"
@@ -67,7 +68,7 @@ func (b *builderImpl) BuildRelevantContext(ctx context.Context, collectionName, 
 	}
 
 	testCoverageContext := b.formatTestCoverageContext(results.testCoverageDocs)
-	fullContext := b.assembleContext(ctx, results.archContext, results.tocContext, results.fileSummaryContext, impactContext, descriptionContext, results.definitionsContext, testCoverageContext, results.hydeResults, results.hydeIndices, changedFiles)
+	fullContext := b.assembleContext(ctx, results.archContext, results.tocContext, results.fileSummaryContext, impactContext, descriptionContext, results.definitionsContext, testCoverageContext, results.packageContext, results.relationContext, results.hydeResults, results.hydeIndices, changedFiles)
 	return fullContext, results.definitionsContext
 }
 
@@ -81,8 +82,11 @@ type contextResults struct {
 	hydeResults        [][]schema.Document
 	hydeIndices        []int
 	testCoverageDocs   []schema.Document
+	packageContext     string
+	relationContext    string
 }
 
+//nolint:gocognit // concurrent context building requires multiple goroutines with error handling
 func (b *builderImpl) buildContextConcurrently(
 	ctx context.Context, collectionName, embedderModelName, repoPath, prDescription string,
 	changedFiles []internalgithub.ChangedFile, scopedStore storage.ScopedVectorStore,
@@ -151,6 +155,22 @@ func (b *builderImpl) buildContextConcurrently(
 			b.cfg.Logger.Warn("definitions context stage failed", "error", err)
 		}
 		results.definitionsContext = defs
+	})
+
+	wg.Go(func() {
+		pkg, err := b.gatherPackageContextSafe(ctx, scopedStore, changedFiles)
+		if err != nil {
+			b.cfg.Logger.Warn("package context stage failed", "error", err)
+		}
+		results.packageContext = pkg
+	})
+
+	wg.Go(func() {
+		rel, err := b.gatherRelationsContextSafe(ctx, scopedStore, changedFiles)
+		if err != nil {
+			b.cfg.Logger.Warn("relations context stage failed", "error", err)
+		}
+		results.relationContext = rel
 	})
 
 	wg.Wait()
@@ -230,8 +250,24 @@ func (b *builderImpl) gatherDescriptionDocs(ctx context.Context, collection, emb
 	return allDocs, nil
 }
 
-func (b *builderImpl) assembleContext(ctx context.Context, arch, toc, fileSummary, impact, description, definitions, testCoverage string, hyde [][]schema.Document, indices []int, files []internalgithub.ChangedFile) string {
+func (b *builderImpl) assembleContext(ctx context.Context, arch, toc, fileSummary, impact, description, definitions, testCoverage, pkgContext, relContext string, hyde [][]schema.Document, indices []int, files []internalgithub.ChangedFile) string {
 	docs := b.buildContextDocuments(arch, toc, fileSummary, impact, description, definitions, testCoverage, hyde, indices, files)
+
+	// Prepend package and relations context to the docs
+	if pkgContext != "" || relContext != "" {
+		var contextSections []string
+		if pkgContext != "" {
+			contextSections = append(contextSections, "## Package Summary\n\n"+pkgContext)
+		}
+		if relContext != "" {
+			contextSections = append(contextSections, "## Cross-File Dependencies\n\n"+relContext)
+		}
+		prependDoc := schema.NewDocument(strings.Join(contextSections, "\n"), map[string]any{
+			"chunk_type": "context_summary",
+			"source":     "__generated__",
+		})
+		docs = append([]schema.Document{prependDoc}, docs...)
+	}
 
 	if b.cfg.ContextPacker == nil {
 		b.cfg.Logger.Error("context packer not initialized, using limited fallback")
@@ -251,6 +287,8 @@ func (b *builderImpl) assembleContext(ctx context.Context, arch, toc, fileSummar
 		"impact_len", len(impact),
 		"definitions_len", len(definitions),
 		"hyde_results_count", len(hyde),
+		"package_len", len(pkgContext),
+		"relations_len", len(relContext),
 		"total_tokens", result.TokenStats.TotalTokens,
 		"documents_packed", result.TokenStats.DocumentsPacked,
 		"documents_considered", result.TokenStats.DocumentsConsidered,


### PR DESCRIPTION
## Summary
This PR fixes gaps where stored package and relation chunks were indexed but never retrieved during code review context building.

### Changes
- Add `gatherPackageContextSafe` stage to retrieve `chunk_type: "package"` summaries for directories containing changed files
- Add `gatherRelationsContextSafe` stage to retrieve `chunk_type: "relations"` cross-file dependency information
- Both stages run concurrently with other context gathering (arch, TOC, HyDE, etc.)
- Package context is prepended to the review context, providing high-level module/exports overview
- Relations context shows which files depend on changed files

### Data Flow Before Fix
```
Package Chunks    → ❌ NOT QUERIED
Relations Chunks  → ❌ NOT QUERIED
```

### Data Flow After Fix
```
Package Chunks    → ✅ Retrieved via gatherPackageContextSafe()
Relations Chunks  → ✅ Retrieved via gatherRelationsContextSafe()
```

### Testing
- All existing tests pass
- Lint passes with nolint directives for complexity and unparam

Relates to #229