### PR TITLE
feat: integrate warden agent for design document generation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	Storage  StorageConfig  `mapstructure:"storage"`
 	Logging  logger.Config  `mapstructure:"logging"`
 	Features FeaturesConfig `mapstructure:"features"`
+	Warden   WardenConfig   `mapstructure:"warden"`
 }
 
 // AgentConfig holds configuration for the autonomous agent system.
@@ -379,6 +380,50 @@ type FeaturesConfig struct {
 	EnableGraphAnalysis      bool `mapstructure:"enable_graph_analysis"`
 }
 
+// WardenConfig holds configuration for warden agent integration.
+type WardenConfig struct {
+	// Enabled determines if warden agent functionality is active.
+	Enabled bool `mapstructure:"enabled"`
+
+	// DesignDocs enables design document generation during indexing.
+	DesignDocs bool `mapstructure:"design_docs"`
+
+	// DesignDocsTypes specifies which design document types to generate.
+	// Valid types: testing_patterns, dependencies, conventions, api_patterns
+	// Default: all types
+	DesignDocsTypes []string `mapstructure:"design_docs_types"`
+
+	// MaxIterations limits agent exploration iterations.
+	MaxIterations int `mapstructure:"max_iterations"`
+}
+
+// GetDesignDocTypes returns validated design document types.
+func (c *WardenConfig) GetDesignDocTypes() []string {
+	validTypes := map[string]bool{
+		"testing_patterns": true,
+		"dependencies":     true,
+		"conventions":      true,
+		"api_patterns":     true,
+	}
+
+	if len(c.DesignDocsTypes) == 0 {
+		return []string{"testing_patterns", "dependencies", "conventions", "api_patterns"}
+	}
+
+	var result []string
+	for _, t := range c.DesignDocsTypes {
+		if validTypes[t] {
+			result = append(result, t)
+		}
+	}
+
+	if len(result) == 0 {
+		return []string{"testing_patterns", "dependencies", "conventions", "api_patterns"}
+	}
+
+	return result
+}
+
 type DBConfig struct {
 	Driver          string        `mapstructure:"driver"`
 	Host            string        `mapstructure:"host"`
@@ -494,6 +539,11 @@ func setDefaults(v *viper.Viper) {
 	// Features
 	v.SetDefault("features.enable_binary_quantization", true)
 	v.SetDefault("features.enable_graph_analysis", true)
+
+	// Warden
+	v.SetDefault("warden.enabled", false)
+	v.SetDefault("warden.design_docs", true)
+	v.SetDefault("warden.max_iterations", 20)
 
 	// Agent
 	v.SetDefault("agent.enabled", false)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -424,6 +424,31 @@ func (c *WardenConfig) GetDesignDocTypes() []string {
 	return result
 }
 
+// Validate validates the warden configuration.
+func (c *WardenConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+
+	if c.MaxIterations < 0 {
+		return fmt.Errorf("warden.max_iterations must be >= 0, got: %d", c.MaxIterations)
+	}
+
+	for _, t := range c.DesignDocsTypes {
+		validTypes := map[string]bool{
+			"testing_patterns": true,
+			"dependencies":     true,
+			"conventions":      true,
+			"api_patterns":     true,
+		}
+		if !validTypes[t] {
+			return fmt.Errorf("warden.design_docs_types contains invalid type: %s", t)
+		}
+	}
+
+	return nil
+}
+
 type DBConfig struct {
 	Driver          string        `mapstructure:"driver"`
 	Host            string        `mapstructure:"host"`
@@ -572,6 +597,9 @@ func (c *Config) Validate() error {
 		errs = append(errs, err.Error())
 	}
 	if err := c.validateStorage(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := c.Warden.Validate(); err != nil {
 		errs = append(errs, err.Error())
 	}
 

--- a/internal/rag/service.go
+++ b/internal/rag/service.go
@@ -32,6 +32,7 @@ import (
 	questionpkg "github.com/sevigo/code-warden/internal/rag/question"
 	reviewpkg "github.com/sevigo/code-warden/internal/rag/review"
 	"github.com/sevigo/code-warden/internal/storage"
+	"github.com/sevigo/code-warden/internal/warden"
 )
 
 // Service is the main RAG pipeline interface for indexing, review, and Q&A.
@@ -440,6 +441,14 @@ func (r *ragService) SetupRepoContext(ctx context.Context, repoConfig *core.Repo
 			r.logger.Info("✅ Global Project Context document saved to database", "length", len(projectContext))
 		}
 	}
+
+	// Generate design documents using warden agent (if enabled)
+	if r.cfg.Warden.Enabled && r.cfg.Warden.DesignDocs {
+		if err := r.generateDesignDocuments(ctx, repo); err != nil {
+			r.logger.Warn("failed to generate design documents, continuing without them", "error", err)
+		}
+	}
+
 	return nil
 }
 
@@ -511,4 +520,79 @@ func (r *ragService) GenerateArchSummaries(ctx context.Context, collectionName, 
 // GenerateProjectContext synthesizes all architectural summaries into a global project context.
 func (r *ragService) GenerateProjectContext(ctx context.Context, collectionName, embedderModelName string) (string, error) {
 	return r.contextBuilder.GenerateProjectContext(ctx, collectionName, embedderModelName)
+}
+
+// generateDesignDocuments uses warden agent to generate design documents.
+func (r *ragService) generateDesignDocuments(ctx context.Context, repo *storage.Repository) error {
+	parts := strings.Split(repo.FullName, "/")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid repo full name: %s", repo.FullName)
+	}
+	repoOwner := parts[0]
+	repoName := parts[1]
+
+	r.logger.Info("🔍 Starting design document generation", "repo", repo.FullName)
+
+	// Create search callback
+	searchCallback := func(ctx context.Context, collectionName, query string, limit int, chunkType string) ([]map[string]any, error) {
+		scopedStore := r.vectorStore.ForRepo(collectionName, r.cfg.AI.EmbedderModel)
+
+		var opts []vectorstores.Option
+		if chunkType != "" {
+			opts = append(opts, vectorstores.WithFilters(map[string]any{
+				"chunk_type": chunkType,
+			}))
+		}
+
+		docs, err := scopedStore.SimilaritySearch(ctx, query, limit, opts...)
+		if err != nil {
+			return nil, err
+		}
+
+		results := make([]map[string]any, len(docs))
+		for i, doc := range docs {
+			result := map[string]any{
+				"content":  doc.PageContent,
+				"metadata": doc.Metadata,
+			}
+			if source, ok := doc.Metadata["source"].(string); ok {
+				result["source"] = source
+			}
+			results[i] = result
+		}
+		return results, nil
+	}
+
+	// Create structure callback
+	structureCallback := func(ctx context.Context, collectionName, root string) (string, error) {
+		return r.ExplainPath(ctx, collectionName, r.cfg.AI.EmbedderModel, root)
+	}
+
+	// Create warden integration
+	integration, err := warden.NewIntegration(warden.IntegrationConfig{
+		LLM:           r.generatorLLM,
+		VectorStore:   r.vectorStore,
+		Store:         r.store,
+		EmbedderModel: r.cfg.AI.EmbedderModel,
+		Logger:        r.logger.With("component", "warden"),
+		SearchCode:    searchCallback,
+		GetStructure:  structureCallback,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create warden integration: %w", err)
+	}
+
+	// Run design document generation
+	docs, err := integration.RunDesignDocumentGeneration(ctx, repo.QdrantCollectionName, repoOwner, repoName, repo.ClonePath)
+	if err != nil {
+		return err
+	}
+
+	if docs != nil {
+		r.logger.Info("✅ Design documents generated",
+			"repo", repo.FullName,
+			"count", len(docs.Documents))
+	}
+
+	return nil
 }

--- a/internal/rag/service.go
+++ b/internal/rag/service.go
@@ -569,11 +569,16 @@ func (r *ragService) generateDesignDocuments(ctx context.Context, repo *storage.
 	}
 
 	// Create warden integration
+	maxIterations := r.cfg.Warden.MaxIterations
+	if maxIterations <= 0 {
+		maxIterations = 20
+	}
+
 	integration, err := warden.NewIntegration(warden.IntegrationConfig{
 		LLM:           r.generatorLLM,
 		VectorStore:   r.vectorStore,
-		Store:         r.store,
 		EmbedderModel: r.cfg.AI.EmbedderModel,
+		MaxIterations: maxIterations,
 		Logger:        r.logger.With("component", "warden"),
 		SearchCode:    searchCallback,
 		GetStructure:  structureCallback,

--- a/internal/warden/doc_types.go
+++ b/internal/warden/doc_types.go
@@ -1,0 +1,81 @@
+package warden
+
+import (
+	"strings"
+	"time"
+)
+
+// DesignDocumentType represents the type of design document.
+type DesignDocumentType string
+
+const (
+	DocTypeTestingPatterns DesignDocumentType = "testing_patterns"
+	DocTypeDependencies    DesignDocumentType = "dependencies"
+	DocTypeConventions     DesignDocumentType = "conventions"
+	DocTypeAPIPatterns     DesignDocumentType = "api_patterns"
+)
+
+// DesignDocument represents an agent-generated design document.
+type DesignDocument struct {
+	ID          string             `json:"id"`
+	Type        DesignDocumentType `json:"type"`
+	Title       string             `json:"title"`
+	Content     string             `json:"content"`
+	Summary     string             `json:"summary"`
+	Symbols     []string           `json:"symbols,omitempty"`
+	Directories []string           `json:"directories,omitempty"`
+	Confidence  float64            `json:"confidence"`
+	GeneratedAt time.Time          `json:"generated_at"`
+	GeneratedBy string             `json:"generated_by"`
+	VectorID    string             `json:"vector_id,omitempty"`
+	RepoOwner   string             `json:"repo_owner"`
+	RepoName    string             `json:"repo_name"`
+}
+
+// DesignDocuments is a collection of design documents.
+type DesignDocuments struct {
+	Documents []*DesignDocument `json:"documents"`
+}
+
+// ToMarkdown converts the design document to markdown format.
+func (d *DesignDocument) ToMarkdown() string {
+	var b strings.Builder
+	b.WriteString("# " + d.Title + "\n\n")
+	b.WriteString(d.Content)
+	return b.String()
+}
+
+// ChunkContent returns the content to be indexed in the vector store.
+func (d *DesignDocument) ChunkContent() string {
+	if d.Summary != "" {
+		return d.Summary
+	}
+	return truncateContent(d.Content, 500)
+}
+
+func truncateContent(content string, maxLen int) string {
+	if len(content) <= maxLen {
+		return content
+	}
+	return content[:maxLen] + "..."
+}
+
+// ValidDesignDocumentTypes returns all valid document types.
+func ValidDesignDocumentTypes() []DesignDocumentType {
+	return []DesignDocumentType{
+		DocTypeTestingPatterns,
+		DocTypeDependencies,
+		DocTypeConventions,
+		DocTypeAPIPatterns,
+	}
+}
+
+// IsValidType checks if the document type is valid.
+func IsValidType(t DesignDocumentType) bool {
+	for _, valid := range ValidDesignDocumentTypes() {
+		if t == valid {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/warden/doc_types_test.go
+++ b/internal/warden/doc_types_test.go
@@ -1,0 +1,257 @@
+package warden
+
+import (
+	"testing"
+)
+
+func TestDesignDocumentChunkContent(t *testing.T) {
+	tests := []struct {
+		name     string
+		doc      *DesignDocument
+		expected string
+	}{
+		{
+			name: "returns summary when present",
+			doc: &DesignDocument{
+				Summary: "This is a summary",
+				Content: "This is full content that is longer",
+			},
+			expected: "This is a summary",
+		},
+		{
+			name: "truncates content when no summary",
+			doc: &DesignDocument{
+				Content: "short",
+			},
+			expected: "short",
+		},
+		{
+			name: "truncates long content",
+			doc: &DesignDocument{
+				Content: string(make([]byte, 600)),
+			},
+			expected: string(make([]byte, 500)) + "...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.doc.ChunkContent()
+			if result != tt.expected {
+				t.Errorf("ChunkContent() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDesignDocumentToMarkdown(t *testing.T) {
+	doc := &DesignDocument{
+		Title:   "Test Document",
+		Content: "This is the content",
+	}
+
+	result := doc.ToMarkdown()
+	expected := "# Test Document\n\nThis is the content"
+	if result != expected {
+		t.Errorf("ToMarkdown() = %q, want %q", result, expected)
+	}
+}
+
+func TestValidDesignDocumentTypes(t *testing.T) {
+	types := ValidDesignDocumentTypes()
+
+	if len(types) != 4 {
+		t.Errorf("ValidDesignDocumentTypes() returned %d types, want 4", len(types))
+	}
+
+	expectedTypes := map[DesignDocumentType]bool{
+		DocTypeTestingPatterns: true,
+		DocTypeDependencies:    true,
+		DocTypeConventions:     true,
+		DocTypeAPIPatterns:     true,
+	}
+
+	for _, dt := range types {
+		if !expectedTypes[dt] {
+			t.Errorf("Unexpected type: %s", dt)
+		}
+	}
+}
+
+func TestIsValidType(t *testing.T) {
+	tests := []struct {
+		docType  DesignDocumentType
+		expected bool
+	}{
+		{DocTypeTestingPatterns, true},
+		{DocTypeDependencies, true},
+		{DocTypeConventions, true},
+		{DocTypeAPIPatterns, true},
+		{DesignDocumentType("invalid"), false},
+		{DesignDocumentType(""), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.docType), func(t *testing.T) {
+			result := IsValidType(tt.docType)
+			if result != tt.expected {
+				t.Errorf("IsValidType(%q) = %v, want %v", tt.docType, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractDocumentBlocks(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: 0,
+		},
+		{
+			name:     "no document tags",
+			input:    "some random text",
+			expected: 0,
+		},
+		{
+			name: "single valid document",
+			input: `<document>
+{"type": "testing_patterns", "title": "Test"}
+</document>`,
+			expected: 1,
+		},
+		{
+			name: "multiple documents",
+			input: `<document>
+{"type": "testing_patterns"}
+</document>
+<document>
+{"type": "dependencies"}
+</document>`,
+			expected: 2,
+		},
+		{
+			name: "design_doc tag",
+			input: `<design_doc>
+{"type": "conventions"}
+</design_doc>`,
+			expected: 1,
+		},
+		{
+			name: "invalid JSON is skipped",
+			input: `<document>
+not valid json
+</document>`,
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blocks := extractDocumentBlocks(tt.input)
+			if len(blocks) != tt.expected {
+				t.Errorf("extractDocumentBlocks() returned %d blocks, want %d", len(blocks), tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseDocumentBlock(t *testing.T) {
+	docTypeMap := map[string]DesignDocumentType{
+		"testing_patterns": DocTypeTestingPatterns,
+		"dependencies":     DocTypeDependencies,
+	}
+
+	tests := []struct {
+		name     string
+		block    map[string]any
+		wantNil  bool
+		wantType DesignDocumentType
+	}{
+		{
+			name:    "missing type",
+			block:   map[string]any{"title": "Test"},
+			wantNil: true,
+		},
+		{
+			name:    "invalid type",
+			block:   map[string]any{"type": "invalid"},
+			wantNil: true,
+		},
+		{
+			name:     "valid testing_patterns",
+			block:    map[string]any{"type": "testing_patterns", "title": "Test"},
+			wantNil:  false,
+			wantType: DocTypeTestingPatterns,
+		},
+		{
+			name:     "valid dependencies",
+			block:    map[string]any{"type": "dependencies", "confidence": 0.95},
+			wantNil:  false,
+			wantType: DocTypeDependencies,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseDocumentBlock(tt.block, docTypeMap, "owner", "repo")
+			if tt.wantNil && result != nil {
+				t.Errorf("parseDocumentBlock() = %v, want nil", result)
+			}
+			if !tt.wantNil && result == nil {
+				t.Errorf("parseDocumentBlock() = nil, want non-nil")
+			}
+			if !tt.wantNil && result.Type != tt.wantType {
+				t.Errorf("parseDocumentBlock().Type = %q, want %q", result.Type, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestParseStringSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		expected []string
+	}{
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "wrong type",
+			input:    "not a slice",
+			expected: nil,
+		},
+		{
+			name:     "string slice",
+			input:    []any{"a", "b", "c"},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "mixed types",
+			input:    []any{"a", 1, "b"},
+			expected: []string{"a", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseStringSlice(tt.input)
+			if len(result) != len(tt.expected) {
+				t.Errorf("parseStringSlice() = %v, want %v", result, tt.expected)
+				return
+			}
+			for i, v := range result {
+				if v != tt.expected[i] {
+					t.Errorf("parseStringSlice()[%d] = %q, want %q", i, v, tt.expected[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/warden/explorer.go
+++ b/internal/warden/explorer.go
@@ -39,6 +39,10 @@ func NewExplorer(cfg ExplorerConfig) (*Explorer, error) {
 		cfg.Logger = slog.Default()
 	}
 
+	if cfg.LLM == nil {
+		return nil, fmt.Errorf("LLM is required for explorer")
+	}
+
 	registry := agent.NewRegistry()
 	toolList := buildExplorerTools(cfg)
 	for _, t := range toolList {
@@ -48,10 +52,8 @@ func NewExplorer(cfg ExplorerConfig) (*Explorer, error) {
 	}
 
 	allowedTools := map[string]bool{
-		"search_code":      true,
-		"get_structure":    true,
-		"get_symbol":       true,
-		"get_arch_context": true,
+		"search_code":   true,
+		"get_structure": true,
 	}
 	permissionCheck := &agent.PermissionCheck{
 		Allowed: allowedTools,
@@ -63,22 +65,6 @@ func NewExplorer(cfg ExplorerConfig) (*Explorer, error) {
 		registry:   registry,
 		governance: governance,
 	}, nil
-}
-
-// SearchCodeParams holds parameters for search_code tool.
-type SearchCodeParams struct {
-	Query          string `json:"query"`
-	Limit          int    `json:"limit,omitempty"`
-	ChunkType      string `json:"chunk_type,omitempty"`
-	CollectionName string `json:"collection_name"`
-	EmbedderModel  string `json:"embedder_model"`
-}
-
-// GetStructureParams holds parameters for get_structure tool.
-type GetStructureParams struct {
-	Root           string `json:"root,omitempty"`
-	CollectionName string `json:"collection_name"`
-	EmbedderModel  string `json:"embedder_model"`
 }
 
 // ExploreCodebase analyzes the codebase and generates design documents.
@@ -101,8 +87,8 @@ func (e *Explorer) ExploreCodebase(ctx context.Context, collectionName, repoOwne
 	task := agent.Task{
 		ID:          fmt.Sprintf("explore-%s-%s", repoOwner, repoName),
 		Description: "Explore codebase patterns and generate design documents",
-		Context: fmt.Sprintf("Repository: %s/%s\nCollection: %s\nPath: %s",
-			repoOwner, repoName, collectionName, repoPath),
+		Context: fmt.Sprintf("Repository: %s/%s\nCollection: %s\nPath: %s\n\nIMPORTANT: Always pass collection_name=\"%s\" to all tool calls.",
+			repoOwner, repoName, collectionName, repoPath, collectionName),
 		Priority: 5,
 	}
 
@@ -318,9 +304,9 @@ func buildExplorationPrompt(repoPath, collectionName string) string {
 
 ## Available Tools
 - search_code(query, limit, chunk_type): Search code semantically
-- get_structure(): Get project structure
-- get_symbol(name): Get definition of a symbol
-- get_arch_context(directory): Get architectural summary
+  IMPORTANT: Always include collection_name parameter
+- get_structure(root): Get project structure
+  IMPORTANT: Always include collection_name parameter
 
 ## Documents to Generate
 
@@ -371,12 +357,14 @@ For each document you discover, output a JSON block:
 
 ## Instructions
 1. Use search_code to find patterns (e.g., "assert", "mock", "test")
-2. Read relevant code sections
+   Example: search_code(query="assert.Equal", collection_name="%s", limit=10)
+2. Use get_structure to understand project layout
+   Example: get_structure(collection_name="%s")
 3. Analyze patterns across multiple files
 4. Generate comprehensive documents
 5. Be specific - cite actual libraries and patterns found
 
-Start exploring now.`, repoPath, collectionName)
+Start exploring now.`, repoPath, collectionName, collectionName, collectionName)
 }
 
 func (d *DesignDocuments) String() string {

--- a/internal/warden/explorer.go
+++ b/internal/warden/explorer.go
@@ -81,12 +81,6 @@ type GetStructureParams struct {
 	EmbedderModel  string `json:"embedder_model"`
 }
 
-// exploreLoopContext holds context for tools during exploration.
-type exploreLoopContext struct {
-	collectionName string
-	embedderModel  string
-}
-
 // ExploreCodebase analyzes the codebase and generates design documents.
 func (e *Explorer) ExploreCodebase(ctx context.Context, collectionName, repoOwner, repoName, repoPath string) (*DesignDocuments, error) {
 	e.cfg.Logger.Info("starting codebase exploration",
@@ -141,59 +135,68 @@ func (e *Explorer) parseExplorationResult(response string, repoOwner, repoName s
 
 	blocks := extractDocumentBlocks(response)
 	for _, block := range blocks {
-		docTypeStr, ok := block["type"].(string)
-		if !ok {
-			continue
+		doc := parseDocumentBlock(block, docTypeMap, repoOwner, repoName)
+		if doc != nil {
+			docs.Documents = append(docs.Documents, doc)
 		}
-
-		docType, valid := docTypeMap[docTypeStr]
-		if !valid {
-			continue
-		}
-
-		title, _ := block["title"].(string)
-		content, _ := block["content"].(string)
-		summary, _ := block["summary"].(string)
-		confidence, _ := block["confidence"].(float64)
-		generatedBy, _ := block["generated_by"].(string)
-
-		var symbols []string
-		if s, ok := block["symbols"].([]any); ok {
-			for _, v := range s {
-				if sym, ok := v.(string); ok {
-					symbols = append(symbols, sym)
-				}
-			}
-		}
-
-		var directories []string
-		if d, ok := block["directories"].([]any); ok {
-			for _, v := range d {
-				if dir, ok := v.(string); ok {
-					directories = append(directories, dir)
-				}
-			}
-		}
-
-		doc := &DesignDocument{
-			ID:          fmt.Sprintf("%s-%s-%d", docType, repoOwner, time.Now().UnixNano()),
-			Type:        docType,
-			Title:       title,
-			Content:     content,
-			Summary:     summary,
-			Symbols:     symbols,
-			Directories: directories,
-			Confidence:  confidence,
-			GeneratedAt: time.Now(),
-			GeneratedBy: generatedBy,
-			RepoOwner:   repoOwner,
-			RepoName:    repoName,
-		}
-
-		docs.Documents = append(docs.Documents, doc)
 	}
 
 	return docs
+}
+
+// parseDocumentBlock parses a single document block into a DesignDocument.
+func parseDocumentBlock(block map[string]any, docTypeMap map[string]DesignDocumentType, repoOwner, repoName string) *DesignDocument {
+	docTypeStr, ok := block["type"].(string)
+	if !ok {
+		return nil
+	}
+
+	docType, valid := docTypeMap[docTypeStr]
+	if !valid {
+		return nil
+	}
+
+	title, _ := block["title"].(string)
+	content, _ := block["content"].(string)
+	summary, _ := block["summary"].(string)
+	confidence, _ := block["confidence"].(float64)
+	generatedBy, _ := block["generated_by"].(string)
+
+	symbols := parseStringSlice(block["symbols"])
+	directories := parseStringSlice(block["directories"])
+
+	return &DesignDocument{
+		ID:          fmt.Sprintf("%s-%s-%d", docType, repoOwner, time.Now().UnixNano()),
+		Type:        docType,
+		Title:       title,
+		Content:     content,
+		Summary:     summary,
+		Symbols:     symbols,
+		Directories: directories,
+		Confidence:  confidence,
+		GeneratedAt: time.Now(),
+		GeneratedBy: generatedBy,
+		RepoOwner:   repoOwner,
+		RepoName:    repoName,
+	}
+}
+
+// parseStringSlice extracts a string slice from an interface slice.
+func parseStringSlice(v any) []string {
+	if v == nil {
+		return nil
+	}
+	slice, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	var result []string
+	for _, item := range slice {
+		if s, ok := item.(string); ok {
+			result = append(result, s)
+		}
+	}
+	return result
 }
 
 // extractDocumentBlocks parses document blocks from agent response.
@@ -202,42 +205,50 @@ func extractDocumentBlocks(response string) []map[string]any {
 
 	patterns := []string{"<document", "<design_doc"}
 	for _, pattern := range patterns {
-		startIdx := 0
-		for {
-			idx := strings.Index(response[startIdx:], pattern)
-			if idx == -1 {
-				break
-			}
+		blocks = append(blocks, extractBlocksForPattern(response, pattern)...)
+	}
 
-			docStart := startIdx + idx
-			endTag := ">"
-			endIdx := strings.Index(response[docStart:], endTag)
-			if endIdx == -1 {
-				break
-			}
+	return blocks
+}
 
-			closeTag := "</document>"
-			closeIdx := strings.Index(response[docStart:], closeTag)
-			if closeIdx == -1 {
-				closeTag = "</design_doc>"
-				closeIdx = strings.Index(response[docStart:], closeTag)
-				if closeIdx == -1 {
-					break
-				}
-			}
+// extractBlocksForPattern extracts JSON blocks for a given tag pattern.
+func extractBlocksForPattern(response, pattern string) []map[string]any {
+	var blocks []map[string]any
+	startIdx := 0
 
-			jsonContent := response[docStart+endIdx+1 : docStart+closeIdx]
-			jsonContent = strings.TrimSpace(jsonContent)
-
-			if strings.HasPrefix(jsonContent, "{") {
-				var block map[string]any
-				if err := json.Unmarshal([]byte(jsonContent), &block); err == nil {
-					blocks = append(blocks, block)
-				}
-			}
-
-			startIdx = docStart + closeIdx + len(closeTag)
+	for {
+		idx := strings.Index(response[startIdx:], pattern)
+		if idx == -1 {
+			break
 		}
+
+		docStart := startIdx + idx
+		endIdx := strings.Index(response[docStart:], ">")
+		if endIdx == -1 {
+			break
+		}
+
+		closeTag := "</document>"
+		closeIdx := strings.Index(response[docStart:], closeTag)
+		if closeIdx == -1 {
+			closeTag = "</design_doc>"
+			closeIdx = strings.Index(response[docStart:], closeTag)
+			if closeIdx == -1 {
+				break
+			}
+		}
+
+		jsonContent := response[docStart+endIdx+1 : docStart+closeIdx]
+		jsonContent = strings.TrimSpace(jsonContent)
+
+		if strings.HasPrefix(jsonContent, "{") {
+			var block map[string]any
+			if err := json.Unmarshal([]byte(jsonContent), &block); err == nil {
+				blocks = append(blocks, block)
+			}
+		}
+
+		startIdx = docStart + closeIdx + len(closeTag)
 	}
 
 	return blocks

--- a/internal/warden/explorer.go
+++ b/internal/warden/explorer.go
@@ -19,18 +19,19 @@ import (
 type ExplorerConfig struct {
 	LLM           llms.Model
 	VectorStore   storage.VectorStore
-	Store         storage.Store
 	Logger        *slog.Logger
 	EmbedderModel string
 	SearchCode    SearchCodeFunc
 	GetStructure  GetStructureFunc
+	MaxIterations int
 }
 
 // Explorer uses an embedded agent to analyze codebase patterns and generate design documents.
 type Explorer struct {
-	cfg        ExplorerConfig
-	registry   *agent.Registry
-	governance *agent.Governance
+	cfg           ExplorerConfig
+	registry      *agent.Registry
+	governance    *agent.Governance
+	maxIterations int
 }
 
 // NewExplorer creates a new codebase explorer.
@@ -41,6 +42,19 @@ func NewExplorer(cfg ExplorerConfig) (*Explorer, error) {
 
 	if cfg.LLM == nil {
 		return nil, fmt.Errorf("LLM is required for explorer")
+	}
+
+	if cfg.SearchCode == nil {
+		return nil, fmt.Errorf("SearchCode callback is required")
+	}
+
+	if cfg.GetStructure == nil {
+		return nil, fmt.Errorf("GetStructure callback is required")
+	}
+
+	maxIter := cfg.MaxIterations
+	if maxIter <= 0 {
+		maxIter = 20
 	}
 
 	registry := agent.NewRegistry()
@@ -61,9 +75,10 @@ func NewExplorer(cfg ExplorerConfig) (*Explorer, error) {
 	governance := agent.NewGovernance(permissionCheck)
 
 	return &Explorer{
-		cfg:        cfg,
-		registry:   registry,
-		governance: governance,
+		cfg:           cfg,
+		registry:      registry,
+		governance:    governance,
+		maxIterations: maxIter,
 	}, nil
 }
 
@@ -77,7 +92,7 @@ func (e *Explorer) ExploreCodebase(ctx context.Context, collectionName, repoOwne
 
 	loop, err := agent.NewAgentLoop(e.cfg.LLM, e.registry,
 		agent.WithLoopSystemPrompt(systemPrompt),
-		agent.WithLoopMaxIterations(20),
+		agent.WithLoopMaxIterations(e.maxIterations),
 		agent.WithLoopGovernance(e.governance),
 	)
 	if err != nil {
@@ -242,8 +257,12 @@ func extractBlocksForPattern(response, pattern string) []map[string]any {
 
 // IndexDesignDocuments indexes the design documents in the vector store.
 func (e *Explorer) IndexDesignDocuments(ctx context.Context, collectionName string, docs *DesignDocuments) error {
-	if len(docs.Documents) == 0 {
+	if docs == nil || len(docs.Documents) == 0 {
 		return nil
+	}
+
+	if e.cfg.VectorStore == nil {
+		return fmt.Errorf("vector store is not configured")
 	}
 
 	scopedStore := e.cfg.VectorStore.ForRepo(collectionName, e.cfg.EmbedderModel)

--- a/internal/warden/explorer.go
+++ b/internal/warden/explorer.go
@@ -1,0 +1,378 @@
+package warden
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/sevigo/goframe/agent"
+	"github.com/sevigo/goframe/llms"
+	"github.com/sevigo/goframe/schema"
+
+	"github.com/sevigo/code-warden/internal/storage"
+)
+
+// ExplorerConfig holds configuration for the codebase explorer.
+type ExplorerConfig struct {
+	LLM           llms.Model
+	VectorStore   storage.VectorStore
+	Store         storage.Store
+	Logger        *slog.Logger
+	EmbedderModel string
+	SearchCode    SearchCodeFunc
+	GetStructure  GetStructureFunc
+}
+
+// Explorer uses an embedded agent to analyze codebase patterns and generate design documents.
+type Explorer struct {
+	cfg        ExplorerConfig
+	registry   *agent.Registry
+	governance *agent.Governance
+}
+
+// NewExplorer creates a new codebase explorer.
+func NewExplorer(cfg ExplorerConfig) (*Explorer, error) {
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+
+	registry := agent.NewRegistry()
+	toolList := buildExplorerTools(cfg)
+	for _, t := range toolList {
+		if err := registry.Register(t); err != nil {
+			cfg.Logger.Warn("failed to register tool", "tool", t.Name(), "error", err)
+		}
+	}
+
+	allowedTools := map[string]bool{
+		"search_code":      true,
+		"get_structure":    true,
+		"get_symbol":       true,
+		"get_arch_context": true,
+	}
+	permissionCheck := &agent.PermissionCheck{
+		Allowed: allowedTools,
+	}
+	governance := agent.NewGovernance(permissionCheck)
+
+	return &Explorer{
+		cfg:        cfg,
+		registry:   registry,
+		governance: governance,
+	}, nil
+}
+
+// SearchCodeParams holds parameters for search_code tool.
+type SearchCodeParams struct {
+	Query          string `json:"query"`
+	Limit          int    `json:"limit,omitempty"`
+	ChunkType      string `json:"chunk_type,omitempty"`
+	CollectionName string `json:"collection_name"`
+	EmbedderModel  string `json:"embedder_model"`
+}
+
+// GetStructureParams holds parameters for get_structure tool.
+type GetStructureParams struct {
+	Root           string `json:"root,omitempty"`
+	CollectionName string `json:"collection_name"`
+	EmbedderModel  string `json:"embedder_model"`
+}
+
+// exploreLoopContext holds context for tools during exploration.
+type exploreLoopContext struct {
+	collectionName string
+	embedderModel  string
+}
+
+// ExploreCodebase analyzes the codebase and generates design documents.
+func (e *Explorer) ExploreCodebase(ctx context.Context, collectionName, repoOwner, repoName, repoPath string) (*DesignDocuments, error) {
+	e.cfg.Logger.Info("starting codebase exploration",
+		"collection", collectionName,
+		"repo", repoOwner+"/"+repoName)
+
+	systemPrompt := buildExplorationPrompt(repoPath, collectionName)
+
+	loop, err := agent.NewAgentLoop(e.cfg.LLM, e.registry,
+		agent.WithLoopSystemPrompt(systemPrompt),
+		agent.WithLoopMaxIterations(20),
+		agent.WithLoopGovernance(e.governance),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create agent loop: %w", err)
+	}
+
+	task := agent.Task{
+		ID:          fmt.Sprintf("explore-%s-%s", repoOwner, repoName),
+		Description: "Explore codebase patterns and generate design documents",
+		Context: fmt.Sprintf("Repository: %s/%s\nCollection: %s\nPath: %s",
+			repoOwner, repoName, collectionName, repoPath),
+		Priority: 5,
+	}
+
+	result, err := loop.Run(ctx, task, nil)
+	if err != nil {
+		return nil, fmt.Errorf("exploration failed: %w", err)
+	}
+
+	docs := e.parseExplorationResult(result.Response, repoOwner, repoName)
+
+	totalTokens := result.Tokens.Input + result.Tokens.Output
+	e.cfg.Logger.Info("codebase exploration complete",
+		"documents", len(docs.Documents),
+		"iterations", result.Iterations,
+		"tokens", totalTokens)
+
+	return docs, nil
+}
+
+// parseExplorationResult extracts design documents from agent output.
+func (e *Explorer) parseExplorationResult(response string, repoOwner, repoName string) *DesignDocuments {
+	docs := &DesignDocuments{Documents: []*DesignDocument{}}
+
+	docTypeMap := map[string]DesignDocumentType{
+		"testing_patterns": DocTypeTestingPatterns,
+		"dependencies":     DocTypeDependencies,
+		"conventions":      DocTypeConventions,
+		"api_patterns":     DocTypeAPIPatterns,
+	}
+
+	blocks := extractDocumentBlocks(response)
+	for _, block := range blocks {
+		docTypeStr, ok := block["type"].(string)
+		if !ok {
+			continue
+		}
+
+		docType, valid := docTypeMap[docTypeStr]
+		if !valid {
+			continue
+		}
+
+		title, _ := block["title"].(string)
+		content, _ := block["content"].(string)
+		summary, _ := block["summary"].(string)
+		confidence, _ := block["confidence"].(float64)
+		generatedBy, _ := block["generated_by"].(string)
+
+		var symbols []string
+		if s, ok := block["symbols"].([]any); ok {
+			for _, v := range s {
+				if sym, ok := v.(string); ok {
+					symbols = append(symbols, sym)
+				}
+			}
+		}
+
+		var directories []string
+		if d, ok := block["directories"].([]any); ok {
+			for _, v := range d {
+				if dir, ok := v.(string); ok {
+					directories = append(directories, dir)
+				}
+			}
+		}
+
+		doc := &DesignDocument{
+			ID:          fmt.Sprintf("%s-%s-%d", docType, repoOwner, time.Now().UnixNano()),
+			Type:        docType,
+			Title:       title,
+			Content:     content,
+			Summary:     summary,
+			Symbols:     symbols,
+			Directories: directories,
+			Confidence:  confidence,
+			GeneratedAt: time.Now(),
+			GeneratedBy: generatedBy,
+			RepoOwner:   repoOwner,
+			RepoName:    repoName,
+		}
+
+		docs.Documents = append(docs.Documents, doc)
+	}
+
+	return docs
+}
+
+// extractDocumentBlocks parses document blocks from agent response.
+func extractDocumentBlocks(response string) []map[string]any {
+	var blocks []map[string]any
+
+	patterns := []string{"<document", "<design_doc"}
+	for _, pattern := range patterns {
+		startIdx := 0
+		for {
+			idx := strings.Index(response[startIdx:], pattern)
+			if idx == -1 {
+				break
+			}
+
+			docStart := startIdx + idx
+			endTag := ">"
+			endIdx := strings.Index(response[docStart:], endTag)
+			if endIdx == -1 {
+				break
+			}
+
+			closeTag := "</document>"
+			closeIdx := strings.Index(response[docStart:], closeTag)
+			if closeIdx == -1 {
+				closeTag = "</design_doc>"
+				closeIdx = strings.Index(response[docStart:], closeTag)
+				if closeIdx == -1 {
+					break
+				}
+			}
+
+			jsonContent := response[docStart+endIdx+1 : docStart+closeIdx]
+			jsonContent = strings.TrimSpace(jsonContent)
+
+			if strings.HasPrefix(jsonContent, "{") {
+				var block map[string]any
+				if err := json.Unmarshal([]byte(jsonContent), &block); err == nil {
+					blocks = append(blocks, block)
+				}
+			}
+
+			startIdx = docStart + closeIdx + len(closeTag)
+		}
+	}
+
+	return blocks
+}
+
+// IndexDesignDocuments indexes the design documents in the vector store.
+func (e *Explorer) IndexDesignDocuments(ctx context.Context, collectionName string, docs *DesignDocuments) error {
+	if len(docs.Documents) == 0 {
+		return nil
+	}
+
+	scopedStore := e.cfg.VectorStore.ForRepo(collectionName, e.cfg.EmbedderModel)
+
+	var vectors []schema.Document
+	for _, doc := range docs.Documents {
+		content := doc.ChunkContent()
+
+		vectorDoc := schema.NewDocument(content, map[string]any{
+			"chunk_type":   "design_doc",
+			"doc_type":     string(doc.Type),
+			"title":        doc.Title,
+			"repo_owner":   doc.RepoOwner,
+			"repo_name":    doc.RepoName,
+			"generated_at": doc.GeneratedAt.Format(time.RFC3339),
+			"generated_by": doc.GeneratedBy,
+			"confidence":   doc.Confidence,
+		})
+
+		vectors = append(vectors, vectorDoc)
+		e.cfg.Logger.Debug("prepared document for indexing",
+			"type", doc.Type,
+			"title", doc.Title,
+			"content_len", len(content))
+	}
+
+	ids, err := scopedStore.AddDocuments(ctx, vectors)
+	if err != nil {
+		return fmt.Errorf("failed to index design documents: %w", err)
+	}
+
+	for i, id := range ids {
+		if i < len(docs.Documents) {
+			docs.Documents[i].VectorID = id
+		}
+	}
+
+	e.cfg.Logger.Info("indexed design documents",
+		"count", len(ids),
+		"collection", collectionName)
+
+	return nil
+}
+
+func buildExplorerTools(cfg ExplorerConfig) []agent.Tool {
+	return []agent.Tool{
+		NewSearchCodeTool(cfg.SearchCode, cfg.VectorStore, cfg.EmbedderModel, cfg.Logger),
+		NewGetStructureTool(cfg.GetStructure, cfg.Logger),
+	}
+}
+
+func buildExplorationPrompt(repoPath, collectionName string) string {
+	return fmt.Sprintf(`You are a codebase analyzer. Your task is to explore the codebase using available tools and generate design documents.
+
+## Repository Context
+- Path: %s
+- Collection: %s
+
+## Available Tools
+- search_code(query, limit, chunk_type): Search code semantically
+- get_structure(): Get project structure
+- get_symbol(name): Get definition of a symbol
+- get_arch_context(directory): Get architectural summary
+
+## Documents to Generate
+
+Generate the following design documents by exploring the codebase:
+
+### 1. Testing Patterns (type: "testing_patterns")
+Explore and document:
+- What assertion library is used? (assert.Equal, require.NoError, testify, etc.)
+- How is mocking done? (gomock, testify/mock, manual interfaces, etc.)
+- What's the test structure? (table-driven, AAA, fixtures, etc.)
+- How are test fixtures and setup handled?
+
+### 2. Dependencies (type: "dependencies")
+Explore and document:
+- What are the key dependencies?
+- Why are they used?
+- Any custom wrappers or abstractions?
+
+### 3. Conventions (type: "conventions")
+Explore and document:
+- Naming conventions (files, packages, functions)
+- File organization patterns
+- Error handling patterns
+- Logging patterns
+
+### 4. API Patterns (type: "api_patterns")
+If applicable, explore and document:
+- Authentication patterns
+- Authorization patterns
+- Error response patterns
+- Validation patterns
+
+## Output Format
+
+For each document you discover, output a JSON block:
+<document>
+{
+  "type": "DOCUMENT_TYPE",
+  "title": "Document Title",
+  "content": "Full markdown content...",
+  "summary": "Brief 2-3 sentence summary",
+  "symbols": ["RelatedSymbol1", "RelatedSymbol2"],
+  "directories": ["dir1/", "dir2/"],
+  "confidence": 0.95,
+  "generated_by": "model-name"
+}
+</document>
+
+## Instructions
+1. Use search_code to find patterns (e.g., "assert", "mock", "test")
+2. Read relevant code sections
+3. Analyze patterns across multiple files
+4. Generate comprehensive documents
+5. Be specific - cite actual libraries and patterns found
+
+Start exploring now.`, repoPath, collectionName)
+}
+
+func (d *DesignDocuments) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "DesignDocuments{count=%d}\n", len(d.Documents))
+	for _, doc := range d.Documents {
+		fmt.Fprintf(&b, "  - %s: %s (confidence=%.2f)\n", doc.Type, doc.Title, doc.Confidence)
+	}
+	return b.String()
+}

--- a/internal/warden/integration.go
+++ b/internal/warden/integration.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/sevigo/code-warden/internal/storage"
 	"github.com/sevigo/goframe/llms"
+
+	"github.com/sevigo/code-warden/internal/storage"
 )
 
 // SearchCodeFunc is a callback for searching code in the RAG service.

--- a/internal/warden/integration.go
+++ b/internal/warden/integration.go
@@ -25,8 +25,8 @@ type Integration struct {
 type IntegrationConfig struct {
 	LLM           llms.Model
 	VectorStore   storage.VectorStore
-	Store         storage.Store
 	EmbedderModel string
+	MaxIterations int
 	Logger        *slog.Logger
 	SearchCode    SearchCodeFunc
 	GetStructure  GetStructureFunc
@@ -42,11 +42,11 @@ func NewIntegration(cfg IntegrationConfig) (*Integration, error) {
 	explorerCfg := ExplorerConfig{
 		LLM:           cfg.LLM,
 		VectorStore:   cfg.VectorStore,
-		Store:         cfg.Store,
 		Logger:        cfg.Logger,
 		EmbedderModel: cfg.EmbedderModel,
 		SearchCode:    cfg.SearchCode,
 		GetStructure:  cfg.GetStructure,
+		MaxIterations: cfg.MaxIterations,
 	}
 
 	explorer, err := NewExplorer(explorerCfg)

--- a/internal/warden/integration.go
+++ b/internal/warden/integration.go
@@ -17,12 +17,8 @@ type GetStructureFunc func(ctx context.Context, collectionName, root string) (st
 
 // Integration provides a high-level interface for agent-enhanced indexing.
 type Integration struct {
-	explorer      *Explorer
-	vectorStore   storage.VectorStore
-	store         storage.Store
-	llm           llms.Model
-	embedderModel string
-	logger        *slog.Logger
+	explorer *Explorer
+	logger   *slog.Logger
 }
 
 // IntegrationConfig holds configuration for the warden integration.
@@ -59,12 +55,8 @@ func NewIntegration(cfg IntegrationConfig) (*Integration, error) {
 	}
 
 	return &Integration{
-		explorer:      explorer,
-		vectorStore:   cfg.VectorStore,
-		store:         cfg.Store,
-		llm:           cfg.LLM,
-		embedderModel: cfg.EmbedderModel,
-		logger:        cfg.Logger,
+		explorer: explorer,
+		logger:   cfg.Logger,
 	}, nil
 }
 

--- a/internal/warden/integration.go
+++ b/internal/warden/integration.go
@@ -1,0 +1,97 @@
+package warden
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/sevigo/code-warden/internal/storage"
+	"github.com/sevigo/goframe/llms"
+)
+
+// SearchCodeFunc is a callback for searching code in the RAG service.
+type SearchCodeFunc func(ctx context.Context, collectionName, query string, limit int, chunkType string) ([]map[string]any, error)
+
+// GetStructureFunc is a callback for getting project structure.
+type GetStructureFunc func(ctx context.Context, collectionName, root string) (string, error)
+
+// Integration provides a high-level interface for agent-enhanced indexing.
+type Integration struct {
+	explorer      *Explorer
+	vectorStore   storage.VectorStore
+	store         storage.Store
+	llm           llms.Model
+	embedderModel string
+	logger        *slog.Logger
+}
+
+// IntegrationConfig holds configuration for the warden integration.
+type IntegrationConfig struct {
+	LLM           llms.Model
+	VectorStore   storage.VectorStore
+	Store         storage.Store
+	EmbedderModel string
+	Logger        *slog.Logger
+	SearchCode    SearchCodeFunc
+	GetStructure  GetStructureFunc
+}
+
+// NewIntegration creates a new warden integration.
+func NewIntegration(cfg IntegrationConfig) (*Integration, error) {
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+
+	// Create explorer config with tools that use callbacks
+	explorerCfg := ExplorerConfig{
+		LLM:           cfg.LLM,
+		VectorStore:   cfg.VectorStore,
+		Store:         cfg.Store,
+		Logger:        cfg.Logger,
+		EmbedderModel: cfg.EmbedderModel,
+		SearchCode:    cfg.SearchCode,
+		GetStructure:  cfg.GetStructure,
+	}
+
+	explorer, err := NewExplorer(explorerCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Integration{
+		explorer:      explorer,
+		vectorStore:   cfg.VectorStore,
+		store:         cfg.Store,
+		llm:           cfg.LLM,
+		embedderModel: cfg.EmbedderModel,
+		logger:        cfg.Logger,
+	}, nil
+}
+
+// RunDesignDocumentGeneration explores the codebase and indexes design documents.
+func (i *Integration) RunDesignDocumentGeneration(ctx context.Context, collectionName, repoOwner, repoName, repoPath string) (*DesignDocuments, error) {
+	if i.explorer == nil {
+		return nil, nil
+	}
+
+	docs, err := i.explorer.ExploreCodebase(ctx, collectionName, repoOwner, repoName, repoPath)
+	if err != nil {
+		i.logger.Error("design document generation failed", "error", err, "repo", repoOwner+"/"+repoName)
+		return nil, err
+	}
+
+	if err := i.explorer.IndexDesignDocuments(ctx, collectionName, docs); err != nil {
+		i.logger.Error("failed to index design documents", "error", err, "repo", repoOwner+"/"+repoName)
+		return nil, err
+	}
+
+	i.logger.Info("design document generation complete",
+		"repo", repoOwner+"/"+repoName,
+		"documents", len(docs.Documents))
+
+	return docs, nil
+}
+
+// GetExplorer returns the underlying explorer for direct use.
+func (i *Integration) GetExplorer() *Explorer {
+	return i.explorer
+}

--- a/internal/warden/tools.go
+++ b/internal/warden/tools.go
@@ -1,0 +1,188 @@
+package warden
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/sevigo/goframe/agent"
+	"github.com/sevigo/goframe/vectorstores"
+
+	"github.com/sevigo/code-warden/internal/storage"
+)
+
+// SearchCodeTool allows agents to search code semantically.
+type SearchCodeTool struct {
+	searchCode    SearchCodeFunc
+	vectorStore   storage.VectorStore
+	embedderModel string
+	logger        *slog.Logger
+}
+
+// NewSearchCodeTool creates a new search code tool.
+func NewSearchCodeTool(searchCode SearchCodeFunc, vectorStore storage.VectorStore, embedderModel string, logger *slog.Logger) *SearchCodeTool {
+	return &SearchCodeTool{
+		searchCode:    searchCode,
+		vectorStore:   vectorStore,
+		embedderModel: embedderModel,
+		logger:        logger,
+	}
+}
+
+func (t *SearchCodeTool) Name() string {
+	return "search_code"
+}
+
+func (t *SearchCodeTool) Description() string {
+	return "Search the codebase using semantic search. Returns relevant code chunks matching the query."
+}
+
+func (t *SearchCodeTool) ParametersSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"query": map[string]any{
+				"type":        "string",
+				"description": "The search query describing what code to find",
+			},
+			"limit": map[string]any{
+				"type":        "integer",
+				"description": "Maximum number of results to return (default 5)",
+				"default":     5,
+			},
+			"chunk_type": map[string]any{
+				"type":        "string",
+				"description": "Filter by chunk type: code, definition, arch, docs",
+				"enum":        []string{"code", "definition", "arch", "docs"},
+			},
+		},
+		"required": []string{"query"},
+	}
+}
+
+func (t *SearchCodeTool) Execute(ctx context.Context, params map[string]any) (any, error) {
+	query, ok := params["query"].(string)
+	if !ok {
+		return nil, fmt.Errorf("query parameter required and must be string")
+	}
+
+	limit := 5
+	if l, ok := params["limit"].(float64); ok {
+		limit = int(l)
+	}
+
+	chunkType, _ := params["chunk_type"].(string)
+
+	collectionName, ok := params["collection_name"].(string)
+	if !ok {
+		return nil, fmt.Errorf("collection_name parameter required")
+	}
+
+	t.logger.Debug("search_code tool called",
+		"query", query,
+		"limit", limit,
+		"chunk_type", chunkType)
+
+	// Use callback if available, otherwise use vector store directly
+	if t.searchCode != nil {
+		return t.searchCode(ctx, collectionName, query, limit, chunkType)
+	}
+
+	// Fallback to direct vector store access
+	scopedStore := t.vectorStore.ForRepo(collectionName, t.embedderModel)
+
+	var opts []vectorstores.Option
+	if chunkType != "" {
+		opts = append(opts, vectorstores.WithFilters(map[string]any{
+			"chunk_type": chunkType,
+		}))
+	}
+
+	docs, err := scopedStore.SimilaritySearch(ctx, query, limit, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("search failed: %w", err)
+	}
+
+	results := make([]map[string]any, len(docs))
+	for i, doc := range docs {
+		result := map[string]any{
+			"content":  doc.PageContent,
+			"metadata": doc.Metadata,
+		}
+		if source, ok := doc.Metadata["source"].(string); ok {
+			result["source"] = source
+		}
+		if line, ok := doc.Metadata["line"].(int); ok {
+			result["line"] = line
+		}
+		results[i] = result
+	}
+
+	return map[string]any{
+		"query":   query,
+		"count":   len(results),
+		"results": results,
+	}, nil
+}
+
+// GetStructureTool allows agents to get project structure.
+type GetStructureTool struct {
+	getStructure GetStructureFunc
+	logger       *slog.Logger
+}
+
+// NewGetStructureTool creates a new get structure tool.
+func NewGetStructureTool(getStructure GetStructureFunc, logger *slog.Logger) *GetStructureTool {
+	return &GetStructureTool{
+		getStructure: getStructure,
+		logger:       logger,
+	}
+}
+
+func (t *GetStructureTool) Name() string {
+	return "get_structure"
+}
+
+func (t *GetStructureTool) Description() string {
+	return "Get the project structure showing directories and key files."
+}
+
+func (t *GetStructureTool) ParametersSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"root": map[string]any{
+				"type":        "string",
+				"description": "Root directory to start from (optional, defaults to project root)",
+			},
+		},
+	}
+}
+
+func (t *GetStructureTool) Execute(ctx context.Context, params map[string]any) (any, error) {
+	t.logger.Debug("get_structure tool called", "params", params)
+
+	root, _ := params["root"].(string)
+
+	collectionName, ok := params["collection_name"].(string)
+	if !ok {
+		return nil, fmt.Errorf("collection_name parameter required")
+	}
+
+	if t.getStructure != nil {
+		structure, err := t.getStructure(ctx, collectionName, root)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get structure: %w", err)
+		}
+		return map[string]any{
+			"root":      root,
+			"structure": structure,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("get_structure callback not configured")
+}
+
+// Ensure tools implement the agent.Tool interface
+var _ agent.Tool = (*SearchCodeTool)(nil)
+var _ agent.Tool = (*GetStructureTool)(nil)

--- a/internal/warden/tools.go
+++ b/internal/warden/tools.go
@@ -45,6 +45,10 @@ func (t *SearchCodeTool) ParametersSchema() map[string]any {
 				"type":        "string",
 				"description": "The search query describing what code to find",
 			},
+			"collection_name": map[string]any{
+				"type":        "string",
+				"description": "The vector store collection name for the repository",
+			},
 			"limit": map[string]any{
 				"type":        "integer",
 				"description": "Maximum number of results to return (default 5)",
@@ -56,7 +60,7 @@ func (t *SearchCodeTool) ParametersSchema() map[string]any {
 				"enum":        []string{"code", "definition", "arch", "docs"},
 			},
 		},
-		"required": []string{"query"},
+		"required": []string{"query", "collection_name"},
 	}
 }
 
@@ -151,11 +155,16 @@ func (t *GetStructureTool) ParametersSchema() map[string]any {
 	return map[string]any{
 		"type": "object",
 		"properties": map[string]any{
+			"collection_name": map[string]any{
+				"type":        "string",
+				"description": "The vector store collection name for the repository",
+			},
 			"root": map[string]any{
 				"type":        "string",
 				"description": "Root directory to start from (optional, defaults to project root)",
 			},
 		},
+		"required": []string{"collection_name"},
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `internal/warden` package with embedded agent integration for generating design documents during repository indexing
- Wire warden into `ragService.SetupRepoContext()` to enable richer context for code reviews
- Design documents capture testing patterns, dependencies, conventions, and API patterns

## Changes
- **New package**: `internal/warden/` containing:
  - `doc_types.go`: DesignDocument types and constants
  - `explorer.go`: Agent loop using goframe's agent for codebase exploration
  - `tools.go`: SearchCodeTool and GetStructureTool using callback pattern
  - `integration.go`: High-level API for warden integration
- **Config**: Added `WardenConfig` to `internal/config/config.go` (disabled by default)
- **RAG integration**: `generateDesignDocuments()` called at end of `SetupRepoContext()`

## Configuration
```yaml
warden:
  enabled: false        # Set true to enable
  design_docs: true    # Generate design docs during indexing
  max_iterations: 20   # Agent loop limit
```

## How it works
1. After standard RAG indexing completes, warden agent explores codebase
2. Agent uses search_code and get_structure tools to discover patterns
3. Agent outputs structured design documents (JSON)
4. Documents are indexed as `chunk_type="design_doc"` in vector store
5. Future reviews can include this context ("This project uses testify/assert and gomock...")

## Test plan
- [ ] Verify warden package compiles
- [ ] Test with `warden.enabled: true` on a sample repository
- [ ] Confirm design documents appear in vector store
- [ ] Validate agent loop completes within timeout