### PR TITLE
feat(agent): add grep/find search tools, read_file hints, wire native loop, update docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,241 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Code-Warden is a self-hosted GitHub App that performs contextual code reviews using LLMs (Ollama or Gemini). It uses a RAG (Retrieval-Augmented Generation) pipeline with Qdrant vector store to provide repository-aware feedback when triggered by `/review` or `/rereview` commands on pull requests.
+
+## Build and Test Commands
+
+```bash
+# Build both server and CLI binaries
+make build
+
+# Build individual binaries
+make build-server   # Creates ./bin/code-warden
+make build-cli      # Creates ./bin/warden-cli
+
+# Run the server
+make run            # Build and run server
+go run ./cmd/server/main.go
+
+# Run tests
+make test           # Runs go test -v ./...
+go test -v ./...    # Direct test execution
+go test -v ./internal/llm/...  # Run tests for specific package
+
+# Lint code
+make lint           # Installs golangci-lint if needed and runs it
+
+# Clean build artifacts
+make clean
+```
+
+> **Pre-commit gate:** `make test && make lint` runs automatically before every
+> `git commit` (enforced via a Claude Code PreToolUse hook in
+> `.claude/settings.local.json`). The commit is blocked if either fails.
+
+## Development Environment
+
+Start required services (PostgreSQL and Qdrant):
+```bash
+docker-compose up -d
+```
+
+For Ollama models (if using ollama provider):
+```bash
+docker-compose -f docker-compose.setup.yml up --build --remove-orphans
+```
+
+## Architecture
+
+### Core Components
+
+- **`cmd/server`**: GitHub App webhook server entry point
+- **`cmd/cli`**: Administrative CLI (`warden-cli`) for update, prescan, review operations
+- **`cmd/terminal`**: Terminal UI for local/debug interaction
+- **`internal/core`**: Domain entities (`Review`, `Repository`, `PullRequest`, `JobQueue`, interfaces)
+- **`internal/jobs`**: Background job execution (ReviewJob, Dispatcher)
+- **`internal/review`**: Unified review execution flow shared by webhook, MCP tool, and CLI (`Executor` handles single-model and consensus modes)
+- **`internal/llm`**: Prompt management, LLM client wrappers, tokenizer, JSON parser
+- **`internal/rag`**: RAG service (`service.go`) + sub-packages:
+  - `contextpkg/`: Context building — architecture summaries, HyDE, symbol search, impact analysis, TOC
+  - `index/`: Qdrant indexing — file hashing, definitions extraction, TOC generation, filter rules
+  - `review/`: Review generation — single-model, consensus (multi-model), rereview, artifact saving
+  - `detect/`: Code reuse/duplication detection backed by VectorDB
+  - `question/`: Free-form Q&A over indexed code
+  - `metadata/`: Line-level document metadata
+- **`internal/storage`**: PostgreSQL (`Store`) and Qdrant (`VectorStore`, `ScopedVectorStore`) data access
+- **`internal/github`**: GitHub API client, webhook handling, diff hunks, status updates
+- **`internal/repomanager`**: Git repository lifecycle (clone, sync, diff)
+- **`internal/prescan`**: Repo preparation for CLI scanning (clone remote or open local, detect owner/repo)
+- **`internal/mcp`**: Model Context Protocol server (SSE + JSON-RPC transports) exposing tools for AI agents; includes governance (allow/deny lists, rate limits)
+- **`internal/globalmcp`**: Global MCP server running continuously alongside the main server; workspace-aware proxy/registry
+- **`internal/agent`**: Orchestrates in-process AI coding agents (warden, native modes) — manages `Session` lifecycle, runs goframe AgentLoop, communicates via MCP; includes planner, file_tools, search_tools (grep/find), fuzzy_edit, context_crawler
+- **`internal/gitutil`**: Git utilities (URL parsing, branch operations, clone/fetch/open)
+- **`internal/wire`**: Google Wire dependency injection setup
+- **`mocks/`**: Mock implementations for unit testing (generated with `go.uber.org/mock`)
+
+### Data Flow (Review Process)
+
+1. Webhook received → `WebhookHandler` validates and queues event
+2. `JobDispatcher` assigns to worker → `ReviewJob.Run()` executes
+3. `RepoManager.SyncRepo()` clones/fetches repo, calculates diff
+4. `RAGService.UpdateRepoContext()` incrementally updates Qdrant vectors (via `rag/index`)
+5. `review.Executor` calls `RAGService.GenerateReview()` — queries context (`rag/contextpkg`), renders prompt, calls LLM (`rag/review`)
+6. Structured JSON review parsed and posted as GitHub PR comments
+
+### MCP / Agent Flow
+
+- `globalmcp.Server` runs on a dedicated port alongside the webhook server
+- AI agents connect via SSE (`GET /sse`) or direct JSON-RPC (`POST /`)
+- Available tools: `search_code`, `get_arch_context`, `get_symbol`, `get_structure`, `find_usages`, `get_callers`, `get_callees`, `review_code`, `push_branch`, `create_pull_request`, `list_issues`, `get_issue`, `grep`, `find`
+- `create_pull_request` enforces that `review_code` was called and returned `APPROVE`/`COMMENT` within the last 30 minutes
+- `internal/agent.Orchestrator` can spawn agent subprocesses and wire them to a per-session MCP server
+
+### Key Patterns
+
+- **Dependency Injection**: All services registered in `internal/wire/wire.go` using Google Wire
+- **Error Handling**: Wrap errors with context: `fmt.Errorf("failed to <action>: %w", err)`
+- **Context Propagation**: All I/O functions accept `context.Context` as first argument
+- **Interface Naming**: Interfaces suffixed with `-er` (e.g., `Reviewer`, `ConfigLoader`)
+- **Logging**: Uses `log/slog` throughout (via `internal/logger` wrapper); not zap
+
+## Configuration
+
+Configuration via `config.yaml` or environment variables (env vars take precedence, use `SECTION_KEY` format like `AI_LLM_PROVIDER`):
+
+Key settings:
+- `ai.llm_provider`: "ollama" or "gemini"
+- `ai.generator_model`: Model for reviews (e.g., "gemma3:latest", "gemini-1.5-flash")
+- `ai.embedder_model`: Model for embeddings (e.g., "nomic-embed-text")
+- `github.app_id`, `github.webhook_secret`, `github.private_key_path`: GitHub App credentials
+- `database.*`: PostgreSQL connection settings
+- `storage.qdrant_host`: Qdrant endpoint
+
+Repository-specific customization via `.code-warden.yml` in repo root:
+- `custom_instructions`: List of guidance strings for the LLM
+- `exclude_dirs`, `exclude_exts`: Files to skip during indexing
+
+## Testing
+
+- Unit tests use standard `go test` framework
+- Mocks are in `mocks/` and generated with `go.uber.org/mock`; regenerate with `go generate ./...`
+- Place tests in `*_test.go` files within the package they test
+- Run a single test: `go test -v -run TestName ./internal/pkg/...`
+- Integration tests skip when external services are unavailable
+
+## Key Dependencies
+
+- `github.com/google/wire`: Compile-time dependency injection
+- `github.com/google/go-github`: GitHub API interactions
+- `github.com/spf13/cobra`: CLI framework
+- `github.com/jmoiron/sqlx`: PostgreSQL access
+- `github.com/sevigo/goframe`: RAG framework (LLM, embeddings, vectorstores, agent registry/governance)
+- `go.uber.org/mock`: Mock generation for unit tests (`mocks/` directory)
+
+## GoFrame Integration
+
+Code-Warden uses goframe v0.23.2+ with the following patterns:
+
+### Chain Constructors (Return Errors)
+```go
+// All these constructors return errors as of goframe v0.23.2
+chain, err := chains.NewLLMChain[T](llm, prompt, opts...)
+qa, err := chains.NewRetrievalQA(retriever, llm, opts...)
+retriever, err := vectorstores.NewDependencyRetriever(store)
+defRetriever, err := vectorstores.NewDefinitionRetriever(store)
+```
+
+### Resource Cleanup
+```go
+// Always close VectorStore when done
+defer vectorStore.Close()
+```
+
+### Context Propagation
+```go
+// Always pass context through to GoFrame operations
+docs, err := store.SimilaritySearch(ctx, query, k)
+sparseVec, err := sparse.GenerateSparseVector(ctx, text)
+```
+
+## Recent Improvements
+
+### Agent Implement Flow (warden mode)
+The in-process agent (`internal/agent/`) runs three sequential loops:
+
+1. **Plan loop** (max 5 iterations, read-only MCP tools): produces a markdown
+   implementation plan injected into the implement loop's system prompt.
+
+2. **Implement loop** (max 50 iterations): all file tools + search tools + MCP tools except
+   `push_branch`/`create_pull_request`. Terminates when `review_code` returns
+   `APPROVE` or iterations are exhausted (draft PR is opened instead).
+
+3. **Publish loop** (max 8 iterations, only if APPROVE): `push_branch` +
+   `create_pull_request`.
+
+**File tools** (`internal/agent/file_tools.go`):
+- `read_file` — returns `{content, lines, path}`; supports `offset`/`limit`; when truncated, includes `total_lines`, `truncated`, and `hint` with next offset
+- `write_file` — creates/overwrites; returns `{ok, path, bytes}`
+- `edit_file` — two calling conventions:
+  - Single: `{path, old_string, new_string}` (backwards-compatible)
+  - Multi: `{path, edits:[{old_string, new_string}, ...]}` — atomic multi-replacement, applied in reverse-position order so earlier indices are not shifted; fuzzy-normalises the entire file if any match needs it
+  - Returns `{ok, path, diff, fuzzy_match?}` — the `diff` field (unified diff, ≤4000 bytes) lets the LLM verify its changes without a follow-up `read_file`
+  - Handles CRLF line endings and UTF-8 BOM transparently (normalizes before matching, restores on write)
+- `list_dir` — returns directory entries with type and size
+
+**Search tools** (`internal/agent/search_tools.go`):
+- `grep` — searches file contents by regex/literal pattern; uses ripgrep with grep fallback; supports glob filter, case-insensitive mode, context lines; path is validated against workspace root
+- `find` — lists files by glob pattern (including `**` for multi-level); pure Go `filepath.WalkDir`; skips `.git`/`node_modules`/`vendor`; returns workspace-relative paths
+
+**Compaction** (`internal/agent/warden.go`):
+- Triggers at 70% of a 128 K token ceiling
+- Iterative: updates prior summary instead of summarising from scratch
+- Appends `<read-files>` / `<modified-files>` XML blocks tracking cumulative file footprint across re-compactions
+- Tail selection: walks backwards to the last human-role message so tool results are never orphaned from the AI turn that requested them
+
+### Review Profile System
+Code reviews now adapt intensity based on PR complexity (merged PR #237):
+- **Quick profile**: Small/low-impact PRs — shorter context, fewer findings
+- **Standard profile**: Moderate complexity — balanced review
+- **Thorough profile**: Large/high-impact PRs — full context, detailed analysis
+- High-risk paths (auth, crypto, payment, security) always force thorough review
+- Profile stored in `internal/core/review_profile.go`, impact radius calculated in `internal/rag/contextpkg/builder.go`
+
+### Background Job Context
+Use server context for background jobs, not HTTP request context. The request context gets cancelled when the HTTP response is sent, causing jobs to fail. See `internal/jobs/dispatcher.go`.
+
+### Sparse Query Validation
+Small LLMs can generate malformed queries that crash sparse vector generation. Queries are validated before processing in `internal/rag/contextpkg/format.go`.
+
+### Branch Protection
+Main branch requires status checks (lint, test, build) but no PR approval. Direct commits to main are blocked.
+
+## Common Tasks
+
+### Adding a New Prompt
+1. Create `internal/llm/prompts/my_prompt.prompt`
+2. Add prompt key to `internal/llm/keys.go`
+3. Use `promptMgr.Render(llm.MyPrompt, data)` in code
+
+### Adding a New RAG Context Stage
+1. Add method to `internal/rag/contextpkg/builder.go` (or a new file in `contextpkg/`)
+2. Call from `buildContextConcurrently()` for parallel execution
+3. Include result in context assembly via `BuildRelevantContext`
+
+### Adding a New CLI Command
+1. Create command in `cmd/cli/`
+2. Register in `cmd/cli/root.go`
+3. Add any new dependencies to `internal/wire/wire.go`
+
+### Adding a New MCP Tool
+1. Create tool struct in `internal/mcp/tools/` implementing the `Tool` interface (`Name`, `Description`, `ParametersSchema`, `Execute`)
+2. Register in `internal/mcp/server.go` inside `registerTools()`
+3. Inject any required dependencies through the struct fields
+
+### Adding a New Agent Tool (grep/find-style)
+1. Create tool struct in `internal/agent/` implementing the `mcp.Tool` interface
+2. Add to `searchTools()` or `fileTools()` helper function
+3. Tool is automatically registered in planner, implement, and native agent loops

--- a/docs/IMPLEMENT_ARCHITECTURE.md
+++ b/docs/IMPLEMENT_ARCHITECTURE.md
@@ -59,8 +59,9 @@ runWardenAgent(ctx, session, branch)
 ├─ ── Phase 1: Plan ──────────────────────────────────────────────────
 │   tracker.setPhase("planning")
 │   buildPlan()  →  buildPlannerLoop()
-│     tools: search_code, get_symbol, get_structure, get_arch_context,
-│            find_usages, get_callers, get_callees, read_file, list_dir
+│   tools: search_code, get_symbol, get_structure, get_arch_context,
+│          find_usages, get_callers, get_callees, read_file, list_dir,
+│          grep, find
 │     max_iterations: 5
 │     output: markdown "## Implementation Plan" injected into implement prompt
 │
@@ -69,8 +70,9 @@ runWardenAgent(ctx, session, branch)
 │   buildImplementLoop()
 │     tools: ALL MCP tools except push_branch / create_pull_request
 │            + read_file, write_file, edit_file, list_dir  (file tools)
-│            + lsp_diagnostics, lsp_definition, lsp_references, lsp_hover
-│     max_iterations: max(MaxIterations*10, 30)
+│            + grep, find  (search tools — exact pattern search and file discovery)
+│            + run_command  (shell commands for lint/test verification)
+│     max_iterations: max(MaxIterations*15, 50)
 │     compactionHook: fires at 70% of 128K tokens, summarises history
 │
 │   loop.Run()  →  Think → call tools → Observe → repeat
@@ -97,50 +99,11 @@ runWardenAgent(ctx, session, branch)
 
 ---
 
-## LSP Integration (`internal/agent/lsp/`)
+## LSP Removal
 
-The Language Server Protocol client provides precise, always-current code navigation during the implement phase — complementing the RAG-based `search_code` tools that are better for open-ended exploration.
+The Language Server Protocol client was removed from agent sessions. It added 30–120 seconds of startup time per session and required per-language server binaries on the host. The agent now uses `grep` for exact pattern search, `find` for file discovery, and `run_command("go build ./...")` for compile checks — which is faster and works for any language without pre-installed language servers.
 
-### Architecture
-
-```
-lsp.Manager
-  ├── detectLanguages()        ← walks workspace, collects extensions
-  ├── Start(ctx)               ← starts one Client per detected language
-  │     GoServer       (.go)   → gopls
-  │     TypeScriptServer (.ts) → typescript-language-server
-  │     PythonServer    (.py)  → pylsp
-  │     RustServer      (.rs)  → rust-analyzer
-  └── clientForFile(absPath)   ← routes tool calls to correct client
-
-lsp.Client (per language)
-  ├── starts server subprocess via stdio
-  ├── JSON-RPC 2.0 with Content-Length framing
-  ├── readLoop()               ← goroutine: routes responses + notifications
-  ├── Diagnostics()            ← pull (textDocument/diagnostic) with push fallback
-  ├── Definition() / References() / Hover()
-  └── DidOpen() / DidChange()  ← keeps server in sync with file edits
-```
-
-### LSP hook on file writes
-
-Every `write_file` and `edit_file` call automatically:
-1. Sends `DidChange` to the language server.
-2. Waits 700 ms for diagnostics to settle.
-3. Calls `Diagnostics()` and appends results to the tool's return value.
-
-The agent sees compiler errors in the **same turn** it made the change — no extra tool call needed.
-
-### Agent-facing LSP tools
-
-| Tool | Parameters | Description |
-|------|-----------|-------------|
-| `lsp_diagnostics` | `path` | Compiler errors and warnings for a file |
-| `lsp_definition` | `path, line, column` | Jump-to-definition (0-based) |
-| `lsp_references` | `path, line, column` | All usages of a symbol |
-| `lsp_hover` | `path, line, column` | Type signature and doc comment |
-
-LSP tools are registered only when at least one language server started successfully. If `gopls` is not on PATH, the agent falls back to RAG-based `search_code` transparently.
+The LSP package (`internal/agent/lsp/`) still exists for non-agent use but is no longer started during workspace preparation.
 
 ---
 
@@ -150,8 +113,8 @@ Tools are assigned to loops architecturally — the model literally cannot call 
 
 | Phase | Loop | Tools available |
 |-------|------|----------------|
-| Plan | `buildPlannerLoop` | `search_code`, `get_symbol`, `get_structure`, `get_arch_context`, `find_usages`, `get_callers`, `get_callees`, `read_file`, `list_dir` |
-| Implement | `buildImplementLoop` | All MCP tools except `push_branch` / `create_pull_request`, plus file tools and LSP tools |
+| Plan | `buildPlannerLoop` | `search_code`, `get_symbol`, `get_structure`, `get_arch_context`, `find_usages`, `get_callers`, `get_callees`, `read_file`, `list_dir`, `grep`, `find` |
+| Implement | `buildImplementLoop` | All MCP tools except `push_branch` / `create_pull_request`, plus file tools (`read_file`, `write_file`, `edit_file`, `list_dir`), search tools (`grep`, `find`), and `run_command` |
 | Publish | `buildPublishLoop` | `push_branch`, `create_pull_request` **only** |
 
 `publishToolNames` is the single source of truth for what is withheld during implementation (see `warden.go`).
@@ -200,10 +163,11 @@ buildCompactionHook(session) → func(ctx, msgs, tokens) []schema.MessageContent
   call LLM with summarization prompt (iterative: update summary vs. fresh start)
     max 400 words; if previousSummary != "": "Update this summary: …" prompt
 
-  extract file ops from newMsgs:
-    - parse tool result messages for read_file / write_file / edit_file paths
-    - merge with file lists already in previousSummary (<read-files>/<modified-files> XML)
-    - append formatFileOps(allRead, allMod) to the new summary
+   extract file ops from newMsgs:
+     - parse tool result messages for read_file / write_file / edit_file paths
+     - also parse grep and find results to track explored files
+     - merge with file lists already in previousSummary (<read-files>/<modified-files> XML)
+     - append formatFileOps(allRead, allMod) to the new summary
 
   find tail boundary via findTailStart(msgs, 8):
     - walks backward from end until landing on a ChatMessageTypeHuman message
@@ -303,23 +267,21 @@ Tools used by the implement loop (see `internal/mcp/tools/` and `internal/agent/
 | `find_usages` | Call sites for a symbol |
 | `get_callers` / `get_callees` | Call graph navigation |
 
+### Code exploration (exact search, read-only)
+
+| Tool | Description |
+|------|-------------|
+| `grep` | Search file contents by pattern (regex or literal). Uses ripgrep with grep fallback. Returns `file:line: content` format with match count and truncation hints. |
+| `find` | Find files by glob pattern (e.g. `*.go`, `**/*_test.go`). Pure Go, skips `.git`/`node_modules`/`vendor`. Returns workspace-relative paths with truncation hints. |
+
 ### File operations (workspace-scoped)
 
 | Tool | Description |
 |------|-------------|
-| `read_file` | Read a file, optionally paginated; returns `{content, lines, path}` |
-| `write_file` | Create or overwrite; returns `{ok, path, bytes}` (triggers LSP diagnostics) |
-| `edit_file` | Exact-string replace with fuzzy fallback; returns `{ok, path, diff}` (triggers LSP diagnostics) — supports single `{old_string, new_string}` or atomic multi-edit `{edits:[…]}` |
+| `read_file` | Read a file, optionally paginated; returns `{content, lines, path}`. When truncated, includes `total_lines`, `truncated`, and `hint` with the offset to read next. |
+| `write_file` | Create or overwrite; returns `{ok, path, bytes}` |
+| `edit_file` | Exact-string replace with fuzzy fallback and CRLF/BOM handling; returns `{ok, path, diff, fuzzy_match?}`. Supports single `{old_string, new_string}` or atomic multi-edit `{edits:[{old_string, new_string}, ...]}`. Returns a unified diff (≤4 KB) for verification without a follow-up `read_file`. |
 | `list_dir` | List directory entries with name, type, size |
-
-### LSP (live compiler feedback)
-
-| Tool | Description |
-|------|-------------|
-| `lsp_diagnostics` | Errors/warnings from language server |
-| `lsp_definition` | Jump to definition |
-| `lsp_references` | Find all usages |
-| `lsp_hover` | Type info and docs |
 
 ### Verification
 

--- a/docs/WARDEN_AGENT_DESIGN.md
+++ b/docs/WARDEN_AGENT_DESIGN.md
@@ -69,9 +69,10 @@ not implement anything.
 **Goal:** Write and verify code until `review_code` returns APPROVE.
 
 **Tool selection:**
-LSP tools complement RAG tools. RAG (`search_code`) is better for "find things related
-to X" open-ended exploration. LSP (`lsp_definition`, `lsp_references`) is better for
-"where exactly is this symbol used" precision — and it is always current (no index lag).
+RAG tools (`search_code`, `get_symbol`) are best for semantic exploration ("find things related to X").
+Search tools (`grep`, `find`) are best for exact pattern search ("find all usages of `handleAuth`") and file
+discovery ("find all `*_test.go` files"). The agent uses `run_command("go build ./...")` for compile checks
+instead of LSP, which was removed to avoid 30–120 seconds of startup per session.
 
 **Verification ladder (cheapest first):**
 1. `write_file` / `edit_file` return gopls diagnostics automatically.
@@ -80,7 +81,7 @@ to X" open-ended exploration. LSP (`lsp_definition`, `lsp_references`) is better
 4. `review_code` — LLM-as-judge with full RAG context.
 
 **Iteration cap:**
-`max(config.MaxIterations * 10, 30)`. With `MaxIterations: 3` the cap is 30 loop
+`max(config.MaxIterations * 15, 50)`. With `MaxIterations: 3` the cap is 50 loop
 steps — enough for multi-file changes with several review cycles.
 
 **Compaction:**
@@ -104,38 +105,17 @@ completed-without-APPROVE loop is treated as a failure (`failSession`).
 
 ---
 
-## LSP Design
+## LSP Removal
 
-### Why LSP instead of more RAG?
+The Language Server Protocol client was removed from agent sessions. It added
+30–120 seconds of startup time per session and required per-language server
+binaries (`gopls`, `typescript-language-server`, etc.) on the host. The agent
+now uses `grep` for exact pattern search, `find` for file discovery, and
+`run_command("go build ./...")` for compile verification — which is faster and
+works across all programming languages without pre-installed servers.
 
-RAG vector search has inherent lag (documents must be indexed before they are
-searchable) and can return stale results when the agent is actively editing files.
-LSP talks directly to the compiler and is always authoritative.
-
-The two tools complement each other:
-- **RAG** for broad, semantic exploration ("what handles authentication?")
-- **LSP** for precise, structural navigation ("where is `handleAuth` called?")
-
-### Language server lifecycle
-
-Each `lsp.Client` starts its server as a subprocess over stdio with JSON-RPC 2.0
-Content-Length framing. The manager starts one client per detected language and
-routes tool calls by file extension. If a server binary is not found, that language
-silently falls back to RAG — no error is surfaced to the agent.
-
-### Extending to new languages
-
-Add one struct implementing `LanguageServer` to `server.go` and add it to
-`DefaultServers()`:
-
-```go
-type RustServer struct{}
-func (s *RustServer) Name()       string   { return "rust-analyzer" }
-func (s *RustServer) Extensions() []string { return []string{".rs"} }
-func (s *RustServer) Command(dir string) []string { return []string{"rust-analyzer"} }
-func (s *RustServer) Env()        []string { return nil }
-func (s *RustServer) LanguageID() string   { return "rust" }
-```
+The LSP package (`internal/agent/lsp/`) still exists for standalone use but is
+no longer started during workspace preparation.
 
 ---
 

--- a/internal/agent/file_tools.go
+++ b/internal/agent/file_tools.go
@@ -61,26 +61,43 @@ func (t *readFileTool) Execute(ctx context.Context, args map[string]any) (any, e
 		return nil, fmt.Errorf("read_file: %w", err)
 	}
 
-	lines := strings.Split(string(data), "\n")
+	allLines := strings.Split(string(data), "\n")
+	// A file ending with \n produces a trailing empty element — don't count it.
+	totalLines := len(allLines)
+	if totalLines > 0 && allLines[totalLines-1] == "" {
+		totalLines--
+	}
 
 	offset := parseIntArg(args, "offset")
 	if offset > 0 {
 		offset-- // convert 1-based to 0-based
 	}
-	if offset >= len(lines) {
+	if offset >= totalLines {
 		return map[string]any{"content": "", "lines": 0}, nil
 	}
-	lines = lines[offset:]
+	lines := allLines[offset:]
 
-	if limit := parseIntArg(args, "limit"); limit > 0 && limit < len(lines) {
+	limit := parseIntArg(args, "limit")
+	truncated := limit > 0 && limit < len(lines)
+	if truncated {
 		lines = lines[:limit]
 	}
 
-	return map[string]any{
+	result := map[string]any{
 		"content": strings.Join(lines, "\n"),
 		"lines":   len(lines),
 		"path":    relPath,
-	}, nil
+	}
+	if truncated {
+		nextOffset := offset + limit + 1 // 1-based for the user-facing parameter
+		result["total_lines"] = totalLines
+		result["truncated"] = true
+		result["hint"] = fmt.Sprintf(
+			"File has %d lines total; output stopped at line %d. Use offset=%d to read the next chunk.",
+			totalLines, offset+limit, nextOffset,
+		)
+	}
+	return result, nil
 }
 
 // writeFileTool writes (or creates) a file in the agent workspace.

--- a/internal/agent/inprocess.go
+++ b/internal/agent/inprocess.go
@@ -156,6 +156,36 @@ func (o *Orchestrator) buildNativeLoopWithObs(obs *loopObserver) loopBuilderFn {
 			allowedTools[t.Name()] = true
 		}
 
+		// Search tools (grep + find) — read-only, useful in native mode too.
+		for _, t := range searchTools() {
+			wrapped := &contextInjectingTool{
+				inner:       t,
+				projectRoot: ws.dir,
+				sessionID:   session.ID,
+			}
+			if err := registry.Register(wrapped); err != nil {
+				o.logger.Warn("runInProcessAgent: failed to register tool",
+					"tool", t.Name(), "error", err)
+				continue
+			}
+			allowedTools[t.Name()] = true
+		}
+
+		// File tools for native agent — needed for read/write/edit/list operations.
+		for _, t := range fileTools() {
+			wrapped := &contextInjectingTool{
+				inner:       t,
+				projectRoot: ws.dir,
+				sessionID:   session.ID,
+			}
+			if err := registry.Register(wrapped); err != nil {
+				o.logger.Warn("runInProcessAgent: failed to register tool",
+					"tool", t.Name(), "error", err)
+				continue
+			}
+			allowedTools[t.Name()] = true
+		}
+
 		governance := goframeagent.NewGovernance(&goframeagent.PermissionCheck{Allowed: allowedTools})
 
 		maxIter := max(o.config.MaxIterations*15, 50)

--- a/internal/agent/planner.go
+++ b/internal/agent/planner.go
@@ -100,6 +100,11 @@ func (o *Orchestrator) buildPlannerLoop(agentLLM llms.Model, session *Session, w
 		registerTool(registry, allowedTools, t, ws, session.ID, tracker, o.logger)
 	}
 
+	// Search tools (grep + find) — read-only, safe during planning.
+	for _, t := range searchTools() {
+		registerTool(registry, allowedTools, t, ws, session.ID, tracker, o.logger)
+	}
+
 	governance := goframeagent.NewGovernance(&goframeagent.PermissionCheck{Allowed: allowedTools})
 
 	loopLogger := o.logger.With("session_id", session.ID, "phase", "plan")

--- a/internal/agent/search_tools.go
+++ b/internal/agent/search_tools.go
@@ -1,0 +1,404 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/sevigo/code-warden/internal/mcp"
+	"github.com/sevigo/code-warden/internal/mcp/tools"
+)
+
+const (
+	grepDefaultLimit   = 50
+	grepMaxOutputBytes = 50 * 1024 // 50 KB
+	findDefaultLimit   = 200
+)
+
+// ── grep tool ─────────────────────────────────────────────────────────────────
+
+// grepTool searches file contents with ripgrep (or grep as fallback).
+// The binary is resolved once at construction time.
+type grepTool struct {
+	binary string // "rg" or "grep"
+}
+
+// newGrepTool constructs a grepTool, preferring ripgrep when available.
+func newGrepTool() *grepTool {
+	binary := "grep"
+	if _, err := exec.LookPath("rg"); err == nil {
+		binary = "rg"
+	}
+	return &grepTool{binary: binary}
+}
+
+func (t *grepTool) Name() string { return "grep" }
+
+func (t *grepTool) Description() string {
+	return `Search for a pattern inside files in the workspace.
+Uses ripgrep or grep. Returns matching lines in "file:line: content" format.
+Path is relative to the workspace root.`
+}
+
+func (t *grepTool) ParametersSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"pattern": map[string]any{
+				"type":        "string",
+				"description": "Search pattern (regular expression by default)",
+			},
+			"path": map[string]any{
+				"type":        "string",
+				"description": "Directory or file to search within the workspace (default: workspace root)",
+			},
+			"glob": map[string]any{
+				"type":        "string",
+				"description": "Restrict search to files matching this glob, e.g. *.go or **/*_test.go",
+			},
+			"ignore_case": map[string]any{
+				"type":        "boolean",
+				"description": "Case-insensitive search (default: false)",
+			},
+			"context": map[string]any{
+				"type":        "integer",
+				"description": "Lines of context to show before and after each match (default: 0)",
+			},
+			"limit": map[string]any{
+				"type":        "integer",
+				"description": fmt.Sprintf("Maximum output lines to return (default: %d)", grepDefaultLimit),
+			},
+		},
+		"required": []string{"pattern"},
+	}
+}
+
+func (t *grepTool) Execute(ctx context.Context, args map[string]any) (any, error) {
+	root := tools.ProjectRootFromContext(ctx)
+
+	pattern, ok := args["pattern"].(string)
+	if !ok || pattern == "" {
+		return nil, fmt.Errorf("pattern is required")
+	}
+
+	relPath := "."
+	if p, ok := args["path"].(string); ok && p != "" {
+		relPath = p
+	}
+
+	// Validate path stays within the workspace root.
+	if _, err := safeJoin(root, relPath); err != nil {
+		return nil, err
+	}
+
+	limit := grepDefaultLimit
+	if l := parseIntArg(args, "limit"); l > 0 {
+		limit = l
+	}
+
+	ignoreCase, _ := args["ignore_case"].(bool)
+	contextLines := parseIntArg(args, "context")
+	glob, _ := args["glob"].(string)
+
+	slog.Debug("grep tool",
+		"pattern", pattern, "path", relPath, "glob", glob,
+		"ignore_case", ignoreCase, "context", contextLines, "limit", limit,
+		"binary", t.binary)
+
+	cmdArgs := t.buildArgs(pattern, relPath, glob, ignoreCase, contextLines)
+	cmd := exec.CommandContext(ctx, t.binary, cmdArgs...) //nolint:gosec // binary is "rg" or "grep", relPath is safeJoin-validated
+	cmd.Dir = root                                        // paths in output are relative to workspace root
+
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = nil // exit code 1 from grep/rg means "no matches" — not an error
+
+	_ = cmd.Run() // non-zero exit is expected when no matches found
+
+	output := buf.String()
+
+	// Apply line limit.
+	limitReached := false
+	outputLines := strings.Split(output, "\n")
+	if len(outputLines) > limit {
+		outputLines = outputLines[:limit]
+		limitReached = true
+	}
+	output = strings.Join(outputLines, "\n")
+
+	// Apply byte limit.
+	truncated := false
+	if len(output) > grepMaxOutputBytes {
+		cut := strings.LastIndexByte(output[:grepMaxOutputBytes], '\n') + 1
+		if cut <= 0 {
+			cut = grepMaxOutputBytes
+		}
+		output = output[:cut] + "... [output truncated]"
+		truncated = true
+		limitReached = true
+	}
+
+	// Count non-blank, non-separator lines as the match count.
+	count := 0
+	for l := range strings.SplitSeq(output, "\n") {
+		if l != "" && l != "--" {
+			count++
+		}
+	}
+
+	result := map[string]any{
+		"output": strings.TrimRight(output, "\n"),
+		"count":  count,
+	}
+	if truncated {
+		result["truncated"] = true
+	}
+	if limitReached {
+		result["limit_reached"] = true
+		result["hint"] = fmt.Sprintf(
+			"Results may be incomplete (limit=%d). Use a more specific pattern or increase the limit parameter.",
+			limit,
+		)
+	}
+
+	slog.Info("grep tool result",
+		"pattern", pattern, "path", relPath, "count", count,
+		"truncated", truncated, "limit_reached", limitReached)
+
+	return result, nil
+}
+
+// buildArgs constructs the argument slice for rg or grep.
+func (t *grepTool) buildArgs(pattern, relPath, glob string, ignoreCase bool, contextLines int) []string {
+	if t.binary == "rg" {
+		return buildRgArgs(pattern, relPath, glob, ignoreCase, contextLines)
+	}
+	return buildGrepArgs(pattern, relPath, glob, ignoreCase, contextLines)
+}
+
+func buildRgArgs(pattern, relPath, glob string, ignoreCase bool, contextLines int) []string {
+	args := []string{"--no-heading", "--line-number"}
+	if glob != "" {
+		args = append(args, "--glob", glob)
+	}
+	if ignoreCase {
+		args = append(args, "-i")
+	}
+	if contextLines > 0 {
+		args = append(args, "-C", strconv.Itoa(contextLines))
+	}
+	return append(args, "--", pattern, relPath)
+}
+
+func buildGrepArgs(pattern, relPath, glob string, ignoreCase bool, contextLines int) []string {
+	args := []string{"-rn"}
+	if glob != "" {
+		args = append(args, "--include="+glob)
+	}
+	if ignoreCase {
+		args = append(args, "-i")
+	}
+	if contextLines > 0 {
+		args = append(args, "-C", strconv.Itoa(contextLines))
+	}
+	return append(args, "--", pattern, relPath)
+}
+
+// ── find tool ─────────────────────────────────────────────────────────────────
+
+// findTool lists workspace files matching a glob pattern.
+// Implemented in pure Go — no external binary required.
+type findTool struct{}
+
+func (t *findTool) Name() string { return "find" }
+
+func (t *findTool) Description() string {
+	return `Find files in the workspace by name pattern.
+Supports glob patterns including ** for multi-level matching (e.g. **/*_test.go).
+Path is relative to the workspace root.
+Skips .git and node_modules directories automatically.`
+}
+
+func (t *findTool) ParametersSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"pattern": map[string]any{
+				"type":        "string",
+				"description": "Glob pattern to match, e.g. *.go, **/*_test.go, internal/agent/*.go",
+			},
+			"path": map[string]any{
+				"type":        "string",
+				"description": "Directory to search within the workspace (default: workspace root)",
+			},
+			"limit": map[string]any{
+				"type":        "integer",
+				"description": fmt.Sprintf("Maximum number of files to return (default: %d)", findDefaultLimit),
+			},
+		},
+		"required": []string{"pattern"},
+	}
+}
+
+// skippedDirs contains directory names that are always excluded from find results.
+var skippedDirs = map[string]bool{
+	".git":         true,
+	"node_modules": true,
+	"vendor":       true,
+}
+
+func (t *findTool) Execute(ctx context.Context, args map[string]any) (any, error) {
+	root := tools.ProjectRootFromContext(ctx)
+
+	pattern, ok := args["pattern"].(string)
+	if !ok || pattern == "" {
+		return nil, fmt.Errorf("pattern is required")
+	}
+
+	relPath := "."
+	if p, ok := args["path"].(string); ok && p != "" {
+		relPath = p
+	}
+	searchRoot, err := safeJoin(root, relPath)
+	if err != nil {
+		return nil, err
+	}
+
+	limit := findDefaultLimit
+	if l := parseIntArg(args, "limit"); l > 0 {
+		limit = l
+	}
+
+	slog.Debug("find tool", "pattern", pattern, "path", relPath, "limit", limit)
+
+	var matches []string
+	truncated := false
+
+	walkFn := newFindWalkFn(root, searchRoot, pattern, limit, &matches, &truncated)
+	if err := filepath.WalkDir(searchRoot, walkFn); err != nil {
+		return nil, fmt.Errorf("find: %w", err)
+	}
+
+	result := map[string]any{
+		"files": matches,
+		"count": len(matches),
+	}
+	if truncated {
+		result["truncated"] = true
+		result["hint"] = fmt.Sprintf(
+			"Results truncated at %d files. Narrow the search path or use a more specific pattern.",
+			limit,
+		)
+	}
+	slog.Info("find tool result",
+		"pattern", pattern, "path", relPath, "count", len(matches), "truncated", truncated)
+
+	return result, nil
+}
+
+// newFindWalkFn returns a filepath.WalkDir callback that collects files
+// matching pattern, appending workspace-relative paths to *matches and setting
+// *truncated when limit is reached.
+func newFindWalkFn(root, searchRoot, pattern string, limit int, matches *[]string, truncated *bool) fs.WalkDirFunc {
+	return func(absPath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			if skippedDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(root, absPath)
+		if relErr != nil {
+			return nil //nolint:nilerr // paths derived from root; Rel only fails on unrooted inputs
+		}
+		rel = filepath.ToSlash(rel)
+
+		relToSearch, relErr := filepath.Rel(searchRoot, absPath)
+		if relErr != nil {
+			return nil //nolint:nilerr // same guarantee as above
+		}
+
+		if !matchGlob(pattern, filepath.ToSlash(relToSearch)) {
+			return nil
+		}
+
+		if len(*matches) >= limit {
+			*truncated = true
+			return fs.SkipAll
+		}
+		*matches = append(*matches, rel)
+		return nil
+	}
+}
+
+// matchGlob reports whether relPath matches the given glob pattern.
+// Supports ** as a multi-segment wildcard and bare patterns (no /) as
+// basename-only matches.
+func matchGlob(pattern, relPath string) bool {
+	pattern = filepath.ToSlash(pattern)
+	relPath = filepath.ToSlash(relPath)
+
+	if !strings.Contains(pattern, "**") {
+		if !strings.Contains(pattern, "/") {
+			// Basename-only: *.go, foo.go
+			m, _ := path.Match(pattern, path.Base(relPath))
+			return m
+		}
+		// Path-rooted: internal/agent/*.go
+		m, _ := path.Match(pattern, relPath)
+		return m
+	}
+	return matchDoublestar(pattern, relPath)
+}
+
+// matchDoublestar matches a pattern that contains at least one ** against s.
+// ** matches zero or more path segments.
+func matchDoublestar(pattern, s string) bool {
+	prefix, after, _ := strings.Cut(pattern, "**")
+	rest := strings.TrimPrefix(after, "/")
+
+	// The prefix (everything before **) must match the beginning of s.
+	if prefix != "" {
+		if !strings.HasPrefix(s+"/", prefix) {
+			return false
+		}
+		s = strings.TrimPrefix(s, strings.TrimSuffix(prefix, "/"))
+		s = strings.TrimPrefix(s, "/")
+	}
+
+	// ** matches zero or more segments. Try each possible split.
+	if rest == "" {
+		return true // trailing ** matches everything
+	}
+	parts := strings.Split(s, "/")
+	for i := 0; i <= len(parts); i++ {
+		candidate := strings.Join(parts[i:], "/")
+		if matchGlob(rest, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+// searchTools returns the workspace search tools (grep + find).
+// Both are read-only and safe to register in the planner loop.
+func searchTools() []mcp.Tool {
+	return []mcp.Tool{
+		newGrepTool(),
+		&findTool{},
+	}
+}

--- a/internal/agent/search_tools_test.go
+++ b/internal/agent/search_tools_test.go
@@ -1,0 +1,300 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sevigo/code-warden/internal/mcp/tools"
+)
+
+// newSearchCtx builds a context with the given temp dir as workspace root.
+func newSearchCtx(dir string) context.Context {
+	return tools.WithProjectRoot(context.Background(), dir)
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func writeSearchFixture(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	abs := filepath.Join(dir, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o750))
+	require.NoError(t, os.WriteFile(abs, []byte(content), 0o644))
+}
+
+// ── grep tests ────────────────────────────────────────────────────────────────
+
+func TestGrepTool_FindsPattern(t *testing.T) {
+	dir := t.TempDir()
+	writeSearchFixture(t, dir, "src/foo.go", "package foo\n\nfunc Hello() string { return \"hello\" }\n")
+	writeSearchFixture(t, dir, "src/bar.go", "package bar\n\nfunc World() {}\n")
+
+	gt := newGrepTool()
+	ctx := newSearchCtx(dir)
+
+	result, err := gt.Execute(ctx, map[string]any{"pattern": "Hello"})
+	require.NoError(t, err)
+
+	m, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, m["output"], "Hello")
+	assert.Greater(t, m["count"], 0)
+}
+
+func TestGrepTool_GlobFilter(t *testing.T) {
+	dir := t.TempDir()
+	writeSearchFixture(t, dir, "main.go", "target")
+	writeSearchFixture(t, dir, "main.txt", "target")
+
+	gt := newGrepTool()
+	ctx := newSearchCtx(dir)
+
+	result, err := gt.Execute(ctx, map[string]any{
+		"pattern": "target",
+		"glob":    "*.go",
+	})
+	require.NoError(t, err)
+
+	m := result.(map[string]any)
+	output, _ := m["output"].(string)
+	assert.Contains(t, output, "main.go")
+	assert.NotContains(t, output, "main.txt")
+}
+
+func TestGrepTool_LimitRespected(t *testing.T) {
+	dir := t.TempDir()
+	// Write a file with 10 matching lines.
+	content := ""
+	for range 10 {
+		content += "match here\n"
+	}
+	writeSearchFixture(t, dir, "file.go", content)
+
+	gt := newGrepTool()
+	ctx := newSearchCtx(dir)
+
+	result, err := gt.Execute(ctx, map[string]any{
+		"pattern": "match",
+		"limit":   3,
+	})
+	require.NoError(t, err)
+
+	m := result.(map[string]any)
+	assert.Equal(t, true, m["limit_reached"])
+	// count should be <= 3 + possible blank trailing line
+	count, _ := m["count"].(int)
+	assert.LessOrEqual(t, count, 4)
+}
+
+func TestGrepTool_PathEscapeRejected(t *testing.T) {
+	dir := t.TempDir()
+	gt := newGrepTool()
+	ctx := newSearchCtx(dir)
+
+	_, err := gt.Execute(ctx, map[string]any{
+		"pattern": "x",
+		"path":    "../etc",
+	})
+	assert.Error(t, err)
+}
+
+func TestGrepTool_NoMatchesReturnsEmptyOutput(t *testing.T) {
+	dir := t.TempDir()
+	writeSearchFixture(t, dir, "a.go", "package a\n")
+
+	gt := newGrepTool()
+	ctx := newSearchCtx(dir)
+
+	result, err := gt.Execute(ctx, map[string]any{"pattern": "zzz_nomatch_zzz"})
+	require.NoError(t, err)
+
+	m := result.(map[string]any)
+	assert.Equal(t, 0, m["count"])
+}
+
+// ── find tests ────────────────────────────────────────────────────────────────
+
+func TestFindTool_GlobBasename(t *testing.T) {
+	dir := t.TempDir()
+	writeSearchFixture(t, dir, "src/foo.go", "")
+	writeSearchFixture(t, dir, "src/bar.go", "")
+	writeSearchFixture(t, dir, "src/readme.txt", "")
+
+	ft := &findTool{}
+	ctx := newSearchCtx(dir)
+
+	result, err := ft.Execute(ctx, map[string]any{"pattern": "*.go"})
+	require.NoError(t, err)
+
+	m := result.(map[string]any)
+	files, _ := m["files"].([]string)
+	assert.Len(t, files, 2)
+	for _, f := range files {
+		assert.Regexp(t, `\.go$`, f)
+	}
+}
+
+func TestFindTool_DoubleStarGlob(t *testing.T) {
+	dir := t.TempDir()
+	writeSearchFixture(t, dir, "a/foo_test.go", "")
+	writeSearchFixture(t, dir, "a/b/bar_test.go", "")
+	writeSearchFixture(t, dir, "a/nottest.go", "")
+
+	ft := &findTool{}
+	ctx := newSearchCtx(dir)
+
+	result, err := ft.Execute(ctx, map[string]any{"pattern": "**/*_test.go"})
+	require.NoError(t, err)
+
+	m := result.(map[string]any)
+	files, _ := m["files"].([]string)
+	assert.Len(t, files, 2)
+	for _, f := range files {
+		assert.Regexp(t, `_test\.go$`, f)
+	}
+}
+
+func TestFindTool_SkipsGitDir(t *testing.T) {
+	dir := t.TempDir()
+	writeSearchFixture(t, dir, ".git/HEAD", "ref: refs/heads/main")
+	writeSearchFixture(t, dir, "src/main.go", "")
+
+	ft := &findTool{}
+	ctx := newSearchCtx(dir)
+
+	result, err := ft.Execute(ctx, map[string]any{"pattern": "*"})
+	require.NoError(t, err)
+
+	m := result.(map[string]any)
+	files, _ := m["files"].([]string)
+	for _, f := range files {
+		assert.NotContains(t, f, ".git")
+	}
+}
+
+func TestFindTool_LimitRespected(t *testing.T) {
+	dir := t.TempDir()
+	for i := range 10 {
+		writeSearchFixture(t, dir, filepath.Join("src", filepath.FromSlash("file"+string(rune('a'+i))+".go")), "")
+	}
+
+	ft := &findTool{}
+	ctx := newSearchCtx(dir)
+
+	result, err := ft.Execute(ctx, map[string]any{"pattern": "*.go", "limit": 3})
+	require.NoError(t, err)
+
+	m := result.(map[string]any)
+	files, _ := m["files"].([]string)
+	assert.Len(t, files, 3)
+	assert.Equal(t, true, m["truncated"])
+}
+
+func TestFindTool_PathEscapeRejected(t *testing.T) {
+	dir := t.TempDir()
+	ft := &findTool{}
+	ctx := newSearchCtx(dir)
+
+	_, err := ft.Execute(ctx, map[string]any{
+		"pattern": "*.go",
+		"path":    "../etc",
+	})
+	assert.Error(t, err)
+}
+
+func TestFindTool_ScopedToSubdir(t *testing.T) {
+	dir := t.TempDir()
+	writeSearchFixture(t, dir, "internal/agent/foo.go", "")
+	writeSearchFixture(t, dir, "cmd/main.go", "")
+
+	ft := &findTool{}
+	ctx := newSearchCtx(dir)
+
+	result, err := ft.Execute(ctx, map[string]any{
+		"pattern": "*.go",
+		"path":    "internal",
+	})
+	require.NoError(t, err)
+
+	m := result.(map[string]any)
+	files, _ := m["files"].([]string)
+	require.Len(t, files, 1)
+	assert.Contains(t, files[0], "internal")
+}
+
+// ── matchGlob unit tests ──────────────────────────────────────────────────────
+
+func TestMatchGlob_Basename(t *testing.T) {
+	assert.True(t, matchGlob("*.go", "foo.go"))
+	assert.True(t, matchGlob("*.go", "src/foo.go"))
+	assert.False(t, matchGlob("*.go", "foo.txt"))
+}
+
+func TestMatchGlob_WithPath(t *testing.T) {
+	assert.True(t, matchGlob("internal/agent/*.go", "internal/agent/foo.go"))
+	assert.False(t, matchGlob("internal/agent/*.go", "internal/other/foo.go"))
+}
+
+func TestMatchGlob_DoubleStar(t *testing.T) {
+	assert.True(t, matchGlob("**/*_test.go", "foo_test.go"))
+	assert.True(t, matchGlob("**/*_test.go", "a/b/foo_test.go"))
+	assert.False(t, matchGlob("**/*_test.go", "a/b/foo.go"))
+	assert.True(t, matchGlob("**/*.go", "main.go"))
+	assert.True(t, matchGlob("**/*.go", "a/b/c/main.go"))
+}
+
+func TestMatchGlob_DoubleStarWithPrefix(t *testing.T) {
+	assert.True(t, matchGlob("internal/**/*.go", "internal/agent/foo.go"))
+	assert.True(t, matchGlob("internal/**/*.go", "internal/a/b/foo.go"))
+	assert.False(t, matchGlob("internal/**/*.go", "cmd/main.go"))
+}
+
+// ── read_file continuation hint tests ────────────────────────────────────────
+
+func TestReadFileTool_TruncationHint(t *testing.T) {
+	dir := t.TempDir()
+	// Write a 20-line file.
+	content := ""
+	for i := range 20 {
+		content += "line " + strconv.Itoa(i+1) + "\n"
+	}
+	writeSearchFixture(t, dir, "big.go", content)
+
+	rt := &readFileTool{}
+	ctx := newSearchCtx(dir)
+
+	result, err := rt.Execute(ctx, map[string]any{
+		"path":  "big.go",
+		"limit": 5,
+	})
+	require.NoError(t, err)
+
+	m := result.(map[string]any)
+	assert.Equal(t, true, m["truncated"])
+	assert.Equal(t, 20, m["total_lines"])
+	hint, _ := m["hint"].(string)
+	assert.Contains(t, hint, "offset=")
+	assert.Contains(t, hint, "20 lines")
+}
+
+func TestReadFileTool_NoHintWhenNotTruncated(t *testing.T) {
+	dir := t.TempDir()
+	writeSearchFixture(t, dir, "small.go", "line1\nline2\n")
+
+	rt := &readFileTool{}
+	ctx := newSearchCtx(dir)
+
+	result, err := rt.Execute(ctx, map[string]any{"path": "small.go"})
+	require.NoError(t, err)
+
+	m := result.(map[string]any)
+	_, hasTruncated := m["truncated"]
+	assert.False(t, hasTruncated)
+	_, hasHint := m["hint"]
+	assert.False(t, hasHint)
+}

--- a/internal/agent/warden.go
+++ b/internal/agent/warden.go
@@ -5,7 +5,8 @@ package agent
 // Runs two sequential agent loops with minimal, phase-appropriate tool sets:
 //
 //  Loop 1 — Implement:
-//    search_code, file tools, LSP tools, run_command, review_code
+//    search_code, file tools (read/write/edit/list_dir), search tools (grep/find),
+//    run_command, review_code
 //    (no push_branch / create_pull_request)
 //    Terminates when review_code returns APPROVE or max iterations reached.
 //
@@ -337,6 +338,11 @@ func (o *Orchestrator) buildImplementLoop(agentLLM llms.Model, session *Session,
 
 	// File tools (no LSP — agent uses run_command for compile checks).
 	for _, t := range fileTools() {
+		registerTool(registry, allowedTools, t, ws, session.ID, tracker, o.logger)
+	}
+
+	// Search tools (grep + find) — read-only, no workspace modifications.
+	for _, t := range searchTools() {
 		registerTool(registry, allowedTools, t, ws, session.ID, tracker, o.logger)
 	}
 


### PR DESCRIPTION
## Summary

Adds the three highest-priority agent exploration tools from the Pi coding agent analysis, plus fixes a gap in the native agent loop and updates all documentation.

### New tools

- **`grep`** — Searches file contents by regex/literal pattern. Uses ripgrep with grep fallback. Supports glob filter, case-insensitive mode, context lines, and output truncation (50 KB / 50 lines). Returns `{output, count, truncated?, limit_reached?, hint?}`.
- **`find`** — Lists files by glob pattern including `**` for multi-level matching. Pure Go `filepath.WalkDir`. Skips `.git`, `node_modules`, `vendor`. Limits to 200 results. Returns `{files, count, truncated?, hint?}`.
- **`read_file` hints** — When paginated (`limit` param), result now includes `total_lines`, `truncated: true`, and `hint` with the next offset to read.

### Tool registration

- Planner loop: `grep` + `find` registered (read-only, safe during planning)
- Implement loop: `grep` + `find` registered
- Native in-process loop: `grep` + `find` + `fileTools()` registered (previously had only MCP server tools)

### Logging

- `grep` and `find` log calls at `slog.Debug` and results at `slog.Info` for observability during agent execution

### Documentation updates

- `IMPLEMENT_ARCHITECTURE.md`: Updated tool tables, removed LSP section (replaced with LSP removal note), added grep/find descriptions, fixed iteration caps (30→50), updated read_file and edit_file descriptions
- `WARDEN_AGENT_DESIGN.md`: Replaced LSP section with LSP removal note, updated iteration caps, updated tool selection description
- `CLAUDE.md`: Added grep/find to tool list, updated file tools section with read_file hints and edit_file CRLF/BOM handling

### Test coverage

- 5 grep tests: FindsPattern, GlobFilter, LimitRespected, PathEscapeRejected, NoMatchesReturnsEmptyOutput
- 6 find tests: GlobBasename, DoubleStarGlob, SkipsGitDir, LimitRespected, PathEscapeRejected, ScopedToSubdir
- 4 matchGlob unit tests: Basename, WithPath, DoubleStar, DoubleStarWithPrefix
- 2 read_file hint tests: TruncationHint, NoHintWhenNotTruncated

## Test plan

- [x] `go build ./...` passes
- [x] `make lint` passes with 0 issues
- [x] `go test ./...` passes all packages
- [x] grep tool finds patterns, filters by glob, respects limits, rejects path escape
- [x] find tool matches basenames, double-star globs, skips .git, respects limit, rejects path escape
- [x] read_file returns total_lines, truncated, hint when paginated
- [x] Native in-process loop now has file tools + search tools
- [x] All logging calls visible in test output