### PR TITLE
fix(agent): observability quick wins for agent harness diagnostics

### DIFF
--- a/internal/agent/comments.go
+++ b/internal/agent/comments.go
@@ -196,3 +196,18 @@ func (o *Orchestrator) completeCheckRun(ctx context.Context, issue Issue, checkR
 		o.logger.Warn("completeCheckRun: failed", "check_run_id", checkRunID, "conclusion", conclusion, "error", err)
 	}
 }
+
+// deferCheckRunCompletion returns a function suitable for deferring that
+// completes a Check Run with a conclusion based on the session's final status.
+func (o *Orchestrator) deferCheckRunCompletion(ctx context.Context, session *Session, checkRunID int64) {
+	conclusion := "success"
+	summary := fmt.Sprintf("Session `%s` completed.", session.ID)
+	if s := session.GetStatus(); s == StatusFailed {
+		conclusion = "failure"
+		summary = fmt.Sprintf("Session `%s` failed: %s", session.ID, session.GetError())
+	} else if s == StatusDraft {
+		conclusion = "action_required"
+		summary = fmt.Sprintf("Session `%s` yielded a draft PR for human review.", session.ID)
+	}
+	o.completeCheckRun(ctx, session.Issue, checkRunID, conclusion, summary)
+}

--- a/internal/agent/inprocess.go
+++ b/internal/agent/inprocess.go
@@ -36,6 +36,7 @@ func (o *Orchestrator) runNativeLoop(ctx context.Context, session *Session, bran
 		o.failSession(ctx, session, err.Error())
 		return
 	}
+	tracer := NewTracingModel(agentLLM)
 
 	ctx, cancel := context.WithTimeout(ctx, o.config.Timeout)
 	defer cancel()
@@ -46,6 +47,10 @@ func (o *Orchestrator) runNativeLoop(ctx context.Context, session *Session, bran
 		return
 	}
 	defer ws.logFile.Close()
+	if ws.traceFile != nil {
+		defer ws.traceFile.Close()
+	}
+	defer o.persistLogs(ws, session.ID)
 	if ws.lsp != nil {
 		defer ws.lsp.Stop()
 	}
@@ -60,7 +65,7 @@ func (o *Orchestrator) runNativeLoop(ctx context.Context, session *Session, bran
 		"model", agentLLM,
 	)
 
-	loop, err := buildLoop(agentLLM, session, ws)
+	loop, err := buildLoop(tracer, session, ws)
 	if err != nil {
 		o.failSession(ctx, session, err.Error())
 		return
@@ -109,14 +114,15 @@ func (o *Orchestrator) runNativeLoop(ctx context.Context, session *Session, bran
 	session.SetStatus(StatusCompleted)
 	o.postSessionCompleted(ctx, session, result)
 
+	totalIn, totalOut, _ := tracer.TokenCounts()
 	o.logger.Info("runNativeLoop: completed",
 		"session_id", session.ID,
 		"label", label,
 		"verdict", result.Verdict,
 		"iterations", result.Iterations,
 		"pr_url", result.PRURL,
-		"tokens_in", loopResult.Tokens.Input,
-		"tokens_out", loopResult.Tokens.Output)
+		"tokens_in", totalIn,
+		"tokens_out", totalOut)
 }
 
 // resolveAgentLLM returns the LLM to use for the native agent.

--- a/internal/agent/tracing_model.go
+++ b/internal/agent/tracing_model.go
@@ -1,0 +1,79 @@
+package agent
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/sevigo/goframe/llms"
+	"github.com/sevigo/goframe/schema"
+)
+
+// TracingModel wraps an llms.Model and accumulates token usage from every
+// GenerateContent call.  The Ollama (and Gemini) providers populate
+// GenerationInfo with PromptTokens / CompletionTokens on each response, but
+// goframe's AgentLoop never extracts them — LoopResult.Tokens is always zero.
+//
+// TracingModel fixes this by reading those values after each call and
+// accumulating them in atomic counters.  After the loop completes, callers
+// can read the totals with TokenCounts().
+type TracingModel struct {
+	inner     llms.Model
+	tokensIn  atomic.Int64
+	tokensOut atomic.Int64
+	calls     atomic.Int64
+}
+
+// NewTracingModel creates a TracingModel that delegates to inner.
+func NewTracingModel(inner llms.Model) *TracingModel {
+	return &TracingModel{inner: inner}
+}
+
+// GenerateContent delegates to the wrapped model and accumulates token counts
+// from the response's GenerationInfo.
+func (t *TracingModel) GenerateContent(ctx context.Context, messages []schema.MessageContent, options ...llms.CallOption) (*schema.ContentResponse, error) {
+	resp, err := t.inner.GenerateContent(ctx, messages, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	t.calls.Add(1)
+
+	for _, choice := range resp.Choices {
+		if choice.GenerationInfo == nil {
+			continue
+		}
+		if v, ok := choice.GenerationInfo["PromptTokens"]; ok {
+			if f, ok := v.(float64); ok && f > 0 {
+				t.tokensIn.Add(int64(f))
+			}
+		}
+		if v, ok := choice.GenerationInfo["CompletionTokens"]; ok {
+			if f, ok := v.(float64); ok && f > 0 {
+				t.tokensOut.Add(int64(f))
+			}
+		}
+	}
+
+	return resp, nil
+}
+
+// Call delegates to the wrapped model.  Token counts are not available for
+// single-turn Call invocations (they return plain strings), so this only
+// increments the call counter.
+func (t *TracingModel) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
+	t.calls.Add(1)
+	return t.inner.Call(ctx, prompt, options...)
+}
+
+// TokenCounts returns the accumulated input tokens, output tokens, and total
+// LLM call count since the last Reset.
+func (t *TracingModel) TokenCounts() (tokensIn, tokensOut, calls int64) {
+	return t.tokensIn.Load(), t.tokensOut.Load(), t.calls.Load()
+}
+
+// Reset zeroes all accumulated counters.
+func (t *TracingModel) Reset() {
+	t.tokensIn.Store(0)
+	t.tokensOut.Store(0)
+	t.calls.Store(0)
+}

--- a/internal/agent/warden.go
+++ b/internal/agent/warden.go
@@ -91,6 +91,7 @@ func (o *Orchestrator) runWardenAgent(ctx context.Context, session *Session, bra
 		o.failSession(ctx, session, err.Error())
 		return
 	}
+	tracer := NewTracingModel(agentLLM)
 
 	ctx, cancel := context.WithTimeout(ctx, o.config.Timeout)
 	defer cancel()
@@ -104,6 +105,7 @@ func (o *Orchestrator) runWardenAgent(ctx context.Context, session *Session, bra
 	if ws.traceFile != nil {
 		defer ws.traceFile.Close()
 	}
+	defer o.persistLogs(ws, session.ID)
 	if ws.lsp != nil {
 		defer ws.lsp.Stop()
 	}
@@ -126,20 +128,7 @@ func (o *Orchestrator) runWardenAgent(ctx context.Context, session *Session, bra
 	checkRunID := o.createCheckRun(ctx, session.Issue, baseSHA,
 		fmt.Sprintf("Session `%s` started.", session.ID))
 	// Complete the Check Run when runWardenAgent returns, whatever the outcome.
-	// checkRunID is passed explicitly so the closure is not sensitive to any
-	// future reassignment of the local variable.
-	defer func(crID int64) {
-		conclusion := "success"
-		summary := fmt.Sprintf("Session `%s` completed.", session.ID)
-		if s := session.GetStatus(); s == StatusFailed {
-			conclusion = "failure"
-			summary = fmt.Sprintf("Session `%s` failed: %s", session.ID, session.GetError())
-		} else if s == StatusDraft {
-			conclusion = "action_required"
-			summary = fmt.Sprintf("Session `%s` yielded a draft PR for human review.", session.ID)
-		}
-		o.completeCheckRun(ctx, session.Issue, crID, conclusion, summary)
-	}(checkRunID)
+	defer o.deferCheckRunCompletion(ctx, session, checkRunID)
 
 	// ── Progress tracker ─────────────────────────────────────────────────────
 	// Intercepts every tool call to write real-time log lines.
@@ -179,19 +168,19 @@ func (o *Orchestrator) runWardenAgent(ctx context.Context, session *Session, bra
 
 	// ── Planning phase ───────────────────────────────────────────────────────
 	tracker.setPhase("planning")
-	plan := o.buildPlan(ctx, agentLLM, session, ws, tracker)
+	plan := o.buildPlan(ctx, tracer, session, ws, tracker)
 	o.logger.Info("warden: planning complete, starting implement loop", "session_id", session.ID)
 
 	// ── Loop 1: Implement ────────────────────────────────────────────────────
 	tracker.setPhase("implementing")
-	implIter, implTokIn, implTokOut, verdict, ok := o.runImplementPhase(ctx, session, agentLLM, ws, branch, plan, tracker)
+	implIter, _, _, verdict, ok := o.runImplementPhase(ctx, session, tracer, ws, branch, plan, tracker)
 	if !ok {
 		return
 	}
 
 	// ── Loop 2: Publish ──────────────────────────────────────────────────────
 	tracker.setPhase("publishing")
-	o.runPublishPhase(ctx, session, agentLLM, ws, branch, verdict, implIter, implTokIn, implTokOut, tracker)
+	o.runPublishPhase(ctx, session, tracer, ws, branch, verdict, implIter, tracker)
 }
 
 // runImplementPhase builds and runs the implement loop. Returns the iteration
@@ -200,12 +189,12 @@ func (o *Orchestrator) runWardenAgent(ctx context.Context, session *Session, bra
 func (o *Orchestrator) runImplementPhase(
 	ctx context.Context,
 	session *Session,
-	agentLLM llms.Model,
+	tracer *TracingModel,
 	ws *agentWorkspace,
 	branch, plan string,
 	tracker *progressTracker,
 ) (iterations int, tokensIn, tokensOut float64, verdict string, ok bool) {
-	implLoop, err := o.buildImplementLoop(agentLLM, session, ws, plan, tracker)
+	implLoop, err := o.buildImplementLoop(tracer, session, ws, plan, tracker)
 	if err != nil {
 		o.failSession(ctx, session, fmt.Sprintf("build implement loop: %v", err))
 		return 0, 0, 0, "", false
@@ -231,11 +220,21 @@ func (o *Orchestrator) runImplementPhase(
 			"session_id", session.ID, "iterations", implResult.Iterations)
 	}
 
+	inTokens, outTokens, llmCalls := tracer.TokenCounts()
+	toolSummary := make(map[string]int)
+	for _, tc := range implResult.ToolCalls {
+		toolSummary[tc.Name]++
+	}
+	modifiedCount := len(modifiedFiles(implResult.ToolCalls))
+
 	o.logger.Info("warden: implement loop done",
 		"session_id", session.ID,
 		"iterations", implResult.Iterations,
-		"tokens_in", implResult.Tokens.Input,
-		"tokens_out", implResult.Tokens.Output,
+		"tokens_in", inTokens,
+		"tokens_out", outTokens,
+		"llm_calls", llmCalls,
+		"tool_calls", toolSummary,
+		"modified_files", modifiedCount,
 	)
 
 	v, _, _ := o.mcpServer.GetReviewBySession(session.ID)
@@ -246,12 +245,12 @@ func (o *Orchestrator) runImplementPhase(
 			"iterations", implResult.Iterations,
 		)
 		o.yieldDraftPR(ctx, session, ws, branch, implResult.Iterations,
-			implResult.Tokens.Input, implResult.Tokens.Output,
+			float64(inTokens), float64(outTokens),
 			modifiedFiles(implResult.ToolCalls))
 		return 0, 0, 0, "", false
 	}
 
-	return implResult.Iterations, implResult.Tokens.Input, implResult.Tokens.Output, v, true
+	return implResult.Iterations, float64(inTokens), float64(outTokens), v, true
 }
 
 // runPublishPhase builds and runs the publish loop, assembles the final result,
@@ -260,14 +259,13 @@ func (o *Orchestrator) runImplementPhase(
 func (o *Orchestrator) runPublishPhase(
 	ctx context.Context,
 	session *Session,
-	agentLLM llms.Model,
+	tracer *TracingModel,
 	ws *agentWorkspace,
 	branch, verdict string,
 	implIterations int,
-	implTokensIn, implTokensOut float64,
 	tracker *progressTracker,
 ) {
-	pubLoop, err := o.buildPublishLoop(agentLLM, session, ws, branch, tracker)
+	pubLoop, err := o.buildPublishLoop(tracer, session, ws, branch, tracker)
 	if err != nil {
 		o.failSession(ctx, session, fmt.Sprintf("build publish loop: %v", err))
 		return
@@ -294,12 +292,15 @@ func (o *Orchestrator) runPublishPhase(
 		return
 	}
 
+	// Accumulate token counts across all phases (tracer keeps running totals).
+	totalIn, totalOut, _ := tracer.TokenCounts()
+
 	result := &Result{
 		Branch:       branch,
 		Verdict:      verdict,
 		Iterations:   implIterations + pubResult.Iterations,
-		TokensInput:  int64(implTokensIn + pubResult.Tokens.Input),
-		TokensOutput: int64(implTokensOut + pubResult.Tokens.Output),
+		TokensInput:  totalIn,
+		TokensOutput: totalOut,
 	}
 	if prInfo := extractPRInfo(pubResult.Response); prInfo != nil {
 		result.PRNumber = prInfo.PRNumber
@@ -364,7 +365,7 @@ func (o *Orchestrator) buildImplementLoop(agentLLM llms.Model, session *Session,
 		goframeagent.WithLoopSystemPrompt(o.buildImplementSystemPrompt(session.Issue, ws.dir, ws.lsp != nil && ws.lsp.Available(), plan)),
 		goframeagent.WithLoopMaxIterations(maxIter),
 		goframeagent.WithLoopGovernance(governance),
-		goframeagent.WithLoopCompactionHook(o.buildCompactionHook(session, ws.traceFile)),
+		goframeagent.WithLoopCompactionHook(o.buildCompactionHook(session, ws.traceFile, agentLLM)),
 		goframeagent.WithLoopLogger(loopLogger),
 	)
 }
@@ -512,7 +513,7 @@ func compactionFilterText(text string) string {
 //
 // If the LLM call for summarization fails the hook returns nil, leaving the
 // history unchanged and letting the loop continue naturally.
-func (o *Orchestrator) buildCompactionHook(session *Session, traceFile *os.File) func(ctx context.Context, msgs []schema.MessageContent, tokens goframeagent.TokenUsage) []schema.MessageContent {
+func (o *Orchestrator) buildCompactionHook(session *Session, traceFile *os.File, llm llms.Model) func(ctx context.Context, msgs []schema.MessageContent, tokens goframeagent.TokenUsage) []schema.MessageContent {
 	return func(ctx context.Context, msgs []schema.MessageContent, tokens goframeagent.TokenUsage) []schema.MessageContent {
 		// Always write a trace snapshot for post-mortem debugging, regardless
 		// of whether compaction fires. This gives a per-iteration conversation
@@ -566,13 +567,7 @@ Do not include any preamble. Output only the summary text.
 --- CONVERSATION ---
 %s`, transcript.String())
 
-		agentLLM, err := o.resolveAgentLLM(ctx)
-		if err != nil {
-			o.logger.Warn("warden: compaction: failed to resolve LLM, skipping", "error", err)
-			return nil
-		}
-
-		resp, err := agentLLM.GenerateContent(ctx,
+		resp, err := llm.GenerateContent(ctx,
 			[]schema.MessageContent{schema.NewHumanMessage(summaryPrompt)},
 		)
 		if err != nil || len(resp.Choices) == 0 {

--- a/internal/agent/workspace.go
+++ b/internal/agent/workspace.go
@@ -16,6 +16,7 @@ import (
 type agentWorkspace struct {
 	dir       string
 	logPath   string
+	tracePath string // absolute path to trace.jsonl (empty if tracing disabled)
 	logFile   *os.File
 	traceFile *os.File     // JSONL conversation trace for post-mortem debugging (nil = not opened)
 	lsp       *lsp.Manager // nil when LSP is unavailable for this workspace
@@ -90,11 +91,12 @@ func (o *Orchestrator) prepareAgentWorkspace(ctx context.Context, session *Sessi
 		o.logger.Warn("lsp: manager failed to start, continuing without LSP", "error", err)
 		lspMgr = nil
 	}
-	o.logger.Info("lsp: language server init complete", "session_id", session.ID, "available", lspMgr != nil)
+	o.logger.Info("lsp: language server init complete", "session_id", session.ID, "available", lspMgr != nil && lspMgr.Available())
 
 	return &agentWorkspace{
 		dir:       workspaceDir,
 		logPath:   logPath,
+		tracePath: tracePath,
 		logFile:   logFile,
 		traceFile: traceFile,
 		lsp:       lspMgr,
@@ -151,7 +153,70 @@ func (o *Orchestrator) cleanupWorkspace(sessionID string) error {
 	return nil
 }
 
-// readLogFile reads the content of a file up to maxBytes.
+// persistLogs copies agent.log and trace.jsonl from the workspace to a stable
+// directory that survives cleanupWorkspace. This enables post-mortem analysis
+// of sessions even after the workspace directory has been removed.
+func (o *Orchestrator) persistLogs(ws *agentWorkspace, sessionID string) {
+	safeID, err := sanitizeSessionID(sessionID)
+	if err != nil {
+		o.logger.Warn("persistLogs: invalid session ID", "error", err)
+		return
+	}
+
+	// Stable directory: sibling of the workspace parent, e.g. /tmp/code-warden-agents/../agent-traces/
+	traceDir := filepath.Join(filepath.Dir(o.config.WorkingDir), "agent-traces")
+	if err := os.MkdirAll(traceDir, 0750); err != nil {
+		o.logger.Warn("persistLogs: failed to create trace directory", "path", traceDir, "error", err)
+		return
+	}
+
+	// Sync+close the files before copying to ensure all data is flushed.
+	if ws.logFile != nil {
+		_ = ws.logFile.Sync()
+	}
+	if ws.traceFile != nil {
+		_ = ws.traceFile.Sync()
+	}
+
+	// Copy agent.log
+	srcLog := filepath.Join(ws.dir, "agent.log")
+	dstLog := filepath.Join(traceDir, safeID+".log")
+	if err := copyFile(srcLog, dstLog); err != nil {
+		o.logger.Debug("persistLogs: could not copy agent.log", "error", err)
+	} else {
+		o.logger.Info("persistLogs: saved agent.log", "path", dstLog)
+	}
+
+	// Copy trace.jsonl
+	if ws.tracePath != "" {
+		dstTrace := filepath.Join(traceDir, safeID+".jsonl")
+		if err := copyFile(ws.tracePath, dstTrace); err != nil {
+			o.logger.Debug("persistLogs: could not copy trace.jsonl", "error", err)
+		} else {
+			o.logger.Info("persistLogs: saved trace.jsonl", "path", dstTrace)
+		}
+	}
+}
+
+// copyFile copies a single file from src to dst. It returns an error if the
+// source file does not exist — callers should treat this as non-fatal.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}
+
 // If the file exceeds maxBytes, it reads the *last* maxBytes to ensure
 // the AGENT_RESULT: sentinel (typically at the end) is captured.
 func (o *Orchestrator) readLogFile(path string, maxBytes int64) ([]byte, error) {


### PR DESCRIPTION
## Summary

- **Fix LSP `available=true` log** — `Manager.Start()` returns nil even when all servers fail to start, so `lspMgr != nil` was always true. Now correctly checks `lspMgr.Available()`.
- **Add TracingModel wrapper for real token tracking** — goframe's `AgentLoop` never populates `LoopResult.Tokens` (always zero). `TracingModel` wraps `llms.Model`, reads `PromptTokens`/`CompletionTokens` from `GenerationInfo`, and accumulates them via atomic counters. Used in both warden and native loops.
- **Log tool call summary on implement loop completion** — After the implement loop ends, logs a breakdown of tool calls by name (`read_file: 12, write_file: 0, ...`) and modified file count. Makes it immediately visible when the agent is stuck in an exploration loop.
- **Persist agent.log and trace.jsonl outside workspace** — Workspace cleanup (`rm -rf`) previously destroyed all diagnostic files. New `persistLogs()` copies them to a stable `agent-traces/` directory before cleanup.
- **Extract `deferCheckRunCompletion` helper** — Reduces `runWardenAgent` statement count below the funlen limit.

## Context

The last agent run (session `mjolnir-ae9654`) ran 17 iterations with zero code changes and `tokens_in=0, tokens_out=0` in the logs. The always-zero token counts made it impossible to diagnose why the model got stuck (exploration loop vs. context window exhaustion vs. tool failure). The trace/log files were deleted by workspace cleanup before they could be inspected.

## What this changes for the next run

Before:
```
tokens_in=0  tokens_out=0  iterations=17  response_length=0
```

After:
```
tokens_in=45230  tokens_out=8742  llm_calls=17  tool_calls="{read_file: 12, search_code: 5, write_file: 0}"  modified_files=0
```

Traces survive at:
```
{data-dir}/agent-traces/{sessionID}.log
{data-dir}/agent-traces/{sessionID}.jsonl
```

## Test plan

- [x] `go build ./...` passes
- [x] `make lint` passes (0 issues)
- [x] `make test` passes (0 failures)
- [ ] Run a live agent session and verify token counts are non-zero in logs
- [ ] Verify `agent-traces/` directory is created and populated after session ends
- [ ] Verify LSP log shows `available=false` when gopls is not running