### PR TITLE
feat(agent): multi-edit, compaction file tracking, turn boundary fix,…

### DIFF
--- a/docs/IMPLEMENT_ARCHITECTURE.md
+++ b/docs/IMPLEMENT_ARCHITECTURE.md
@@ -193,19 +193,44 @@ The compaction hook fires when `tokens.Input + tokens.Output > 128_000 * 0.70`:
 ```
 buildCompactionHook(session) → func(ctx, msgs, tokens) []schema.MessageContent
   if used < threshold: return nil  ← no-op, loop continues unchanged
-  
-  build plain-text transcript of msgs[1:]  ← exclude system prompt
-  call LLM with summarization prompt (max 400 words)
-  
+
+  previousSummary := extract prior "## Context Summary" from msgs[1] (if any)
+
+  build plain-text transcript of newMsgs (messages after the prior summary)
+  call LLM with summarization prompt (iterative: update summary vs. fresh start)
+    max 400 words; if previousSummary != "": "Update this summary: …" prompt
+
+  extract file ops from newMsgs:
+    - parse tool result messages for read_file / write_file / edit_file paths
+    - merge with file lists already in previousSummary (<read-files>/<modified-files> XML)
+    - append formatFileOps(allRead, allMod) to the new summary
+
+  find tail boundary via findTailStart(msgs, 8):
+    - walks backward from end until landing on a ChatMessageTypeHuman message
+    - ensures tool-result messages are never orphaned from the AI turn that called them
+
   rebuild history:
-    [0] system prompt           (preserved verbatim)
-    [1] "## Context Summary…"  (LLM summary)
-    [2..5] last 4 messages     (current iteration context)
-  
+    [0] system prompt                     (preserved verbatim)
+    [1] "## Context Summary\n…<read-files>…<modified-files>…"
+    [2..] msgs[tailStart:]                (≥8 messages from last clean turn boundary)
+
   return compacted  ← goframe replaces messages, increments result.Compactions
 ```
 
-If the summarization call fails, the hook returns `nil` and the loop continues with the full history (graceful degradation).
+**Iterative summarization** — if `msgs[1]` already contains a prior summary the hook
+asks the LLM to update rather than re-summarise from scratch. This keeps each
+compaction cheap and avoids losing early context (e.g. the original task description).
+
+**File footprint tracking** — `<read-files>` and `<modified-files>` XML blocks are
+appended to every summary and merged cumulatively. On re-compaction the agent always
+knows which files it has touched in the current session.
+
+**Turn boundary safety** — `findTailStart` ensures the preserved tail always begins on
+a human message, so a `tool` role result is never the first message in the compacted
+history (which would confuse the LLM about the origin of the result).
+
+If the summarization call fails, the hook returns `nil` and the loop continues with the
+full history (graceful degradation).
 
 The hook is wired via `goframeagent.WithLoopCompactionHook` added in goframe v0.36.6.
 
@@ -282,10 +307,10 @@ Tools used by the implement loop (see `internal/mcp/tools/` and `internal/agent/
 
 | Tool | Description |
 |------|-------------|
-| `read_file` | Read a file, optionally paginated |
-| `write_file` | Create or overwrite (triggers LSP diagnostics) |
-| `edit_file` | Exact-string replace (triggers LSP diagnostics) |
-| `list_dir` | List directory contents |
+| `read_file` | Read a file, optionally paginated; returns `{content, lines, path}` |
+| `write_file` | Create or overwrite; returns `{ok, path, bytes}` (triggers LSP diagnostics) |
+| `edit_file` | Exact-string replace with fuzzy fallback; returns `{ok, path, diff}` (triggers LSP diagnostics) — supports single `{old_string, new_string}` or atomic multi-edit `{edits:[…]}` |
+| `list_dir` | List directory entries with name, type, size |
 
 ### LSP (live compiler feedback)
 

--- a/go.mod
+++ b/go.mod
@@ -112,7 +112,7 @@ require (
 	github.com/ollama/ollama v0.20.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/qdrant/go-client v1.17.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -1,0 +1,219 @@
+package agent
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sevigo/goframe/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── findTailStart ──────────────────────────────────────────────────────────────
+
+func TestFindTailStart_StartsOnHumanMessage(t *testing.T) {
+	// Build a message slice that ends with tool-role messages.
+	// The tail should walk back past them to the last human message.
+	msgs := []schema.MessageContent{
+		schema.NewSystemMessage("system"),    // 0 — system prompt
+		schema.NewHumanMessage("task"),       // 1
+		schema.NewAIMessage("thinking"),      // 2
+		schema.NewHumanMessage("user msg"),   // 3  ← expected tail start
+		schema.NewAIMessage("tool request"),  // 4
+		schema.NewToolResultMessage("t", "r"), // 5  role=tool
+		schema.NewAIMessage("tool request2"), // 6
+		schema.NewToolResultMessage("t", "r"), // 7  role=tool
+		schema.NewAIMessage("final"),         // 8
+	}
+	// minTail=4 → ideal start = len(9)-4 = 5, but msgs[5] is tool-role.
+	// Should walk back to msgs[3] (human).
+	start := findTailStart(msgs, 4)
+	assert.Equal(t, schema.ChatMessageTypeHuman, msgs[start].Role,
+		"tail must start at a human message")
+	// Should not be an ai or tool message
+	assert.NotEqual(t, schema.ChatMessageTypeTool, msgs[start].Role)
+}
+
+func TestFindTailStart_AlreadyOnHuman(t *testing.T) {
+	msgs := []schema.MessageContent{
+		schema.NewSystemMessage("sys"),
+		schema.NewHumanMessage("h1"),
+		schema.NewAIMessage("a1"),
+		schema.NewHumanMessage("h2"),
+		schema.NewAIMessage("a2"),
+		schema.NewHumanMessage("h3"), // index 5 — ideal start for minTail=3
+	}
+	start := findTailStart(msgs, 3)
+	assert.Equal(t, 3, start, "already landed on a human message, no walk needed")
+}
+
+func TestFindTailStart_TooFewMessages(t *testing.T) {
+	msgs := []schema.MessageContent{
+		schema.NewSystemMessage("sys"),
+		schema.NewHumanMessage("task"),
+		schema.NewAIMessage("response"),
+	}
+	// len=3, minTail+1=9 → returns 1 (keep all)
+	start := findTailStart(msgs, 8)
+	assert.Equal(t, 1, start)
+}
+
+func TestFindTailStart_NeverOrphansToolResult(t *testing.T) {
+	// Construct a history where every reasonable cut point is a tool-role message.
+	// findTailStart must keep walking until it finds a human message.
+	msgs := []schema.MessageContent{
+		schema.NewSystemMessage("sys"),        // 0
+		schema.NewHumanMessage("start"),       // 1
+		schema.NewAIMessage("req"),            // 2
+		schema.NewHumanMessage("user reply"),  // 3 ← only safe boundary in range
+		schema.NewAIMessage("req"),            // 4
+		schema.NewToolResultMessage("t", "x"), // 5
+		schema.NewAIMessage("req"),            // 6
+		schema.NewToolResultMessage("t", "x"), // 7
+		schema.NewAIMessage("req"),            // 8
+		schema.NewToolResultMessage("t", "x"), // 9
+	}
+	start := findTailStart(msgs, 6) // ideal start = 4 (ai msg)
+	assert.Equal(t, schema.ChatMessageTypeHuman, msgs[start].Role)
+}
+
+// ── extractFileOpsFromMsgs ─────────────────────────────────────────────────────
+
+func toolResultMsg(toolName, path string) schema.MessageContent {
+	content := fmt.Sprintf("Tool '%s' returned: {\"ok\":true,\"path\":%q,\"bytes\":10}", toolName, path)
+	return schema.NewToolResultMessage(toolName, content)
+}
+
+func readResultMsg(path string) schema.MessageContent {
+	content := fmt.Sprintf("Tool 'read_file' returned: {\"content\":\"x\",\"lines\":1,\"path\":%q}", path)
+	return schema.NewToolResultMessage("read_file", content)
+}
+
+func TestExtractFileOpsFromMsgs_Basic(t *testing.T) {
+	msgs := []schema.MessageContent{
+		schema.NewHumanMessage("task"),
+		schema.NewAIMessage("planning"),
+		readResultMsg("src/foo.go"),
+		readResultMsg("src/bar.go"),
+		schema.NewAIMessage("editing"),
+		toolResultMsg("edit_file", "src/foo.go"),
+		toolResultMsg("write_file", "src/new.go"),
+	}
+
+	readFiles, modFiles := extractFileOpsFromMsgs(msgs)
+
+	// foo.go was read then modified → should appear only in modFiles
+	assert.Contains(t, modFiles, "src/foo.go", "edited file must be in modFiles")
+	assert.Contains(t, modFiles, "src/new.go", "written file must be in modFiles")
+	assert.Contains(t, readFiles, "src/bar.go", "read-only file must be in readFiles")
+	assert.NotContains(t, readFiles, "src/foo.go", "modified file must not appear in readFiles")
+}
+
+func TestExtractFileOpsFromMsgs_NoToolMessages(t *testing.T) {
+	msgs := []schema.MessageContent{
+		schema.NewHumanMessage("task"),
+		schema.NewAIMessage("response"),
+	}
+	readFiles, modFiles := extractFileOpsFromMsgs(msgs)
+	assert.Empty(t, readFiles)
+	assert.Empty(t, modFiles)
+}
+
+func TestExtractFileOpsFromMsgs_Deduplication(t *testing.T) {
+	msgs := []schema.MessageContent{
+		readResultMsg("src/foo.go"),
+		readResultMsg("src/foo.go"), // duplicate read
+		toolResultMsg("edit_file", "src/foo.go"),
+		toolResultMsg("edit_file", "src/foo.go"), // duplicate edit
+	}
+	_, modFiles := extractFileOpsFromMsgs(msgs)
+	count := 0
+	for _, f := range modFiles {
+		if f == "src/foo.go" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "duplicate paths must be deduplicated")
+}
+
+// ── parseFileTagsFromSummary / formatFileOps round-trip ───────────────────────
+
+func TestFileTagsRoundTrip(t *testing.T) {
+	readFiles := []string{"src/bar.go", "src/foo.go"}
+	modFiles := []string{"src/baz.go", "src/qux.go"}
+
+	tags := formatFileOps(readFiles, modFiles)
+	require.NotEmpty(t, tags)
+
+	gotRead, gotMod := parseFileTagsFromSummary("Some summary text." + tags)
+	assert.Equal(t, readFiles, gotRead)
+	assert.Equal(t, modFiles, gotMod)
+}
+
+func TestFileTagsRoundTrip_ReadOnly(t *testing.T) {
+	tags := formatFileOps([]string{"a.go", "b.go"}, nil)
+	gotRead, gotMod := parseFileTagsFromSummary(tags)
+	assert.Equal(t, []string{"a.go", "b.go"}, gotRead)
+	assert.Empty(t, gotMod)
+}
+
+func TestFileTagsRoundTrip_ModOnly(t *testing.T) {
+	tags := formatFileOps(nil, []string{"c.go"})
+	gotRead, gotMod := parseFileTagsFromSummary(tags)
+	assert.Empty(t, gotRead)
+	assert.Equal(t, []string{"c.go"}, gotMod)
+}
+
+func TestFormatFileOps_EmptyLists(t *testing.T) {
+	assert.Empty(t, formatFileOps(nil, nil))
+	assert.Empty(t, formatFileOps([]string{}, []string{}))
+}
+
+func TestParseFileTagsFromSummary_NoTags(t *testing.T) {
+	r, m := parseFileTagsFromSummary("plain summary without any XML tags")
+	assert.Nil(t, r)
+	assert.Nil(t, m)
+}
+
+// ── mergeFileLists ─────────────────────────────────────────────────────────────
+
+func TestMergeFileLists_Deduplication(t *testing.T) {
+	a := []string{"a.go", "b.go"}
+	b := []string{"b.go", "c.go"}
+	got := mergeFileLists(a, b)
+	assert.Equal(t, []string{"a.go", "b.go", "c.go"}, got)
+}
+
+func TestMergeFileLists_BothEmpty(t *testing.T) {
+	assert.Empty(t, mergeFileLists(nil, nil))
+}
+
+// ── buildUnifiedDiff ───────────────────────────────────────────────────────────
+
+func TestBuildUnifiedDiff_BasicChange(t *testing.T) {
+	original := "line1\nline2\nline3\n"
+	updated := "line1\nLINE2\nline3\n"
+	diff := buildUnifiedDiff(original, updated, "src/foo.go")
+	assert.Contains(t, diff, "-line2")
+	assert.Contains(t, diff, "+LINE2")
+	assert.Contains(t, diff, "a/src/foo.go")
+}
+
+func TestBuildUnifiedDiff_NoChange(t *testing.T) {
+	content := "unchanged\n"
+	diff := buildUnifiedDiff(content, content, "f.go")
+	assert.Empty(t, diff, "no diff expected when content is identical")
+}
+
+func TestBuildUnifiedDiff_Truncation(t *testing.T) {
+	// Create a diff large enough to trigger truncation (> diffMaxBytes).
+	var big string
+	for i := range 300 {
+		big += fmt.Sprintf("line%d\n", i)
+	}
+	updated := "NEW_FIRST_LINE\n" + big
+	diff := buildUnifiedDiff(big, updated, "large.go")
+	if len(diff) > diffMaxBytes {
+		assert.Contains(t, diff, "[diff truncated]")
+	}
+}

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -15,15 +15,15 @@ func TestFindTailStart_StartsOnHumanMessage(t *testing.T) {
 	// Build a message slice that ends with tool-role messages.
 	// The tail should walk back past them to the last human message.
 	msgs := []schema.MessageContent{
-		schema.NewSystemMessage("system"),    // 0 — system prompt
-		schema.NewHumanMessage("task"),       // 1
-		schema.NewAIMessage("thinking"),      // 2
-		schema.NewHumanMessage("user msg"),   // 3  ← expected tail start
-		schema.NewAIMessage("tool request"),  // 4
+		schema.NewSystemMessage("system"),     // 0 — system prompt
+		schema.NewHumanMessage("task"),        // 1
+		schema.NewAIMessage("thinking"),       // 2
+		schema.NewHumanMessage("user msg"),    // 3  ← expected tail start
+		schema.NewAIMessage("tool request"),   // 4
 		schema.NewToolResultMessage("t", "r"), // 5  role=tool
-		schema.NewAIMessage("tool request2"), // 6
+		schema.NewAIMessage("tool request2"),  // 6
 		schema.NewToolResultMessage("t", "r"), // 7  role=tool
-		schema.NewAIMessage("final"),         // 8
+		schema.NewAIMessage("final"),          // 8
 	}
 	// minTail=4 → ideal start = len(9)-4 = 5, but msgs[5] is tool-role.
 	// Should walk back to msgs[3] (human).

--- a/internal/agent/file_tools.go
+++ b/internal/agent/file_tools.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/pmezard/go-difflib/difflib"
+
 	"github.com/sevigo/code-warden/internal/mcp"
 	"github.com/sevigo/code-warden/internal/mcp/tools"
 )
@@ -202,37 +203,9 @@ func (t *editFileTool) Execute(ctx context.Context, args map[string]any) (any, e
 		return nil, fmt.Errorf("path is required")
 	}
 
-	// Resolve edit pairs from either convention.
-	var pairs []editPair
-	if rawEdits, ok := args["edits"]; ok {
-		// Multi-edit: edits: [{old_string, new_string}, ...]
-		list, ok := rawEdits.([]any)
-		if !ok {
-			return nil, fmt.Errorf("edits must be an array")
-		}
-		for i, item := range list {
-			m, ok := item.(map[string]any)
-			if !ok {
-				return nil, fmt.Errorf("edits[%d] must be an object", i)
-			}
-			oldStr, _ := m["old_string"].(string)
-			newStr, _ := m["new_string"].(string)
-			if oldStr == "" {
-				return nil, fmt.Errorf("edits[%d].old_string is required", i)
-			}
-			pairs = append(pairs, editPair{OldStr: oldStr, NewStr: newStr})
-		}
-		if len(pairs) == 0 {
-			return nil, fmt.Errorf("edits array is empty")
-		}
-	} else {
-		// Single replacement: old_string / new_string.
-		oldStr, ok := args["old_string"].(string)
-		if !ok {
-			return nil, fmt.Errorf("old_string is required (or provide edits array)")
-		}
-		newStr, _ := args["new_string"].(string)
-		pairs = []editPair{{OldStr: oldStr, NewStr: newStr}}
+	pairs, err := parseEditPairs(args)
+	if err != nil {
+		return nil, err
 	}
 
 	abs, err := safeJoin(root, relPath)
@@ -273,8 +246,51 @@ func (t *editFileTool) Execute(ctx context.Context, args map[string]any) (any, e
 // field. Large rewrites are truncated with a marker.
 const diffMaxBytes = 4000
 
+// parseEditPairs resolves the edit specification from tool args.
+// Accepts two calling conventions:
+//   - edits: [{old_string, new_string}, ...]  (multi-edit array)
+//   - old_string / new_string flat keys       (single replacement, backwards-compat)
+func parseEditPairs(args map[string]any) ([]editPair, error) {
+	if rawEdits, ok := args["edits"]; ok {
+		return parseEditsArray(rawEdits)
+	}
+	oldStr, ok := args["old_string"].(string)
+	if !ok {
+		return nil, fmt.Errorf("old_string is required (or provide edits array)")
+	}
+	newStr, _ := args["new_string"].(string)
+	return []editPair{{OldStr: oldStr, NewStr: newStr}}, nil
+}
+
+// parseEditsArray decodes the multi-edit array format.
+func parseEditsArray(rawEdits any) ([]editPair, error) {
+	list, ok := rawEdits.([]any)
+	if !ok {
+		return nil, fmt.Errorf("edits must be an array")
+	}
+	pairs := make([]editPair, 0, len(list))
+	for i, item := range list {
+		m, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("edits[%d] must be an object", i)
+		}
+		oldStr, _ := m["old_string"].(string)
+		newStr, _ := m["new_string"].(string)
+		if oldStr == "" {
+			return nil, fmt.Errorf("edits[%d].old_string is required", i)
+		}
+		pairs = append(pairs, editPair{OldStr: oldStr, NewStr: newStr})
+	}
+	if len(pairs) == 0 {
+		return nil, fmt.Errorf("edits array is empty")
+	}
+	return pairs, nil
+}
+
 // buildUnifiedDiff returns a unified diff string between original and updated,
 // or an empty string if the diff cannot be produced.
+// Truncation is done at a newline boundary to avoid splitting mid-line (and
+// to sidestep any multi-byte UTF-8 boundary issues at the byte limit).
 func buildUnifiedDiff(original, updated, path string) string {
 	ud := difflib.UnifiedDiff{
 		A:        difflib.SplitLines(original),
@@ -288,7 +304,12 @@ func buildUnifiedDiff(original, updated, path string) string {
 		return ""
 	}
 	if len(s) > diffMaxBytes {
-		return s[:diffMaxBytes] + "\n... [diff truncated]"
+		// Truncate at the last newline before the byte limit.
+		cut := strings.LastIndexByte(s[:diffMaxBytes], '\n') + 1
+		if cut <= 0 {
+			cut = diffMaxBytes
+		}
+		return s[:cut] + "... [diff truncated]"
 	}
 	return s
 }

--- a/internal/agent/file_tools.go
+++ b/internal/agent/file_tools.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/pmezard/go-difflib/difflib"
 	"github.com/sevigo/code-warden/internal/mcp"
 	"github.com/sevigo/code-warden/internal/mcp/tools"
 )
@@ -77,6 +78,7 @@ func (t *readFileTool) Execute(ctx context.Context, args map[string]any) (any, e
 	return map[string]any{
 		"content": strings.Join(lines, "\n"),
 		"lines":   len(lines),
+		"path":    relPath,
 	}, nil
 }
 
@@ -134,17 +136,30 @@ func (t *writeFileTool) Execute(ctx context.Context, args map[string]any) (any, 
 	return result, nil
 }
 
-// editFileTool replaces the first occurrence of old_string with new_string.
-// Mirrors Claude Code's Edit tool semantics.
+// editFileTool replaces text in a file. Accepts either a single old_string/new_string
+// pair (backwards-compatible) or an edits array for atomic multi-replacement.
+// Mirrors Pi's edit tool semantics.
 type editFileTool struct{}
 
 func (t *editFileTool) Name() string { return "edit_file" }
 
 func (t *editFileTool) Description() string {
-	return `Replace the first exact occurrence of old_string with new_string in a file.
-The match must be unique — if old_string appears more than once the edit is
-rejected. Use write_file to replace the entire file instead.
-Path is relative to the workspace root.`
+	return `Replace text in a file using exact-then-fuzzy matching.
+
+Two calling conventions are supported:
+
+1. Single replacement (backwards-compatible):
+   {"path": "...", "old_string": "...", "new_string": "..."}
+
+2. Multiple atomic replacements:
+   {"path": "...", "edits": [{"old_string": "...", "new_string": "..."}, ...]}
+
+Each old_string must appear exactly once; the edit is rejected if it is
+not found or is ambiguous. All replacements in edits[] are applied atomically
+in a single pass (no partial writes). Use write_file to replace the entire file.
+Path is relative to the workspace root.
+
+Returns ok, path, an optional fuzzy_match flag, and a unified diff of the changes.`
 }
 
 func (t *editFileTool) ParametersSchema() map[string]any {
@@ -157,14 +172,26 @@ func (t *editFileTool) ParametersSchema() map[string]any {
 			},
 			"old_string": map[string]any{
 				"type":        "string",
-				"description": "The exact string to replace (must appear exactly once in the file)",
+				"description": "Single replacement: the exact string to replace (must appear exactly once)",
 			},
 			"new_string": map[string]any{
 				"type":        "string",
-				"description": "The string to replace it with",
+				"description": "Single replacement: the string to replace it with",
+			},
+			"edits": map[string]any{
+				"type":        "array",
+				"description": "Multiple atomic replacements applied in one pass",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"old_string": map[string]any{"type": "string"},
+						"new_string": map[string]any{"type": "string"},
+					},
+					"required": []string{"old_string", "new_string"},
+				},
 			},
 		},
-		"required": []string{"path", "old_string", "new_string"},
+		"required": []string{"path"},
 	}
 }
 
@@ -174,13 +201,38 @@ func (t *editFileTool) Execute(ctx context.Context, args map[string]any) (any, e
 	if !ok || relPath == "" {
 		return nil, fmt.Errorf("path is required")
 	}
-	oldStr, ok := args["old_string"].(string)
-	if !ok {
-		return nil, fmt.Errorf("old_string is required")
-	}
-	newStr, ok := args["new_string"].(string)
-	if !ok {
-		return nil, fmt.Errorf("new_string is required")
+
+	// Resolve edit pairs from either convention.
+	var pairs []editPair
+	if rawEdits, ok := args["edits"]; ok {
+		// Multi-edit: edits: [{old_string, new_string}, ...]
+		list, ok := rawEdits.([]any)
+		if !ok {
+			return nil, fmt.Errorf("edits must be an array")
+		}
+		for i, item := range list {
+			m, ok := item.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("edits[%d] must be an object", i)
+			}
+			oldStr, _ := m["old_string"].(string)
+			newStr, _ := m["new_string"].(string)
+			if oldStr == "" {
+				return nil, fmt.Errorf("edits[%d].old_string is required", i)
+			}
+			pairs = append(pairs, editPair{OldStr: oldStr, NewStr: newStr})
+		}
+		if len(pairs) == 0 {
+			return nil, fmt.Errorf("edits array is empty")
+		}
+	} else {
+		// Single replacement: old_string / new_string.
+		oldStr, ok := args["old_string"].(string)
+		if !ok {
+			return nil, fmt.Errorf("old_string is required (or provide edits array)")
+		}
+		newStr, _ := args["new_string"].(string)
+		pairs = []editPair{{OldStr: oldStr, NewStr: newStr}}
 	}
 
 	abs, err := safeJoin(root, relPath)
@@ -194,7 +246,7 @@ func (t *editFileTool) Execute(ctx context.Context, args map[string]any) (any, e
 	}
 	original := string(data)
 
-	updated, usedFuzzy, err := applyEdit(original, oldStr, newStr)
+	updated, usedFuzzy, err := applyMultiEdit(original, pairs)
 	if err != nil {
 		return nil, fmt.Errorf("edit_file: %w", err)
 	}
@@ -206,7 +258,39 @@ func (t *editFileTool) Execute(ctx context.Context, args map[string]any) (any, e
 	if usedFuzzy {
 		result["fuzzy_match"] = true
 	}
+
+	// Generate a unified diff so the LLM can verify its changes without a
+	// follow-up read_file call. Truncated to avoid flooding the context.
+	diffStr := buildUnifiedDiff(original, updated, relPath)
+	if diffStr != "" {
+		result["diff"] = diffStr
+	}
+
 	return result, nil
+}
+
+// diffMaxBytes is the maximum number of bytes returned in the edit_file diff
+// field. Large rewrites are truncated with a marker.
+const diffMaxBytes = 4000
+
+// buildUnifiedDiff returns a unified diff string between original and updated,
+// or an empty string if the diff cannot be produced.
+func buildUnifiedDiff(original, updated, path string) string {
+	ud := difflib.UnifiedDiff{
+		A:        difflib.SplitLines(original),
+		B:        difflib.SplitLines(updated),
+		FromFile: "a/" + path,
+		ToFile:   "b/" + path,
+		Context:  3,
+	}
+	s, err := difflib.GetUnifiedDiffString(ud)
+	if err != nil || s == "" {
+		return ""
+	}
+	if len(s) > diffMaxBytes {
+		return s[:diffMaxBytes] + "\n... [diff truncated]"
+	}
+	return s
 }
 
 // listDirTool lists the contents of a directory in the workspace.

--- a/internal/agent/fuzzy_edit.go
+++ b/internal/agent/fuzzy_edit.go
@@ -140,28 +140,39 @@ type editPair struct {
 // NFKC-normalised form of the entire file — characters outside the edited
 // regions (smart quotes, ligatures, special spaces) are converted to their
 // ASCII equivalents. Acceptable for code; may alter documentation.
-func applyMultiEdit(content string, edits []editPair) (result string, usedFuzzy bool, err error) {
+// matchResult holds the resolved position of a single edit in the working content.
+// found must be true before index/matchLen are meaningful; a zero-value struct
+// is intentionally an unresolved match to avoid confusion with a real match at
+// byte offset 0.
+type matchResult struct {
+	found    bool
+	index    int
+	matchLen int
+}
+
+// applyMultiEdit applies multiple (old→new) replacements atomically.
+// If any pair requires fuzzy matching the entire content is normalised first,
+// ensuring all replacements operate in a consistent character space.
+// Replacements are applied in descending position order so earlier indices
+// are not shifted by later writes.
+//
+// Rules (mirroring Pi's applyEditsToNormalizedContent):
+//   - Each OldStr must match exactly once (error if 0 or >1 occurrences).
+//   - No two matches may overlap (error if they do).
+//
+// WARNING: When fuzzy matching is used the returned content is the
+// NFKC-normalised form of the entire file — characters outside the edited
+// regions (smart quotes, ligatures, special spaces) are converted to their
+// ASCII equivalents. Acceptable for code; may alter documentation.
+func applyMultiEdit(content string, edits []editPair) (string, bool, error) {
 	if len(edits) == 0 {
 		return content, false, nil
 	}
 
-	// Phase 1: attempt exact matches for all edits, note if any need fuzzy.
-	type matchResult struct {
-		index    int
-		matchLen int
-	}
-	matches := make([]matchResult, len(edits))
-	needsFuzzy := false
-
-	for i, e := range edits {
-		cnt := strings.Count(content, e.OldStr)
-		if cnt == 1 {
-			matches[i] = matchResult{strings.Index(content, e.OldStr), len(e.OldStr)}
-		} else if cnt > 1 {
-			return "", false, fmt.Errorf("edit_file: edits[%d] old_string appears %d times; provide more context to make it unique", i, cnt)
-		} else {
-			needsFuzzy = true
-		}
+	// Phase 1: attempt exact matches; note whether any edit requires fuzzy.
+	matches, needsFuzzy, err := exactMatches(content, edits)
+	if err != nil {
+		return "", false, err
 	}
 
 	// Phase 2: if any edit missed exactly, normalise the entire content and
@@ -169,41 +180,83 @@ func applyMultiEdit(content string, edits []editPair) (result string, usedFuzzy 
 	working := content
 	if needsFuzzy {
 		working = normalizeForFuzzyMatch(content)
-		usedFuzzy = true
-		for i, e := range edits {
-			if matches[i].index != 0 || matches[i].matchLen != 0 {
-				// Re-find in normalised space (was exact in original space but
-				// the index is now invalid; normalisation may change byte offsets).
-				matches[i] = matchResult{}
-			}
-			normOld := normalizeForFuzzyMatch(e.OldStr)
-			cnt := strings.Count(working, normOld)
-			if cnt == 0 {
-				return "", false, fmt.Errorf("edit_file: edits[%d] old_string not found (tried exact match and fuzzy normalization)", i)
-			}
-			if cnt > 1 {
-				return "", false, fmt.Errorf("edit_file: edits[%d] old_string appears %d times after normalization; provide more context to make it unique", i, cnt)
-			}
-			matches[i] = matchResult{strings.Index(working, normOld), len(normOld)}
+		matches, err = fuzzyMatches(working, edits)
+		if err != nil {
+			return "", false, err
 		}
-	} else {
-		// All exact — re-index in original content (already done above).
 	}
 
 	// Phase 3: validate no overlapping ranges.
+	if err := validateNoOverlaps(matches); err != nil {
+		return "", false, err
+	}
+
+	// Phase 4: sort by position descending and apply in that order.
+	order := descendingOrder(matches)
+	out := working
+	for _, i := range order {
+		m := matches[i]
+		out = out[:m.index] + edits[i].NewStr + out[m.index+m.matchLen:]
+	}
+	return out, needsFuzzy, nil
+}
+
+// exactMatches tries an exact string count for each edit.
+// Returns matches (zero-value for misses), whether any edit needs fuzzy, and
+// any hard error (e.g. ambiguous match).
+func exactMatches(content string, edits []editPair) ([]matchResult, bool, error) {
+	matches := make([]matchResult, len(edits))
+	needsFuzzy := false
+	for i, e := range edits {
+		switch cnt := strings.Count(content, e.OldStr); {
+		case cnt == 1:
+			matches[i] = matchResult{found: true, index: strings.Index(content, e.OldStr), matchLen: len(e.OldStr)}
+		case cnt > 1:
+			return nil, false, fmt.Errorf("edit_file: edits[%d] old_string appears %d times; provide more context to make it unique", i, cnt)
+		default: // cnt == 0
+			needsFuzzy = true
+		}
+	}
+	return matches, needsFuzzy, nil
+}
+
+// fuzzyMatches re-resolves all edit positions in the already-normalised working
+// content. Every edit is normalised and searched; missing or ambiguous matches
+// are hard errors.
+func fuzzyMatches(working string, edits []editPair) ([]matchResult, error) {
+	matches := make([]matchResult, len(edits))
+	for i, e := range edits {
+		normOld := normalizeForFuzzyMatch(e.OldStr)
+		cnt := strings.Count(working, normOld)
+		switch {
+		case cnt == 0:
+			return nil, fmt.Errorf("edit_file: edits[%d] old_string not found (tried exact match and fuzzy normalization)", i)
+		case cnt > 1:
+			return nil, fmt.Errorf("edit_file: edits[%d] old_string appears %d times after normalization; provide more context to make it unique", i, cnt)
+		}
+		matches[i] = matchResult{found: true, index: strings.Index(working, normOld), matchLen: len(normOld)}
+	}
+	return matches, nil
+}
+
+// validateNoOverlaps returns an error if any two match ranges intersect.
+func validateNoOverlaps(matches []matchResult) error {
 	for i := range matches {
 		iEnd := matches[i].index + matches[i].matchLen
 		for j := i + 1; j < len(matches); j++ {
 			jEnd := matches[j].index + matches[j].matchLen
 			if matches[i].index < jEnd && matches[j].index < iEnd {
-				return "", false, fmt.Errorf("edit_file: edits[%d] and edits[%d] overlap", i, j)
+				return fmt.Errorf("edit_file: edits[%d] and edits[%d] overlap", i, j)
 			}
 		}
 	}
+	return nil
+}
 
-	// Phase 4: sort by position descending, apply in that order.
-	// Use a simple insertion sort — edit count is always small.
-	order := make([]int, len(edits))
+// descendingOrder returns indices sorted by match position descending so
+// replacements can be applied without shifting earlier indices.
+func descendingOrder(matches []matchResult) []int {
+	order := make([]int, len(matches))
 	for i := range order {
 		order[i] = i
 	}
@@ -212,20 +265,7 @@ func applyMultiEdit(content string, edits []editPair) (result string, usedFuzzy 
 			order[j], order[j-1] = order[j-1], order[j]
 		}
 	}
-
-	out := working
-	newStrFor := func(i int) string {
-		if needsFuzzy {
-			return edits[i].NewStr // newStr is always applied verbatim
-		}
-		return edits[i].NewStr
-	}
-	for _, i := range order {
-		m := matches[i]
-		out = out[:m.index] + newStrFor(i) + out[m.index+m.matchLen:]
-	}
-
-	return out, usedFuzzy, nil
+	return order
 }
 
 // applyEdit performs a single text replacement using exact-then-fuzzy matching.

--- a/internal/agent/fuzzy_edit.go
+++ b/internal/agent/fuzzy_edit.go
@@ -120,9 +120,116 @@ func fuzzyFindText(content, oldText string) fuzzyFindResult {
 	}
 }
 
-// applyEdit performs a text replacement using exact-then-fuzzy matching.
-// It first tries an exact match; if that fails (not found or ambiguous),
-// it falls back to fuzzy matching with Unicode normalization.
+// editPair is a single old→new replacement to be applied to a file.
+type editPair struct {
+	OldStr string
+	NewStr string
+}
+
+// applyMultiEdit applies multiple (old→new) replacements atomically.
+// If any pair requires fuzzy matching the entire content is normalised first,
+// ensuring all replacements operate in a consistent character space.
+// Replacements are applied in descending position order so earlier indices
+// are not shifted by later writes.
+//
+// Rules (mirroring Pi's applyEditsToNormalizedContent):
+//   - Each OldStr must match exactly once (error if 0 or >1 occurrences).
+//   - No two matches may overlap (error if they do).
+//
+// WARNING: When fuzzy matching is used the returned content is the
+// NFKC-normalised form of the entire file — characters outside the edited
+// regions (smart quotes, ligatures, special spaces) are converted to their
+// ASCII equivalents. Acceptable for code; may alter documentation.
+func applyMultiEdit(content string, edits []editPair) (result string, usedFuzzy bool, err error) {
+	if len(edits) == 0 {
+		return content, false, nil
+	}
+
+	// Phase 1: attempt exact matches for all edits, note if any need fuzzy.
+	type matchResult struct {
+		index    int
+		matchLen int
+	}
+	matches := make([]matchResult, len(edits))
+	needsFuzzy := false
+
+	for i, e := range edits {
+		cnt := strings.Count(content, e.OldStr)
+		if cnt == 1 {
+			matches[i] = matchResult{strings.Index(content, e.OldStr), len(e.OldStr)}
+		} else if cnt > 1 {
+			return "", false, fmt.Errorf("edit_file: edits[%d] old_string appears %d times; provide more context to make it unique", i, cnt)
+		} else {
+			needsFuzzy = true
+		}
+	}
+
+	// Phase 2: if any edit missed exactly, normalise the entire content and
+	// re-resolve all matches in the normalised space.
+	working := content
+	if needsFuzzy {
+		working = normalizeForFuzzyMatch(content)
+		usedFuzzy = true
+		for i, e := range edits {
+			if matches[i].index != 0 || matches[i].matchLen != 0 {
+				// Re-find in normalised space (was exact in original space but
+				// the index is now invalid; normalisation may change byte offsets).
+				matches[i] = matchResult{}
+			}
+			normOld := normalizeForFuzzyMatch(e.OldStr)
+			cnt := strings.Count(working, normOld)
+			if cnt == 0 {
+				return "", false, fmt.Errorf("edit_file: edits[%d] old_string not found (tried exact match and fuzzy normalization)", i)
+			}
+			if cnt > 1 {
+				return "", false, fmt.Errorf("edit_file: edits[%d] old_string appears %d times after normalization; provide more context to make it unique", i, cnt)
+			}
+			matches[i] = matchResult{strings.Index(working, normOld), len(normOld)}
+		}
+	} else {
+		// All exact — re-index in original content (already done above).
+	}
+
+	// Phase 3: validate no overlapping ranges.
+	for i := range matches {
+		iEnd := matches[i].index + matches[i].matchLen
+		for j := i + 1; j < len(matches); j++ {
+			jEnd := matches[j].index + matches[j].matchLen
+			if matches[i].index < jEnd && matches[j].index < iEnd {
+				return "", false, fmt.Errorf("edit_file: edits[%d] and edits[%d] overlap", i, j)
+			}
+		}
+	}
+
+	// Phase 4: sort by position descending, apply in that order.
+	// Use a simple insertion sort — edit count is always small.
+	order := make([]int, len(edits))
+	for i := range order {
+		order[i] = i
+	}
+	for i := 1; i < len(order); i++ {
+		for j := i; j > 0 && matches[order[j]].index > matches[order[j-1]].index; j-- {
+			order[j], order[j-1] = order[j-1], order[j]
+		}
+	}
+
+	out := working
+	newStrFor := func(i int) string {
+		if needsFuzzy {
+			return edits[i].NewStr // newStr is always applied verbatim
+		}
+		return edits[i].NewStr
+	}
+	for _, i := range order {
+		m := matches[i]
+		out = out[:m.index] + newStrFor(i) + out[m.index+m.matchLen:]
+	}
+
+	return out, usedFuzzy, nil
+}
+
+// applyEdit performs a single text replacement using exact-then-fuzzy matching.
+// It delegates to applyMultiEdit with a one-element slice.
 //
 // WARNING: When fuzzy matching is used, the returned content is the
 // NFKC-normalized form of the entire file. This means characters outside
@@ -130,27 +237,5 @@ func fuzzyFindText(content, oldText string) fuzzyFindResult {
 // converted to their ASCII equivalents. This is an acceptable trade-off
 // for code files but may alter non-code content.
 func applyEdit(content, oldText, newText string) (result string, usedFuzzy bool, err error) {
-	count := strings.Count(content, oldText)
-	if count == 1 {
-		return strings.Replace(content, oldText, newText, 1), false, nil
-	}
-
-	if count > 1 {
-		return "", false, fmt.Errorf("edit_file: old_string appears %d times; provide more context to make it unique", count)
-	}
-
-	fuzzyResult := fuzzyFindText(content, oldText)
-	if !fuzzyResult.found {
-		return "", false, fmt.Errorf("edit_file: old_string not found in file (tried exact match and fuzzy normalization)")
-	}
-
-	fuzzyContent := fuzzyResult.contentForReplacement
-	fuzzyOldText := normalizeForFuzzyMatch(oldText)
-	fuzzyCount := strings.Count(fuzzyContent, fuzzyOldText)
-	if fuzzyCount > 1 {
-		return "", false, fmt.Errorf("edit_file: old_string appears %d times after normalization; provide more context to make it unique", fuzzyCount)
-	}
-
-	newContent := fuzzyContent[:fuzzyResult.index] + newText + fuzzyContent[fuzzyResult.index+fuzzyResult.matchLen:]
-	return newContent, true, nil
+	return applyMultiEdit(content, []editPair{{OldStr: oldText, NewStr: newText}})
 }

--- a/internal/agent/fuzzy_edit_test.go
+++ b/internal/agent/fuzzy_edit_test.go
@@ -194,3 +194,104 @@ func TestFuzzyFindText_FuzzyFallback(t *testing.T) {
 		t.Error("should have used fuzzy matching")
 	}
 }
+
+// ── applyMultiEdit ────────────────────────────────────────────────────────────
+
+func TestApplyMultiEdit_SingleEdit(t *testing.T) {
+	content := "package main\n\nfunc main() {\n\tprintln(\"hello\")\n}\n"
+	result, fuzzy, err := applyMultiEdit(content, []editPair{
+		{OldStr: "println(\"hello\")", NewStr: "println(\"world\")"},
+	})
+	assert.NoError(t, err)
+	assert.False(t, fuzzy)
+	assert.Contains(t, result, "println(\"world\")")
+	assert.NotContains(t, result, "println(\"hello\")")
+}
+
+func TestApplyMultiEdit_TwoEdits(t *testing.T) {
+	content := "const A = 1\nconst B = 2\nconst C = 3\n"
+	result, fuzzy, err := applyMultiEdit(content, []editPair{
+		{OldStr: "A = 1", NewStr: "A = 10"},
+		{OldStr: "C = 3", NewStr: "C = 30"},
+	})
+	assert.NoError(t, err)
+	assert.False(t, fuzzy)
+	assert.Contains(t, result, "A = 10")
+	assert.Contains(t, result, "B = 2") // unchanged
+	assert.Contains(t, result, "C = 30")
+}
+
+func TestApplyMultiEdit_ReverseOrderApplied(t *testing.T) {
+	// Edit at start of file + edit at end; both must be applied even though
+	// the first edit shifts byte positions of everything after it.
+	content := "START\nMIDDLE\nEND\n"
+	result, _, err := applyMultiEdit(content, []editPair{
+		{OldStr: "START", NewStr: "BEGINNING"},
+		{OldStr: "END", NewStr: "FINISH"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "BEGINNING\nMIDDLE\nFINISH\n", result)
+}
+
+func TestApplyMultiEdit_OverlapError(t *testing.T) {
+	content := "abcdef"
+	// "abc" and "cde" overlap at 'c'
+	_, _, err := applyMultiEdit(content, []editPair{
+		{OldStr: "abc", NewStr: "X"},
+		{OldStr: "cde", NewStr: "Y"},
+	})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "overlap")
+}
+
+func TestApplyMultiEdit_NotFoundError(t *testing.T) {
+	content := "hello world"
+	_, _, err := applyMultiEdit(content, []editPair{
+		{OldStr: "nonexistent", NewStr: "x"},
+	})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "not found")
+}
+
+func TestApplyMultiEdit_AmbiguousMatchError(t *testing.T) {
+	content := "x\nx\n"
+	_, _, err := applyMultiEdit(content, []editPair{
+		{OldStr: "x", NewStr: "y"},
+	})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "2 times")
+}
+
+func TestApplyMultiEdit_FuzzySmartQuotes(t *testing.T) {
+	// File has ASCII quotes; LLM sends smart quotes in old_string.
+	content := "msg := \"hello\"\n"
+	oldText := "msg := \u201Chello\u201D\n" // smart double quotes
+	result, fuzzy, err := applyMultiEdit(content, []editPair{
+		{OldStr: oldText, NewStr: "msg := \"goodbye\"\n"},
+	})
+	assert.NoError(t, err)
+	assert.True(t, fuzzy)
+	assert.Contains(t, result, "goodbye")
+}
+
+func TestApplyMultiEdit_EmptyEdits(t *testing.T) {
+	content := "unchanged"
+	result, fuzzy, err := applyMultiEdit(content, nil)
+	assert.NoError(t, err)
+	assert.False(t, fuzzy)
+	assert.Equal(t, content, result)
+}
+
+func TestApplyMultiEdit_FuzzyOneEditMissedOtherExact(t *testing.T) {
+	// First edit needs fuzzy (smart quote); second is exact.
+	// Both must still be applied in normalised space.
+	content := "A = 1\nB = 2\n"
+	result, fuzzy, err := applyMultiEdit(content, []editPair{
+		{OldStr: "A\u00A0=\u00A01", NewStr: "A = 10"}, // NBSP spaces → fuzzy
+		{OldStr: "B = 2", NewStr: "B = 20"},
+	})
+	assert.NoError(t, err)
+	assert.True(t, fuzzy)
+	assert.Contains(t, result, "A = 10")
+	assert.Contains(t, result, "B = 20")
+}

--- a/internal/agent/warden.go
+++ b/internal/agent/warden.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -47,6 +48,14 @@ var publishToolNames = map[string]bool{
 // before the implement loop is told to stop and request human review.
 // This prevents endless ping-pong when reviewer and coder keep disagreeing.
 const maxReviewRounds = 10
+
+// editFileName and writeFileName are the canonical tool names used in
+// compaction helpers. Defined as constants to satisfy goconst and to make
+// any future renames a single-point change.
+const (
+	editFileName  = "edit_file"
+	writeFileName = "write_file"
+)
 
 // reviewCapTool wraps the review_code MCP tool and enforces maxReviewRounds.
 // After the cap is reached every subsequent call returns a synthetic verdict
@@ -562,19 +571,26 @@ func compactionFilterText(text string) string {
 // the AI turn that requested it.
 //
 // It walks backwards from the ideal cut point (len(msgs)-minTail) until it
-// lands on a human message. Stops at index 2 to always leave room for
-// msgs[0] (system prompt) and the new summary human message.
+// lands on a human message. The minimum index is 1 (msgs[0] is always the
+// system prompt and is never included in the tail — it is prepended separately
+// by the caller).
 func findTailStart(msgs []schema.MessageContent, minTail int) int {
 	n := len(msgs)
 	if n <= minTail+1 {
 		return 1 // not enough to compact — keep everything after system prompt
 	}
 	start := n - minTail
-	for start > 2 && msgs[start].Role != schema.ChatMessageTypeHuman {
+	for start > 1 && msgs[start].Role != schema.ChatMessageTypeHuman {
 		start--
 	}
 	return start
 }
+
+// goframeToolResultPrefix is the prefix goframe prepends to every tool result
+// message: "Tool '<name>' returned: <json>". extractPathFromToolResult depends
+// on this format; if goframe changes it, file tracking will silently return
+// empty paths (safe degradation, not a crash).
+const goframeToolResultPrefix = "returned: "
 
 // extractFileOpsFromMsgs parses ToolResultContent parts in the message history
 // and returns two sorted, deduplicated file lists:
@@ -588,9 +604,14 @@ func findTailStart(msgs []schema.MessageContent, minTail int) int {
 // so we strip the prefix and unmarshal the JSON to read the "path" field.
 // read_file results also include "path" (added in this PR).
 func extractFileOpsFromMsgs(msgs []schema.MessageContent) (readFiles, modifiedFiles []string) {
-	readSet := make(map[string]struct{})
-	modSet := make(map[string]struct{})
+	readSet, modSet := collectFileOpSets(msgs)
+	return fileOpSetsToLists(readSet, modSet)
+}
 
+// collectFileOpSets walks the message history and returns two sets of file paths.
+func collectFileOpSets(msgs []schema.MessageContent) (readSet, modSet map[string]struct{}) {
+	readSet = make(map[string]struct{})
+	modSet = make(map[string]struct{})
 	for _, m := range msgs {
 		if m.Role != schema.ChatMessageTypeTool {
 			continue
@@ -600,22 +621,29 @@ func extractFileOpsFromMsgs(msgs []schema.MessageContent) (readFiles, modifiedFi
 			if !ok {
 				continue
 			}
-			switch trc.ToolName {
-			case "read_file", "write_file", "edit_file":
-				path := extractPathFromToolResult(trc.Content)
-				if path == "" {
-					continue
-				}
-				if trc.ToolName == "read_file" {
-					readSet[path] = struct{}{}
-				} else {
-					modSet[path] = struct{}{}
-				}
-			}
+			recordFileOp(trc, readSet, modSet)
 		}
 	}
+	return readSet, modSet
+}
 
-	// read-only = read − modified
+// recordFileOp adds a path to the appropriate set based on the tool name.
+func recordFileOp(trc schema.ToolResultContent, readSet, modSet map[string]struct{}) {
+	switch trc.ToolName {
+	case "read_file":
+		if p := extractPathFromToolResult(trc.Content); p != "" {
+			readSet[p] = struct{}{}
+		}
+	case writeFileName, editFileName:
+		if p := extractPathFromToolResult(trc.Content); p != "" {
+			modSet[p] = struct{}{}
+		}
+	}
+}
+
+// fileOpSetsToLists converts raw read/mod sets into sorted, deduplicated lists
+// where readFiles contains only paths not also in modSet.
+func fileOpSetsToLists(readSet, modSet map[string]struct{}) (readFiles, modifiedFiles []string) {
 	for p := range readSet {
 		if _, modified := modSet[p]; !modified {
 			readFiles = append(readFiles, p)
@@ -624,15 +652,15 @@ func extractFileOpsFromMsgs(msgs []schema.MessageContent) (readFiles, modifiedFi
 	for p := range modSet {
 		modifiedFiles = append(modifiedFiles, p)
 	}
-	sortStrings(readFiles)
-	sortStrings(modifiedFiles)
+	sort.Strings(readFiles)
+	sort.Strings(modifiedFiles)
 	return readFiles, modifiedFiles
 }
 
 // extractPathFromToolResult extracts the "path" field from a goframe tool
 // result string of the form "Tool '<name>' returned: <json>".
 func extractPathFromToolResult(content string) string {
-	_, jsonPart, found := strings.Cut(content, "returned: ")
+	_, jsonPart, found := strings.Cut(content, goframeToolResultPrefix)
 	if !found {
 		return ""
 	}
@@ -661,13 +689,13 @@ func parseFileTagsFromSummary(summary string) (readFiles, modifiedFiles []string
 //	</tag>
 func parseXMLBlock(s, tag string) []string {
 	open := "<" + tag + ">"
-	close := "</" + tag + ">"
+	closeTag := "</" + tag + ">"
 	start := strings.Index(s, open)
 	if start == -1 {
 		return nil
 	}
 	start += len(open)
-	end := strings.Index(s[start:], close)
+	end := strings.Index(s[start:], closeTag)
 	if end == -1 {
 		return nil
 	}
@@ -724,17 +752,8 @@ func mergeFileLists(a, b []string) []string {
 	for s := range seen {
 		out = append(out, s)
 	}
-	sortStrings(out)
+	sort.Strings(out)
 	return out
-}
-
-// sortStrings sorts a string slice in place.
-func sortStrings(s []string) {
-	for i := 1; i < len(s); i++ {
-		for j := i; j > 0 && s[j] < s[j-1]; j-- {
-			s[j], s[j-1] = s[j-1], s[j]
-		}
-	}
 }
 
 // buildCompactionHook returns a goframe WithLoopCompactionHook callback that

--- a/internal/agent/warden.go
+++ b/internal/agent/warden.go
@@ -556,6 +556,187 @@ func compactionFilterText(text string) string {
 	return text
 }
 
+// findTailStart returns the index of the first message to include in the
+// preserved tail after compaction. It ensures the tail starts at a
+// ChatMessageTypeHuman message so a "tool"-role result is never orphaned from
+// the AI turn that requested it.
+//
+// It walks backwards from the ideal cut point (len(msgs)-minTail) until it
+// lands on a human message. Stops at index 2 to always leave room for
+// msgs[0] (system prompt) and the new summary human message.
+func findTailStart(msgs []schema.MessageContent, minTail int) int {
+	n := len(msgs)
+	if n <= minTail+1 {
+		return 1 // not enough to compact — keep everything after system prompt
+	}
+	start := n - minTail
+	for start > 2 && msgs[start].Role != schema.ChatMessageTypeHuman {
+		start--
+	}
+	return start
+}
+
+// extractFileOpsFromMsgs parses ToolResultContent parts in the message history
+// and returns two sorted, deduplicated file lists:
+//   - readFiles: files touched by read_file but not subsequently modified
+//   - modifiedFiles: files written or edited (write_file / edit_file)
+//
+// Tool results are formatted by goframe as
+//
+//	"Tool '<name>' returned: <json>"
+//
+// so we strip the prefix and unmarshal the JSON to read the "path" field.
+// read_file results also include "path" (added in this PR).
+func extractFileOpsFromMsgs(msgs []schema.MessageContent) (readFiles, modifiedFiles []string) {
+	readSet := make(map[string]struct{})
+	modSet := make(map[string]struct{})
+
+	for _, m := range msgs {
+		if m.Role != schema.ChatMessageTypeTool {
+			continue
+		}
+		for _, part := range m.Parts {
+			trc, ok := part.(schema.ToolResultContent)
+			if !ok {
+				continue
+			}
+			switch trc.ToolName {
+			case "read_file", "write_file", "edit_file":
+				path := extractPathFromToolResult(trc.Content)
+				if path == "" {
+					continue
+				}
+				if trc.ToolName == "read_file" {
+					readSet[path] = struct{}{}
+				} else {
+					modSet[path] = struct{}{}
+				}
+			}
+		}
+	}
+
+	// read-only = read − modified
+	for p := range readSet {
+		if _, modified := modSet[p]; !modified {
+			readFiles = append(readFiles, p)
+		}
+	}
+	for p := range modSet {
+		modifiedFiles = append(modifiedFiles, p)
+	}
+	sortStrings(readFiles)
+	sortStrings(modifiedFiles)
+	return readFiles, modifiedFiles
+}
+
+// extractPathFromToolResult extracts the "path" field from a goframe tool
+// result string of the form "Tool '<name>' returned: <json>".
+func extractPathFromToolResult(content string) string {
+	_, jsonPart, found := strings.Cut(content, "returned: ")
+	if !found {
+		return ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(jsonPart)), &m); err != nil {
+		return ""
+	}
+	path, _ := m["path"].(string)
+	return path
+}
+
+// parseFileTagsFromSummary extracts the <read-files> and <modified-files> XML
+// blocks that were appended by a prior compaction, so they can be merged with
+// the file operations discovered in the new messages.
+func parseFileTagsFromSummary(summary string) (readFiles, modifiedFiles []string) {
+	readFiles = parseXMLBlock(summary, "read-files")
+	modifiedFiles = parseXMLBlock(summary, "modified-files")
+	return readFiles, modifiedFiles
+}
+
+// parseXMLBlock extracts newline-separated file paths from a block of the form
+//
+//	<tag>
+//	path1
+//	path2
+//	</tag>
+func parseXMLBlock(s, tag string) []string {
+	open := "<" + tag + ">"
+	close := "</" + tag + ">"
+	start := strings.Index(s, open)
+	if start == -1 {
+		return nil
+	}
+	start += len(open)
+	end := strings.Index(s[start:], close)
+	if end == -1 {
+		return nil
+	}
+	var paths []string
+	for line := range strings.SplitSeq(strings.TrimSpace(s[start:start+end]), "\n") {
+		if p := strings.TrimSpace(line); p != "" {
+			paths = append(paths, p)
+		}
+	}
+	return paths
+}
+
+// formatFileOps formats read and modified file lists as XML tags suitable for
+// appending to a compaction summary. Returns an empty string when both lists
+// are empty.
+func formatFileOps(readFiles, modifiedFiles []string) string {
+	if len(readFiles) == 0 && len(modifiedFiles) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\n\n")
+	if len(readFiles) > 0 {
+		b.WriteString("<read-files>\n")
+		for _, f := range readFiles {
+			b.WriteString(f)
+			b.WriteByte('\n')
+		}
+		b.WriteString("</read-files>\n")
+	}
+	if len(modifiedFiles) > 0 {
+		if len(readFiles) > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString("<modified-files>\n")
+		for _, f := range modifiedFiles {
+			b.WriteString(f)
+			b.WriteByte('\n')
+		}
+		b.WriteString("</modified-files>")
+	}
+	return b.String()
+}
+
+// mergeFileLists merges two slices, returning a sorted, deduplicated result.
+func mergeFileLists(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for _, s := range a {
+		seen[s] = struct{}{}
+	}
+	for _, s := range b {
+		seen[s] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for s := range seen {
+		out = append(out, s)
+	}
+	sortStrings(out)
+	return out
+}
+
+// sortStrings sorts a string slice in place.
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j] < s[j-1]; j-- {
+			s[j], s[j-1] = s[j-1], s[j]
+		}
+	}
+}
+
 // buildCompactionHook returns a goframe WithLoopCompactionHook callback that
 // summarizes the conversation history when token usage exceeds 70% of the
 // conservative context ceiling. The system prompt (first message) and the most
@@ -595,10 +776,8 @@ func (o *Orchestrator) buildCompactionHook(session *Session, traceFile *os.File,
 			"original_messages", len(msgs),
 		)
 
-		tail := msgs
-		if len(msgs) > 9 {
-			tail = msgs[len(msgs)-8:]
-		}
+		tailStart := findTailStart(msgs, 8)
+		tail := msgs[tailStart:]
 
 		compacted := make([]schema.MessageContent, 0, 2+len(tail))
 		compacted = append(compacted, msgs[0])
@@ -613,6 +792,12 @@ func (o *Orchestrator) buildCompactionHook(session *Session, traceFile *os.File,
 // compactMessages produces a conversation summary using iterative compaction.
 // If a previous summary exists in the messages, it updates it rather than
 // summarizing from scratch — more efficient and preserves continuity.
+//
+// File operation tracking: file paths touched by read_file / write_file /
+// edit_file are extracted from the message history and appended to the summary
+// as <read-files> / <modified-files> XML blocks, mirroring Pi's compaction
+// details. On re-compaction the prior blocks are merged with new operations so
+// the cumulative file footprint is never lost.
 func (o *Orchestrator) compactMessages(ctx context.Context, llm llms.Model, msgs []schema.MessageContent) (string, error) {
 	previousSummary, newMsgs := extractPreviousSummary(msgs)
 
@@ -641,7 +826,27 @@ func (o *Orchestrator) compactMessages(ctx context.Context, llm llms.Model, msgs
 		return "", fmt.Errorf("LLM summarization failed: %w", err)
 	}
 
-	return resp.Choices[0].Content, nil
+	summary := resp.Choices[0].Content
+
+	// Merge file operations: previous summary tags + new messages.
+	prevRead, prevMod := parseFileTagsFromSummary(previousSummary)
+	newRead, newMod := extractFileOpsFromMsgs(newMsgs)
+	allMod := mergeFileLists(prevMod, newMod)
+	// read-only = merged reads minus anything in modified
+	allReadRaw := mergeFileLists(prevRead, newRead)
+	modSet := make(map[string]struct{}, len(allMod))
+	for _, f := range allMod {
+		modSet[f] = struct{}{}
+	}
+	var allRead []string
+	for _, f := range allReadRaw {
+		if _, inMod := modSet[f]; !inMod {
+			allRead = append(allRead, f)
+		}
+	}
+
+	summary += formatFileOps(allRead, allMod)
+	return summary, nil
 }
 
 // errNoChanges is returned by yieldCommitAndPush when the workspace has no


### PR DESCRIPTION
… diff output

Ported four improvements from the Pi coding-agent reference:

- fix(compaction): replace fixed-count tail with findTailStart() that walks backwards to the nearest human-role message so a tool result is never orphaned from the AI turn that requested it

- feat(compaction): track file footprint across compactions — read_file / write_file / edit_file results are parsed and emitted as <read-files> / <modified-files> XML blocks appended to every summary; merged cumulatively on re-compaction (mirrors Pi compaction/utils.ts)

- feat(edit_file): accept edits:[{old_string,new_string}] array for atomic multi-replacement; applyMultiEdit() normalises the whole file once if any pair needs fuzzy matching, then applies all replacements in reverse-position order; backwards-compatible with flat old_string/new_string

- feat(edit_file): return unified diff field so the LLM can verify changes without a follow-up read_file (go-difflib, truncated at 4000 bytes)

- fix(read_file): include "path" in result so all three file tools emit it uniformly, enabling file-op extraction from tool result messages

26 new unit tests covering all new code paths.