### PR TITLE
feat: demo and quickstart for easy local/on-prem deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,61 @@
+# .env.example — Code-Warden demo & quickstart configuration
+#
+# Copy to .env and fill in your values:
+#   cp .env.example .env
+#
+# Env vars override config.yaml values automatically (Viper AutomaticEnv).
+# Mapping: section.key → SECTION_KEY  (e.g. ai.ollama_host → AI_OLLAMA_HOST)
+
+# ── GitHub ────────────────────────────────────────────────────────────────────
+
+# Personal Access Token — for CLI demo (no GitHub App needed)
+# Required scopes: repo (or repo:read for private repos)
+# Create at: https://github.com/settings/tokens
+GITHUB_TOKEN=ghp_replace_me
+
+# GitHub App credentials — full server mode only (leave empty for CLI demo)
+GITHUB_APP_ID=
+GITHUB_WEBHOOK_SECRET=
+GITHUB_PRIVATE_KEY_PATH=keys/code-warden-app.private-key.pem
+
+# ── AI / LLM ──────────────────────────────────────────────────────────────────
+
+# Provider: "ollama" (local) or "gemini" (cloud)
+AI_LLM_PROVIDER=ollama
+
+# Ollama endpoint — set to docker service name when running in docker-compose
+AI_OLLAMA_HOST=http://ollama:11434
+
+# Models (change to larger models for better review quality)
+# Generator: Ollama cloud model — no GPU, no local download needed.
+# Alternatives: qwen3.5:35b, glm-5.1, minimax-m2.7, deepseek-v3.2
+AI_GENERATOR_MODEL=kimi-k2.5
+
+# Fast model: small local model for HyDE and quick passes (~1 GB, pulled automatically).
+# Must run locally — used frequently during indexing and context building.
+AI_FAST_MODEL=qwen2.5-coder:1.5b
+
+# Embedder: local model (~639 MB, pulled automatically on first start).
+# Must run locally — called for every indexed chunk.
+# Upgrade options:
+#   qwen3-embedding:4b  — 2.5 GB, 40K ctx, 4096-dim, better recall
+#   qwen3-embedding:8b  — 4.7 GB, 40K ctx, MTEB #1, best quality
+# (nomic-embed-text has only 2K context — truncates large source files)
+AI_EMBEDDER_MODEL=qwen3-embedding:0.6b
+
+# Reranking is disabled in demo config for speed (no model needed)
+# AI_RERANKER_MODEL=qwen2.5-coder:1.5b
+
+# Gemini API key — required only when AI_LLM_PROVIDER=gemini
+# AI_GEMINI_API_KEY=
+
+# ── Database ──────────────────────────────────────────────────────────────────
+
+# PostgreSQL connection — matches docker-compose.demo.yml defaults
+DATABASE_HOST=db
+DATABASE_PASSWORD=secret
+
+# ── Vector Store ──────────────────────────────────────────────────────────────
+
+# Qdrant gRPC address — matches docker-compose.demo.yml
+STORAGE_QDRANT_HOST=qdrant:6334

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ bin/
 keys/
 reviews/
 *.sh
+!scripts/quickstart.sh
 
 # Go workspace file
 go.work

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ OPENCODE_PORT=4096
 OPENCODE_MCP_URL=http://127.0.0.1:8081/sse
 
 .DEFAULT_GOAL := all
-.PHONY: all build run clean test lint opencode-start opencode-stop opencode-config dev ui-deps build-ui dev-ui run/server run/ui
+.PHONY: all build run clean test lint opencode-start opencode-stop opencode-config dev ui-deps build-ui dev-ui run/server run/ui \
+	demo quickstart pull-models demo-up demo-down demo-logs
 
 all: build
 
@@ -131,3 +132,35 @@ dev-ui:
 # Full build including UI
 build-all: build build-ui
 	@echo "All binaries and UI built successfully"
+
+# ── Demo & Quickstart ─────────────────────────────────────────────────────────
+
+## CLI review — no server, no GitHub App needed. Just a GitHub PAT.
+## Usage: make demo PR=https://github.com/owner/repo/pull/123
+demo:
+	@[ -f .env ] || cp .env.example .env
+	@[ -n "$(PR)" ] || (echo "Usage: make demo PR=<pr-url>" && exit 1)
+	@go run ./cmd/cli review $(PR)
+
+## Full server quickstart — starts all services in Docker, opens web UI.
+quickstart:
+	@[ -f .env ] || cp .env.example .env
+	@bash scripts/quickstart.sh
+
+## Pull local Ollama models for demo (run on host Ollama, not Docker)
+## Generator (kimi-k2.5) is a cloud model — no local download needed for it.
+pull-models:
+	ollama pull qwen3-embedding:0.6b
+	ollama pull qwen2.5-coder:1.5b
+
+## Start all demo services (after initial quickstart)
+demo-up:
+	docker compose -f docker-compose.demo.yml up -d
+
+## Stop all demo services
+demo-down:
+	docker compose -f docker-compose.demo.yml down
+
+## Stream server logs from the demo stack
+demo-logs:
+	docker compose -f docker-compose.demo.yml logs -f server

--- a/README.md
+++ b/README.md
@@ -82,52 +82,72 @@ The `/implement` command goes further: an autonomous agent reads the issue, expl
 
 ## Quick Start
 
-### Prerequisites
+### Demo mode — 5 minutes, no GitHub App needed
 
-- Go 1.22+
-- Docker & Docker Compose
-- A GitHub App (see [GitHub App Setup](#github-app-setup))
-
-### 1. Clone and configure
+Review a real pull request with just a GitHub personal access token:
 
 ```sh
 git clone https://github.com/sevigo/code-warden
 cd code-warden
-cp config.yaml.example config.yaml
-# Edit config.yaml with your GitHub App credentials and model settings
+cp .env.example .env        # add your GitHub PAT to GITHUB_TOKEN
+make demo PR=https://github.com/owner/repo/pull/42
 ```
 
-### 2. Start services
+The CLI clones the repo, indexes it into a local Qdrant instance, and prints findings to the terminal. No webhook, no GitHub App, no public URL required.
+
+### Full server — 15 minutes, includes web UI
+
+Everything running in Docker with a web dashboard at `localhost:8080`:
 
 ```sh
-docker-compose up -d                                    # Qdrant + PostgreSQL
-docker-compose -f docker-compose.setup.yml up --build  # Pull Ollama models
+git clone https://github.com/sevigo/code-warden
+cd code-warden
+make quickstart             # guided interactive setup
 ```
 
-### 3. Run
+The wizard checks prerequisites, configures `.env`, detects your GPU, and starts all services. On first run it pulls two local models (~1.6 GB): the embedder and fast model. The code review generator (`kimi-k2.5`) is an Ollama cloud model — no GPU or large download needed. Open `http://localhost:8080` when it finishes.
 
+**GPU support** (optional — CPU works fine for demos):
 ```sh
-make build && ./bin/code-warden
-# or for development:
-go run ./cmd/server/main.go
+# NVIDIA
+docker compose -f docker-compose.demo.yml -f docker-compose.gpu.yml up -d
+
+# AMD ROCm
+docker compose -f docker-compose.demo.yml -f docker-compose.amd.yml up -d
 ```
 
-### 4. Trigger a review
+**Useful commands:**
+```sh
+make demo-logs    # tail server logs
+make demo-down    # stop all services
+make demo-up      # restart services
+make pull-models  # pull models to host Ollama (outside Docker)
+```
 
-Comment `/review` on any open pull request in a repository where the GitHub App is installed. Code-Warden will clone the repo (first time), index it, and post findings.
+**Prerequisites:** Docker, Go 1.22+
 
 ---
 
 ## GitHub App Setup
 
+Required for full server mode (webhook-triggered reviews on PRs).
+
 1. Create a new GitHub App in your organization settings
-2. Set the webhook URL to `https://your-host/webhook`
+2. Set the webhook URL to `https://your-host/api/v1/webhook/github`
 3. Request permissions: `Pull requests: Read & Write`, `Issues: Read & Write`, `Contents: Read`
 4. Subscribe to events: `Pull request`, `Issue comment`, `Push`
-5. Generate and download a private key
+5. Generate and download a private key → save to `keys/`
 6. Install the app on the repositories you want reviewed
 
-Set the credentials in `config.yaml`:
+Add credentials to `.env`:
+
+```sh
+GITHUB_APP_ID=12345
+GITHUB_WEBHOOK_SECRET=your-secret
+GITHUB_PRIVATE_KEY_PATH=keys/app.private-key.pem
+```
+
+Or set them in `config.yaml`:
 
 ```yaml
 github:

--- a/config.demo.yaml
+++ b/config.demo.yaml
@@ -1,0 +1,105 @@
+# config.demo.yaml — Code-Warden demo / quickstart configuration
+#
+# This config is designed for local demo and on-prem evaluation.
+# All secrets are read from environment variables (see .env.example).
+# Viper maps env vars automatically: SECTION_KEY → section.key
+#
+# Used by:
+#   make demo PR=<url>        — CLI review with just a GitHub PAT
+#   make quickstart           — Full server stack via Docker
+#   docker-compose.demo.yml   — Mounts this file as /app/config.yaml
+
+server:
+  port: "8080"
+  max_workers: 3
+
+github:
+  # Secrets come from env vars: GITHUB_APP_ID, GITHUB_WEBHOOK_SECRET,
+  # GITHUB_PRIVATE_KEY_PATH, GITHUB_TOKEN
+  private_key_path: "keys/code-warden-app.private-key.pem"
+
+ai:
+  # Provider: "ollama" — routes to Ollama cloud for generation, local for embeddings
+  # Override via AI_LLM_PROVIDER env var.
+  llm_provider: "ollama"
+  embedder_provider: "ollama"
+
+  # Ollama endpoint — overridden to http://ollama:11434 inside docker-compose
+  ollama_host: "http://localhost:11434"
+
+  # Generator: Ollama cloud model — runs on Ollama's infrastructure, no GPU needed.
+  # No large model download; Ollama routes the request to the cloud.
+  # Override via AI_GENERATOR_MODEL env var.
+  # Alternatives: qwen3.5:35b, glm-5.1, minimax-m2.7, deepseek-v3.2
+  generator_model: "kimi-k2.5"
+
+  # Fast model: local model used for quick passes (HyDE, validation).
+  # Must run locally. ollama-init pulls this alongside the embedder.
+  # qwen2.5-coder:1.5b is ~1 GB — small enough for any machine.
+  fast_model: "qwen2.5-coder:1.5b"
+
+  # Embedder: local model — called for every indexed chunk, must run locally.
+  # ollama-init pulls this automatically (~639 MB one-time download).
+  # qwen3-embedding:0.6b: 32K context, 1024-dim — ideal for code files
+  # Upgrade options (set AI_EMBEDDER_MODEL in .env):
+  #   qwen3-embedding:4b  — 2.5 GB, 40K ctx, 4096-dim, better recall
+  #   qwen3-embedding:8b  — 4.7 GB, 40K ctx, MTEB #1, best quality
+  # (nomic-embed-text only has 2K context — truncates larger source files)
+  embedder_model: "qwen3-embedding:0.6b"
+  embedder_task_description: "search_document"
+
+  # Reranking disabled — no extra model needed.
+  # Sparse vectors are handled in-process by the Go code-sparse provider.
+  enable_reranking: false
+  reranker_model: "qwen2.5-coder:1.5b"
+
+  # Hybrid search (dense + sparse) — sparse is zero-cost in-process
+  enable_hybrid_search: true
+  sparse_vector_name: "code_sparse"
+
+  # HyDE adds an extra LLM round-trip; disable for demo speed
+  enable_hyde: false
+
+  # Thinking/reasoning mode — off by default; enable for models that support it
+  # (kimi-k2.5 and qwen3.5 both support thinking mode)
+  enable_thinking: false
+
+  context_token_budget: 64000
+  model_keep_alive: "10m"
+  enable_code_suggestions: true
+
+storage:
+  # gRPC port — overridden to qdrant:6334 inside docker-compose
+  qdrant_host: "localhost:6334"
+  repo_path: "./data/repos"
+
+database:
+  driver: "postgres"
+  # Host overridden to "db" inside docker-compose via DATABASE_HOST env var
+  host: "localhost"
+  port: 5432
+  database: "codewarden"
+  username: "warden"
+  # Password comes from DATABASE_PASSWORD env var
+  password: "secret"
+  ssl_mode: "disable"
+  max_open_conns: 10
+  max_idle_conns: 3
+  conn_max_lifetime: "5m"
+  conn_max_idle_time: "5m"
+
+logging:
+  level: "info"
+  format: "text"
+  output: "stdout"
+
+features:
+  enable_binary_quantization: true
+  enable_graph_analysis: false
+
+# Agent and Warden disabled in demo mode
+agent:
+  enabled: false
+
+warden:
+  enabled: false

--- a/docker-compose.amd.yml
+++ b/docker-compose.amd.yml
@@ -1,0 +1,29 @@
+# docker-compose.amd.yml — AMD ROCm GPU override for docker-compose.demo.yml
+#
+# Usage:
+#   docker-compose -f docker-compose.demo.yml -f docker-compose.amd.yml up -d
+#
+# Requirements:
+#   - AMD GPU with ROCm support (RDNA2/RX 6000 series or newer recommended)
+#   - ROCm drivers installed on the host (https://rocm.docs.amd.com)
+#   - The /dev/kfd and /dev/dri devices must be available
+#
+# Supported cards (ROCm): RX 6000/7000 series, MI-series datacenter GPUs
+# Unsupported: RX 5000 series and older (no ROCm support)
+#
+# Verify GPU is visible inside the container:
+#   docker exec cw-ollama rocm-smi
+
+services:
+  ollama:
+    image: ollama/ollama:rocm
+    devices:
+      - /dev/kfd:/dev/kfd
+      - /dev/dri:/dev/dri
+    group_add:
+      - video
+    security_opt:
+      - seccomp:unconfined
+    environment:
+      HSA_OVERRIDE_GFX_VERSION: "10.3.0"   # override for RX 6000 if not auto-detected
+      # Remove the line above if you are using RX 7000/MI-series (auto-detected)

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,0 +1,153 @@
+# docker-compose.demo.yml — Code-Warden all-in-one demo stack
+#
+# Includes: PostgreSQL + Qdrant + Ollama + Code-Warden server
+#
+# Usage:
+#   make quickstart           — guided first-time setup
+#   make demo-up              — start all services
+#   make demo-down            — stop all services
+#   make demo-logs            — tail server logs
+#
+# GPU overrides (optional):
+#   NVIDIA:  docker-compose -f docker-compose.demo.yml -f docker-compose.gpu.yml up -d
+#   AMD ROCm: docker-compose -f docker-compose.demo.yml -f docker-compose.amd.yml up -d
+#
+# Models pulled on first start (~1.6 GB total):
+#   qwen3-embedding:0.6b   ~639 MB  (embedder — local, called per indexed chunk)
+#   qwen2.5-coder:1.5b     ~1.0 GB  (fast model — local, used for HyDE and quick passes)
+#
+# The generator (kimi-k2.5 by default) is an Ollama cloud model — no local download.
+#
+# Reranking is disabled in config.demo.yaml — no reranker model needed.
+# Sparse vectors are generated in-process (no Ollama call required).
+
+services:
+
+  # ── PostgreSQL ──────────────────────────────────────────────────────────────
+  db:
+    image: postgres:16-alpine
+    container_name: cw-db
+    environment:
+      POSTGRES_DB: codewarden
+      POSTGRES_USER: warden
+      POSTGRES_PASSWORD: secret
+    ports:
+      - "5432:5432"
+    volumes:
+      - demo_postgres_data:/var/lib/postgresql/data
+    networks:
+      - cw-demo-net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U warden -d codewarden"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  # ── Qdrant Vector Database ──────────────────────────────────────────────────
+  qdrant:
+    image: qdrant/qdrant:latest
+    container_name: cw-qdrant
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - demo_qdrant_data:/var/lib/qdrant/storage
+    networks:
+      - cw-demo-net
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://localhost:6333/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  # ── Ollama LLM Runtime ──────────────────────────────────────────────────────
+  ollama:
+    image: ollama/ollama:latest
+    container_name: cw-ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - demo_ollama_data:/root/.ollama
+    networks:
+      - cw-demo-net
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://localhost:11434/api/tags || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+    # GPU is optional — generator (kimi-k2.5) is a cloud model; no local GPU needed.
+    # A GPU only speeds up the local embedder (qwen3-embedding:0.6b).
+    # NVIDIA: add docker-compose.gpu.yml override
+    # AMD ROCm: add docker-compose.amd.yml override
+    # Apple Silicon: Metal acceleration works automatically via this image.
+
+  # ── Model Initialiser (one-shot) ────────────────────────────────────────────
+  ollama-init:
+    image: ollama/ollama:latest
+    container_name: cw-ollama-init
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      OLLAMA_HOST: http://ollama:11434
+    entrypoint: >
+      sh -c "
+        echo '>> Pulling qwen3-embedding:0.6b (~639 MB)...' &&
+        ollama pull qwen3-embedding:0.6b &&
+        echo '>> Pulling qwen2.5-coder:1.5b (~1 GB, fast/HyDE model)...' &&
+        ollama pull qwen2.5-coder:1.5b &&
+        echo '>> Local models ready. Generator (kimi-k2.5) is a cloud model — no download needed.'
+      "
+    networks:
+      - cw-demo-net
+    restart: "no"
+
+  # ── Code-Warden Server ──────────────────────────────────────────────────────
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: cw-server
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
+    environment:
+      # Point to docker-compose service names — override any values in .env
+      AI_OLLAMA_HOST: http://ollama:11434
+      DATABASE_HOST: db
+      STORAGE_QDRANT_HOST: qdrant:6334
+    volumes:
+      - ./config.demo.yaml:/app/config.yaml:ro
+      - ./keys:/app/keys:ro
+      - demo_server_data:/app/data
+    networks:
+      - cw-demo-net
+    depends_on:
+      db:
+        condition: service_healthy
+      qdrant:
+        condition: service_healthy
+      ollama-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://localhost:8080/health || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
+    restart: unless-stopped
+
+networks:
+  cw-demo-net:
+    driver: bridge
+
+volumes:
+  demo_postgres_data:
+  demo_qdrant_data:
+  demo_ollama_data:
+  demo_server_data:

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -1,0 +1,23 @@
+# docker-compose.gpu.yml — NVIDIA GPU override for docker-compose.demo.yml
+#
+# Usage:
+#   docker-compose -f docker-compose.demo.yml -f docker-compose.gpu.yml up -d
+#
+# Requirements:
+#   - NVIDIA GPU with CUDA support (Turing/RTX 20xx or newer recommended)
+#   - nvidia-container-toolkit installed on the host:
+#       https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
+#
+# Verify GPU is visible inside the container:
+#   docker exec cw-ollama nvidia-smi
+
+services:
+  ollama:
+    image: ollama/ollama:latest
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,5 +1,31 @@
 # Setup Guide
 
+---
+
+## Quick Demo (5 minutes, no GitHub App)
+
+Review a real PR with just a GitHub PAT:
+
+```sh
+git clone https://github.com/sevigo/code-warden
+cd code-warden
+cp .env.example .env    # set GITHUB_TOKEN to your PAT
+make demo PR=https://github.com/owner/repo/pull/42
+```
+
+**Full server with web UI (15 minutes):**
+
+```sh
+make quickstart         # guided setup, starts all Docker services
+# open http://localhost:8080
+```
+
+See the [README](../README.md#quick-start) for GPU support and useful commands.
+
+---
+
+## Full Production Setup
+
 This guide walks through deploying Code-Warden from scratch — GitHub App creation, infrastructure, configuration, and first review.
 
 ## Prerequisites

--- a/internal/server/handler/dashboard.go
+++ b/internal/server/handler/dashboard.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -53,79 +54,9 @@ func (h *DashboardHandler) SetupStatus(w http.ResponseWriter, r *http.Request) {
 		appName = ""
 	}
 
-	// Ping DB via a lightweight store call
-	var dbStatus string
-	var dbLatency int64
-	{
-		start := time.Now()
-		_, err := h.store.GetReviewStats(ctx)
-		dbLatency = time.Since(start).Milliseconds()
-		if err == nil {
-			dbStatus = "ok"
-		} else {
-			dbStatus = statusError
-		}
-	}
-
-	// Ping Qdrant HTTP health endpoint
-	var qdrantStatus string
-	var qdrantLatency int64
-	{
-		host := h.cfg.Storage.QdrantHost
-		// Switch to HTTP port for health check if configured for gRPC
-		if rest, ok := strings.CutSuffix(host, ":6334"); ok {
-			host = rest + ":6333"
-		}
-		if !strings.HasPrefix(host, "http") {
-			host = "http://" + host
-		}
-		start := time.Now()
-		resp, err := http.Get(host + "/healthz") //nolint:noctx // short health check request
-		qdrantLatency = time.Since(start).Milliseconds()
-		if err == nil {
-			_, _ = io.Copy(io.Discard, resp.Body)
-			_ = resp.Body.Close()
-			if resp.StatusCode < 300 {
-				qdrantStatus = "ok"
-			} else {
-				qdrantStatus = statusError
-			}
-		} else {
-			qdrantStatus = statusError
-		}
-	}
-
-	// Ping LLM endpoint (Ollama or Gemini)
-	var llmStatus string
-	var llmLatency int64
-	{
-		var llmURL string
-		switch h.cfg.AI.LLMProvider {
-		case "gemini":
-			llmURL = "https://generativelanguage.googleapis.com/v1beta/models"
-		default: // ollama
-			host := h.cfg.AI.OllamaHost
-			if host == "" {
-				host = "http://localhost:11434"
-			}
-			llmURL = host + "/api/tags"
-		}
-		start := time.Now()
-		client := &http.Client{Timeout: 5 * time.Second}
-		resp, err := client.Get(llmURL) //nolint:noctx // short health check
-		llmLatency = time.Since(start).Milliseconds()
-		if err == nil {
-			_, _ = io.Copy(io.Discard, resp.Body)
-			_ = resp.Body.Close()
-			if resp.StatusCode < 300 {
-				llmStatus = "ok"
-			} else {
-				llmStatus = statusError
-			}
-		} else {
-			llmStatus = statusError
-		}
-	}
+	dbStatus, dbLatency := h.pingDatabase(ctx)
+	qdrantStatus, qdrantLatency := pingURL(h.cfg.Storage.QdrantHost, "/healthz", true)
+	llmStatus, llmLatency := h.pingLLM()
 
 	installURL := ""
 	if configured && appName != "" {
@@ -147,6 +78,59 @@ func (h *DashboardHandler) SetupStatus(w http.ResponseWriter, r *http.Request) {
 		},
 		"ready": configured && dbStatus == "ok" && qdrantStatus == "ok" && llmStatus == "ok",
 	})
+}
+
+// pingDatabase pings the store and returns (status, latency_ms).
+func (h *DashboardHandler) pingDatabase(ctx context.Context) (string, int64) {
+	start := time.Now()
+	_, err := h.store.GetReviewStats(ctx)
+	latency := time.Since(start).Milliseconds()
+	if err != nil {
+		return statusError, latency
+	}
+	return "ok", latency
+}
+
+// pingURL performs a GET health check against a service URL.
+// When grpcPort is true, ":6334" is converted to ":6333" (Qdrant gRPC→HTTP).
+func pingURL(host, path string, grpcPort bool) (string, int64) {
+	if grpcPort {
+		if rest, ok := strings.CutSuffix(host, ":6334"); ok {
+			host = rest + ":6333"
+		}
+	}
+	if !strings.HasPrefix(host, "http") {
+		host = "http://" + host
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	start := time.Now()
+	resp, err := client.Get(host + path) //nolint:noctx // short health check
+	latency := time.Since(start).Milliseconds()
+	if err != nil {
+		return statusError, latency
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode < 300 {
+		return "ok", latency
+	}
+	return statusError, latency
+}
+
+// pingLLM checks reachability of the configured LLM provider.
+func (h *DashboardHandler) pingLLM() (string, int64) {
+	var url string
+	switch h.cfg.AI.LLMProvider {
+	case "gemini":
+		url = "https://generativelanguage.googleapis.com/v1beta/models"
+	default: // ollama
+		host := h.cfg.AI.OllamaHost
+		if host == "" {
+			host = "http://localhost:11434"
+		}
+		url = host + "/api/tags"
+	}
+	return pingURL(url, "", false)
 }
 
 func (h *DashboardHandler) GetConfig(w http.ResponseWriter, _ *http.Request) {

--- a/internal/server/handler/dashboard.go
+++ b/internal/server/handler/dashboard.go
@@ -73,8 +73,8 @@ func (h *DashboardHandler) SetupStatus(w http.ResponseWriter, r *http.Request) {
 	{
 		host := h.cfg.Storage.QdrantHost
 		// Switch to HTTP port for health check if configured for gRPC
-		if strings.HasSuffix(host, ":6334") {
-			host = strings.TrimSuffix(host, ":6334") + ":6333"
+		if rest, ok := strings.CutSuffix(host, ":6334"); ok {
+			host = rest + ":6333"
 		}
 		if !strings.HasPrefix(host, "http") {
 			host = "http://" + host
@@ -95,6 +95,38 @@ func (h *DashboardHandler) SetupStatus(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Ping LLM endpoint (Ollama or Gemini)
+	var llmStatus string
+	var llmLatency int64
+	{
+		var llmURL string
+		switch h.cfg.AI.LLMProvider {
+		case "gemini":
+			llmURL = "https://generativelanguage.googleapis.com/v1beta/models"
+		default: // ollama
+			host := h.cfg.AI.OllamaHost
+			if host == "" {
+				host = "http://localhost:11434"
+			}
+			llmURL = host + "/api/tags"
+		}
+		start := time.Now()
+		client := &http.Client{Timeout: 5 * time.Second}
+		resp, err := client.Get(llmURL) //nolint:noctx // short health check
+		llmLatency = time.Since(start).Milliseconds()
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode < 300 {
+				llmStatus = "ok"
+			} else {
+				llmStatus = statusError
+			}
+		} else {
+			llmStatus = statusError
+		}
+	}
+
 	installURL := ""
 	if configured && appName != "" {
 		installURL = fmt.Sprintf("https://github.com/apps/%s/installations/new",
@@ -111,8 +143,9 @@ func (h *DashboardHandler) SetupStatus(w http.ResponseWriter, r *http.Request) {
 		"services": map[string]any{
 			"database": map[string]any{"status": dbStatus, "latency_ms": dbLatency},
 			"qdrant":   map[string]any{"status": qdrantStatus, "latency_ms": qdrantLatency},
+			"llm":      map[string]any{"status": llmStatus, "latency_ms": llmLatency, "provider": h.cfg.AI.LLMProvider},
 		},
-		"ready": configured && dbStatus == "ok" && qdrantStatus == "ok",
+		"ready": configured && dbStatus == "ok" && qdrantStatus == "ok" && llmStatus == "ok",
 	})
 }
 
@@ -573,8 +606,8 @@ func buildTitle(comment string, idx int) string {
 	// (Simple check for common review emojis)
 	emojis := []string{"🔍", "💡", "📖", "🔴", "🟠", "🟡", "🟢", "✅", "🚫", "💬"}
 	for _, e := range emojis {
-		if strings.HasPrefix(comment, e) {
-			comment = strings.TrimSpace(strings.TrimPrefix(comment, e))
+		if rest, ok := strings.CutPrefix(comment, e); ok {
+			comment = strings.TrimSpace(rest)
 			break
 		}
 	}

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# scripts/quickstart.sh — Code-Warden guided setup wizard
+#
+# Idempotent: safe to run multiple times.
+# Run via: make quickstart   or   bash scripts/quickstart.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HEALTH_URL="http://localhost:8080/health"
+COMPOSE_FILE="docker-compose.demo.yml"
+
+# ── Colours ──────────────────────────────────────────────────────────────────
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+RED='\033[0;31m'
+BOLD='\033[1m'
+NC='\033[0m' # No Colour
+
+info()    { echo -e "${CYAN}  >${NC} $*"; }
+ok()      { echo -e "${GREEN}  ✓${NC} $*"; }
+warn()    { echo -e "${YELLOW}  !${NC} $*"; }
+err()     { echo -e "${RED}  ✗${NC} $*" >&2; }
+heading() { echo -e "\n${BOLD}$*${NC}"; }
+
+# ── Prerequisites ─────────────────────────────────────────────────────────────
+
+heading "Code-Warden Quickstart"
+echo "  Full server mode: PostgreSQL + Qdrant + Ollama + Code-Warden"
+echo "  Web UI will be available at http://localhost:8080"
+echo ""
+
+check_dep() {
+    if ! command -v "$1" &>/dev/null; then
+        err "Required tool not found: $1"
+        echo "  Install it and re-run this script."
+        exit 1
+    fi
+    ok "$1 found"
+}
+
+heading "1. Checking prerequisites..."
+check_dep docker
+check_dep git
+
+# docker compose v2 or docker-compose v1
+if docker compose version &>/dev/null 2>&1; then
+    COMPOSE_CMD="docker compose"
+elif command -v docker-compose &>/dev/null; then
+    COMPOSE_CMD="docker-compose"
+else
+    err "Neither 'docker compose' (v2) nor 'docker-compose' (v1) found."
+    echo "  Install Docker Desktop or docker-compose and re-run."
+    exit 1
+fi
+ok "Docker Compose found ($COMPOSE_CMD)"
+
+# ── .env setup ────────────────────────────────────────────────────────────────
+
+heading "2. Environment configuration..."
+
+cd "$REPO_ROOT"
+
+if [ ! -f .env ]; then
+    cp .env.example .env
+    info "Created .env from .env.example"
+fi
+
+# Check if GITHUB_TOKEN is still the placeholder
+if grep -q 'GITHUB_TOKEN=ghp_replace_me' .env 2>/dev/null; then
+    warn "GITHUB_TOKEN is not set in .env"
+    echo ""
+    echo "  You need a GitHub Personal Access Token for the server to authenticate."
+    echo "  Create one at: https://github.com/settings/tokens"
+    echo "  Required scopes: repo (or repo:read for private repos)"
+    echo ""
+    printf "  Paste your GitHub PAT (or press Enter to skip): "
+    read -r pat
+    if [ -n "$pat" ]; then
+        # Replace the placeholder value
+        sed -i.bak "s|GITHUB_TOKEN=ghp_replace_me|GITHUB_TOKEN=$pat|" .env
+        rm -f .env.bak
+        ok "GitHub PAT saved to .env"
+    else
+        warn "Skipped — set GITHUB_TOKEN in .env before connecting to GitHub"
+    fi
+else
+    ok "GITHUB_TOKEN is configured"
+fi
+
+# ── GPU detection ─────────────────────────────────────────────────────────────
+
+heading "3. GPU detection..."
+
+GPU_OVERRIDE=""
+
+if command -v nvidia-smi &>/dev/null && nvidia-smi &>/dev/null 2>&1; then
+    ok "NVIDIA GPU detected"
+    GPU_OVERRIDE="-f docker-compose.gpu.yml"
+    info "Using NVIDIA GPU compose override for Ollama"
+elif [ -e /dev/kfd ] && [ -e /dev/dri ]; then
+    ok "AMD ROCm GPU detected (/dev/kfd + /dev/dri)"
+    GPU_OVERRIDE="-f docker-compose.amd.yml"
+    info "Using AMD ROCm compose override for Ollama"
+    info "Note: HSA_OVERRIDE_GFX_VERSION=10.3.0 is set for RX 6000 series"
+    info "Remove that env var from docker-compose.amd.yml for RX 7000/MI-series"
+else
+    info "No GPU detected — using CPU mode (Ollama runs on CPU)"
+    info "Apple Silicon: Metal acceleration works automatically via the Ollama image"
+fi
+
+# ── Build & start ─────────────────────────────────────────────────────────────
+
+heading "4. Starting services..."
+
+info "Building Code-Warden image and starting all containers..."
+info "First run pulls local Ollama models (~1.6 GB): embedder + fast model."
+info "Generator (kimi-k2.5) is a cloud model — no local download needed."
+echo ""
+
+# shellcheck disable=SC2086
+$COMPOSE_CMD -f $COMPOSE_FILE $GPU_OVERRIDE up -d --build
+
+ok "All containers started"
+
+# ── Wait for health ───────────────────────────────────────────────────────────
+
+heading "5. Waiting for server to be ready..."
+
+MAX_WAIT=180  # seconds
+ELAPSED=0
+INTERVAL=5
+
+printf "  Polling %s" "$HEALTH_URL"
+
+until curl -sf "$HEALTH_URL" &>/dev/null; do
+    if [ "$ELAPSED" -ge "$MAX_WAIT" ]; then
+        echo ""
+        err "Server did not become healthy within ${MAX_WAIT}s"
+        echo ""
+        echo "  Check logs with:  $COMPOSE_CMD -f $COMPOSE_FILE logs server"
+        echo "  Common causes:"
+        echo "    - Ollama model pull still in progress (ollama-init service)"
+        echo "    - Not enough disk space for models (~5.3 GB needed)"
+        echo "    - Port 8080 already in use on the host"
+        exit 1
+    fi
+    printf "."
+    sleep "$INTERVAL"
+    ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+echo ""
+ok "Server is healthy"
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+
+heading "6. Setup complete!"
+echo ""
+echo -e "  ${GREEN}${BOLD}Code-Warden is running at http://localhost:8080${NC}"
+echo ""
+echo "  Next steps:"
+echo "    • Open http://localhost:8080/setup to configure your GitHub App"
+echo "    • Or run a quick CLI review (no GitHub App needed):"
+echo ""
+echo -e "      ${CYAN}make demo PR=https://github.com/owner/repo/pull/123${NC}"
+echo ""
+echo "  Useful commands:"
+echo "    make demo-logs    — tail server logs"
+echo "    make demo-down    — stop all services"
+echo "    make demo-up      — restart services"
+echo ""


### PR DESCRIPTION
## Summary

- **`make demo PR=<url>`** — review a real PR in 5 min with just a GitHub PAT; no GitHub App, no server, no Docker required
- **`make quickstart`** — guided wizard that starts the full server stack (Postgres + Qdrant + Ollama + web UI) via Docker in ~15 min
- Generator uses an **Ollama cloud model** (`kimi-k2.5`) — no GPU needed, only ~1.6 GB of local model downloads (embedder + fast model)

## New files

| File | Purpose |
|------|---------|
| `.env.example` | All env vars documented with demo defaults |
| `config.demo.yaml` | Pre-filled demo config (cloud generator, local embedder/fast model) |
| `docker-compose.demo.yml` | All-in-one stack: Postgres + Qdrant + Ollama + server |
| `docker-compose.gpu.yml` | NVIDIA GPU override for Ollama |
| `docker-compose.amd.yml` | AMD ROCm GPU override for Ollama |
| `scripts/quickstart.sh` | Interactive setup wizard with GPU auto-detection and health polling |

## Model strategy

| Role | Model | Where | Download |
|------|-------|-------|----------|
| Generator | `kimi-k2.5` | Ollama cloud | 0 MB |
| Fast model | `qwen2.5-coder:1.5b` | Local Ollama | ~1 GB |
| Embedder | `qwen3-embedding:0.6b` | Local Ollama | ~639 MB |
| Reranker | *(disabled)* | — | 0 MB |
| Sparse vectors | *(in-process Go)* | — | 0 MB |

Total local download: **~1.6 GB**. No GPU required.

`qwen3-embedding:0.6b` chosen over `nomic-embed-text` for its 32K context window (nomic is limited to 2K, which truncates larger source files).

## Changes

- **Makefile**: `demo`, `quickstart`, `pull-models`, `demo-up/down/logs` targets
- **`dashboard.go`**: real LLM health check added to `/api/v1/setup/status`; two lint fixes (`CutSuffix`, `CutPrefix`)
- **`README.md`**: replaced old Quick Start with demo-mode + full-server sections
- **`docs/SETUP.md`**: demo section at top, full App setup pushed below
- **`.gitignore`**: exempt `scripts/quickstart.sh` from `*.sh` exclusion

## Test plan

- [ ] `cp .env.example .env` → set `GITHUB_TOKEN` → `make demo PR=<url>` → prints review findings
- [ ] `make quickstart` → all containers start → `http://localhost:8080` loads
- [ ] `GET /api/v1/setup/status` → returns `services.llm.status` field
- [ ] `make demo-down && make demo-up` → services recover cleanly
- [ ] `make lint && make test` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)