### PR TITLE
fix: run_command whitelist, reranker bug, multi-edit partial application

### DIFF
--- a/internal/agent/file_tools.go
+++ b/internal/agent/file_tools.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -254,6 +255,10 @@ func (t *editFileTool) Execute(ctx context.Context, args map[string]any) (any, e
 
 	updated, usedFuzzy, err := applyMultiEdit(working, normalizedPairs)
 	if err != nil {
+		var pe *partialEditError
+		if errors.As(err, &pe) {
+			return handlePartialEdit(abs, relPath, original, updated, lineEnding, hasBOM, usedFuzzy, pe, err)
+		}
 		return nil, fmt.Errorf("edit_file: %w", err)
 	}
 
@@ -449,4 +454,30 @@ func parseIntArg(args map[string]any, key string) int {
 	default:
 		return 0
 	}
+}
+
+func handlePartialEdit(abs, relPath, original, working, lineEnding string, hasBOM, usedFuzzy bool, pe *partialEditError, origErr error) (map[string]any, error) {
+	partialResult := restoreLineEndings(working, lineEnding)
+	partialResult = prependBOM(partialResult, hasBOM)
+	if writeErr := os.WriteFile(abs, []byte(partialResult), 0o644); writeErr != nil { //nolint:gosec // G306: 0644 is intentional for source files
+		return nil, fmt.Errorf("edit_file: partial edit write failed: %w", writeErr)
+	}
+
+	diffStr := buildUnifiedDiff(original, partialResult, relPath)
+	result := map[string]any{
+		"ok":            false,
+		"path":          relPath,
+		"partial":       true,
+		"applied_edits": pe.TotalEdits - len(pe.FailedIndices),
+		"failed_edits":  pe.FailedIndices,
+		"total_edits":   pe.TotalEdits,
+		"error":         origErr.Error(),
+	}
+	if usedFuzzy {
+		result["fuzzy_match"] = true
+	}
+	if diffStr != "" {
+		result["diff"] = diffStr
+	}
+	return result, nil
 }

--- a/internal/agent/file_tools.go
+++ b/internal/agent/file_tools.go
@@ -257,7 +257,10 @@ func (t *editFileTool) Execute(ctx context.Context, args map[string]any) (any, e
 	if err != nil {
 		var pe *partialEditError
 		if errors.As(err, &pe) {
-			return handlePartialEdit(abs, relPath, original, updated, lineEnding, hasBOM, usedFuzzy, pe, err)
+			return handlePartialEdit(editContext{
+				abs: abs, relPath: relPath, original: original, working: updated,
+				lineEnding: lineEnding, hasBOM: hasBOM, usedFuzzy: usedFuzzy,
+			}, pe, err)
 		}
 		return nil, fmt.Errorf("edit_file: %w", err)
 	}
@@ -456,28 +459,40 @@ func parseIntArg(args map[string]any, key string) int {
 	}
 }
 
-func handlePartialEdit(abs, relPath, original, working, lineEnding string, hasBOM, usedFuzzy bool, pe *partialEditError, origErr error) (map[string]any, error) {
-	partialResult := restoreLineEndings(working, lineEnding)
-	partialResult = prependBOM(partialResult, hasBOM)
-	if writeErr := os.WriteFile(abs, []byte(partialResult), 0o644); writeErr != nil { //nolint:gosec // G306: 0644 is intentional for source files
-		return nil, fmt.Errorf("edit_file: partial edit write failed: %w", writeErr)
-	}
+// editContext holds file metadata needed to restore line endings and BOM
+// after a partial edit, and to generate a diff for the LLM.
+type editContext struct {
+	abs, relPath, original, working, lineEnding string
+	hasBOM, usedFuzzy                           bool
+}
 
-	diffStr := buildUnifiedDiff(original, partialResult, relPath)
+func handlePartialEdit(ctx editContext, pe *partialEditError, origErr error) (map[string]any, error) {
+	appliedCount := pe.TotalEdits - len(pe.FailedIndices)
 	result := map[string]any{
 		"ok":            false,
-		"path":          relPath,
+		"path":          ctx.relPath,
 		"partial":       true,
-		"applied_edits": pe.TotalEdits - len(pe.FailedIndices),
+		"applied_edits": appliedCount,
 		"failed_edits":  pe.FailedIndices,
 		"total_edits":   pe.TotalEdits,
 		"error":         origErr.Error(),
 	}
-	if usedFuzzy {
+	if ctx.usedFuzzy {
 		result["fuzzy_match"] = true
 	}
-	if diffStr != "" {
-		result["diff"] = diffStr
+
+	// Only write to disk if at least one edit succeeded.
+	if appliedCount > 0 {
+		partialResult := restoreLineEndings(ctx.working, ctx.lineEnding)
+		partialResult = prependBOM(partialResult, ctx.hasBOM)
+		if writeErr := os.WriteFile(ctx.abs, []byte(partialResult), 0o644); writeErr != nil { //nolint:gosec // G306: 0644 is intentional for source files
+			return nil, fmt.Errorf("edit_file: partial edit write failed: %w", writeErr)
+		}
+		diffStr := buildUnifiedDiff(ctx.original, partialResult, ctx.relPath)
+		if diffStr != "" {
+			result["diff"] = diffStr
+		}
 	}
+
 	return result, nil
 }

--- a/internal/agent/fuzzy_edit.go
+++ b/internal/agent/fuzzy_edit.go
@@ -363,6 +363,10 @@ func descendingOrder(matches []matchResult) []int {
 // applyEdit performs a single text replacement using exact-then-fuzzy matching.
 // It delegates to applyMultiEdit with a one-element slice.
 //
+// Note: when the edit is not found, applyMultiEdit returns a partialEditError
+// (with FailedIndices=[0]). Callers that need to distinguish "not found" from
+// other errors should check for *partialEditError via errors.As.
+//
 // WARNING: When fuzzy matching is used, the returned content is the
 // NFKC-normalized form of the entire file. This means characters outside
 // the edited region (smart quotes, ligatures, special spaces) will be

--- a/internal/agent/fuzzy_edit.go
+++ b/internal/agent/fuzzy_edit.go
@@ -194,7 +194,7 @@ type matchResult struct {
 	matchLen int
 }
 
-// applyMultiEdit applies multiple (old→new) replacements atomically.
+// applyMultiEdit applies multiple (old→new) replacements.
 // If any pair requires fuzzy matching the entire content is normalised first,
 // ensuring all replacements operate in a consistent character space.
 // Replacements are applied in descending position order so earlier indices
@@ -203,6 +203,10 @@ type matchResult struct {
 // Rules (mirroring Pi's applyEditsToNormalizedContent):
 //   - Each OldStr must match exactly once (error if 0 or >1 occurrences).
 //   - No two matches may overlap (error if they do).
+//
+// If some edits match but others fail, the successful edits are still applied
+// and the returned error lists the failed edit indices. The caller can decide
+// whether to keep the partial result.
 //
 // WARNING: When fuzzy matching is used the returned content is the
 // NFKC-normalised form of the entire file — characters outside the edited
@@ -230,19 +234,60 @@ func applyMultiEdit(content string, edits []editPair) (string, bool, error) {
 		}
 	}
 
-	// Phase 3: validate no overlapping ranges.
-	if err := validateNoOverlaps(matches); err != nil {
+	// Phase 3: separate successful and failed matches.
+	var succeeded []int
+	var failedIndices []int
+	for i, m := range matches {
+		if m.found {
+			succeeded = append(succeeded, i)
+		} else {
+			failedIndices = append(failedIndices, i)
+		}
+	}
+
+	// Phase 4: validate no overlapping ranges among succeeded matches.
+	succeededMatches := make([]matchResult, 0, len(succeeded))
+	for _, i := range succeeded {
+		succeededMatches = append(succeededMatches, matches[i])
+	}
+	if err := validateNoOverlaps(succeededMatches); err != nil {
 		return "", false, err
 	}
 
-	// Phase 4: sort by position descending and apply in that order.
-	order := descendingOrder(matches)
+	// Phase 5: sort by position descending and apply in that order.
+	order := descendingOrder(succeededMatches)
 	out := working
-	for _, i := range order {
-		m := matches[i]
-		out = out[:m.index] + edits[i].NewStr + out[m.index+m.matchLen:]
+	for _, idx := range order {
+		// idx is an index into succeededMatches, which corresponds to
+		// succeeded[idx] in the original edits slice. We need the original
+		// edit index to look up the match and replacement.
+		origIdx := succeeded[idx]
+		m := matches[origIdx]
+		out = out[:m.index] + edits[origIdx].NewStr + out[m.index+m.matchLen:]
 	}
+
+	if len(failedIndices) > 0 {
+		return out, needsFuzzy, &partialEditError{
+			FailedIndices: failedIndices,
+			TotalEdits:    len(edits),
+		}
+	}
+
 	return out, needsFuzzy, nil
+}
+
+// partialEditError is returned when some edits in a multi-edit batch
+// succeeded but others failed. The caller can inspect FailedIndices to know
+// which edits were not applied. The returned content contains all successful
+// edits already applied.
+type partialEditError struct {
+	FailedIndices []int
+	TotalEdits    int
+}
+
+func (e *partialEditError) Error() string {
+	return fmt.Sprintf("edit_file: applied %d of %d edits; edits at indices %v not found",
+		e.TotalEdits-len(e.FailedIndices), e.TotalEdits, e.FailedIndices)
 }
 
 // exactMatches tries an exact string count for each edit.
@@ -265,8 +310,9 @@ func exactMatches(content string, edits []editPair) ([]matchResult, bool, error)
 }
 
 // fuzzyMatches re-resolves all edit positions in the already-normalised working
-// content. Every edit is normalised and searched; missing or ambiguous matches
-// are hard errors.
+// content. Ambiguous matches (more than one occurrence) are hard errors.
+// Missing matches return a zero-value matchResult (found=false) so the caller
+// can apply partial edits.
 func fuzzyMatches(working string, edits []editPair) ([]matchResult, error) {
 	matches := make([]matchResult, len(edits))
 	for i, e := range edits {
@@ -274,11 +320,13 @@ func fuzzyMatches(working string, edits []editPair) ([]matchResult, error) {
 		cnt := strings.Count(working, normOld)
 		switch {
 		case cnt == 0:
-			return nil, fmt.Errorf("edit_file: edits[%d] old_string not found (tried exact match and fuzzy normalization)", i)
+			// Not found — leave as zero-value (found=false). Caller decides
+			// whether to proceed with partial edits.
 		case cnt > 1:
 			return nil, fmt.Errorf("edit_file: edits[%d] old_string appears %d times after normalization; provide more context to make it unique", i, cnt)
+		default:
+			matches[i] = matchResult{found: true, index: strings.Index(working, normOld), matchLen: len(normOld)}
 		}
-		matches[i] = matchResult{found: true, index: strings.Index(working, normOld), matchLen: len(normOld)}
 	}
 	return matches, nil
 }

--- a/internal/agent/fuzzy_edit_test.go
+++ b/internal/agent/fuzzy_edit_test.go
@@ -247,11 +247,14 @@ func TestApplyMultiEdit_OverlapError(t *testing.T) {
 
 func TestApplyMultiEdit_NotFoundError(t *testing.T) {
 	content := "hello world"
-	_, _, err := applyMultiEdit(content, []editPair{
+	result, _, err := applyMultiEdit(content, []editPair{
 		{OldStr: "nonexistent", NewStr: "x"},
 	})
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "not found")
+	var pe *partialEditError
+	assert.ErrorAs(t, err, &pe)
+	assert.Equal(t, []int{0}, pe.FailedIndices)
+	assert.Equal(t, content, result, "content should be unchanged when all edits fail")
 }
 
 func TestApplyMultiEdit_AmbiguousMatchError(t *testing.T) {
@@ -261,6 +264,57 @@ func TestApplyMultiEdit_AmbiguousMatchError(t *testing.T) {
 	})
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "2 times")
+}
+
+func TestApplyMultiEdit_PartialEdit(t *testing.T) {
+	content := "const A = 1\nconst B = 2\nconst C = 3\n"
+	result, fuzzy, err := applyMultiEdit(content, []editPair{
+		{OldStr: "A = 1", NewStr: "A = 10"},  // found
+		{OldStr: "nonexistent", NewStr: "X"}, // not found
+		{OldStr: "C = 3", NewStr: "C = 30"},  // found
+	})
+	assert.Error(t, err)
+	var pe *partialEditError
+	assert.ErrorAs(t, err, &pe)
+	assert.Equal(t, []int{1}, pe.FailedIndices)
+	assert.Equal(t, 3, pe.TotalEdits)
+	assert.True(t, fuzzy, "fuzzy mode activated because one edit missed exactly")
+	assert.Contains(t, result, "A = 10")
+	assert.Contains(t, result, "C = 30")
+	assert.Contains(t, result, "B = 2") // unchanged
+}
+
+func TestApplyMultiEdit_PartialEdit_AllFail(t *testing.T) {
+	content := "hello world"
+	result, _, err := applyMultiEdit(content, []editPair{
+		{OldStr: "nonexistent", NewStr: "x"},
+		{OldStr: "also_missing", NewStr: "y"},
+	})
+	assert.Error(t, err)
+	var pe *partialEditError
+	assert.ErrorAs(t, err, &pe)
+	assert.Equal(t, []int{0, 1}, pe.FailedIndices)
+	assert.Equal(t, content, result, "content unchanged when all edits fail")
+}
+
+func TestApplyMultiEdit_PartialEdit_WithFuzzy(t *testing.T) {
+	content := "A \u00A0= 1\nB = 2\n" // NBSP in file content
+	result, fuzzy, err := applyMultiEdit(content, []editPair{
+		{OldStr: "A \u00A0= 1", NewStr: "A = 10"}, // NBSP in old_string → fuzzy match
+		{OldStr: "Z_missing", NewStr: "X"},        // not found even with fuzzy
+	})
+	assert.Error(t, err)
+	var pe *partialEditError
+	assert.ErrorAs(t, err, &pe)
+	assert.Equal(t, []int{1}, pe.FailedIndices)
+	assert.True(t, fuzzy)
+	assert.Contains(t, result, "A = 10")
+	assert.Contains(t, result, "B = 2")
+}
+
+func TestPartialEditError_Message(t *testing.T) {
+	pe := &partialEditError{FailedIndices: []int{2, 5}, TotalEdits: 7}
+	assert.Equal(t, "edit_file: applied 5 of 7 edits; edits at indices [2 5] not found", pe.Error())
 }
 
 func TestApplyMultiEdit_FuzzySmartQuotes(t *testing.T) {

--- a/internal/agent/warden.go
+++ b/internal/agent/warden.go
@@ -417,13 +417,13 @@ Working directory: %s
 - list_dir(path?) — list directory contents
 
 **Verification**:
-- run_command(command) — run whitelisted commands: "make lint", "make test"
+- run_command(command) — run whitelisted commands: "make build", "make lint", "make test"
 - review_code — request an automated code review of your changes
 
 ## Workflow
 1. **Explore** — use grep / search_code / get_symbol / read_file to understand the code. Prefer grep for exact pattern search, search_code for semantic discovery.
 2. **Implement** — use write_file / edit_file. Prefer edit_file for targeted changes.
-3. **Verify** — run_command("make lint"), then run_command("make test"). Fix failures.
+3. **Verify** — run_command("make build"), then run_command("make lint"), then run_command("make test"). Fix failures.
 4. **Review** — call review_code. If REQUEST_CHANGES, fix and re-verify. Repeat until APPROVE.
 
 ## Rules

--- a/internal/agent/workspace.go
+++ b/internal/agent/workspace.go
@@ -80,7 +80,7 @@ func (o *Orchestrator) prepareAgentWorkspace(ctx context.Context, session *Sessi
 		traceFile = nil
 	}
 
-	// Start LSP manager removed — agent uses run_command("go build ./...")
+	// Start LSP manager removed — agent uses run_command("make build")
 	// for compile checks instead. 30-120s LSP startup is not worth it
 	// when the model can verify with `make lint` / `make test`.
 

--- a/internal/llm/prompt_manager.go
+++ b/internal/llm/prompt_manager.go
@@ -80,6 +80,11 @@ func (pm *PromptManager) Get(key PromptKey) (*template.Template, error) {
 	return tmpl, nil
 }
 
+// Raw returns the un-rendered template source for a prompt key.
+// Use this (instead of Render) when the template will be rendered by an
+// external system (e.g. goframe's LLMReranker) that provides its own data
+// at runtime. Render(key, nil) is explicitly NOT what you want for this
+// case — it replaces all {{.Field}} placeholders with "<no value>".
 func (pm *PromptManager) Raw(key PromptKey) (string, error) {
 	s, ok := pm.raw[key]
 	if !ok {

--- a/internal/llm/prompt_manager.go
+++ b/internal/llm/prompt_manager.go
@@ -33,11 +33,13 @@ const (
 
 type PromptManager struct {
 	prompts map[PromptKey]*template.Template
+	raw     map[PromptKey]string
 }
 
 func NewPromptManager() (*PromptManager, error) {
 	pm := &PromptManager{
 		prompts: make(map[PromptKey]*template.Template),
+		raw:     make(map[PromptKey]string),
 	}
 
 	files, err := promptFiles.ReadDir("prompts")
@@ -64,6 +66,7 @@ func NewPromptManager() (*PromptManager, error) {
 		}
 
 		pm.prompts[key] = tmpl
+		pm.raw[key] = string(content)
 	}
 
 	return pm, nil
@@ -75,6 +78,14 @@ func (pm *PromptManager) Get(key PromptKey) (*template.Template, error) {
 		return nil, fmt.Errorf("no prompt found for key '%s'", key)
 	}
 	return tmpl, nil
+}
+
+func (pm *PromptManager) Raw(key PromptKey) (string, error) {
+	s, ok := pm.raw[key]
+	if !ok {
+		return "", fmt.Errorf("no prompt found for key '%s'", key)
+	}
+	return s, nil
 }
 
 func (pm *PromptManager) Render(key PromptKey, data any) (string, error) {

--- a/internal/llm/prompt_manager_test.go
+++ b/internal/llm/prompt_manager_test.go
@@ -39,6 +39,11 @@ func TestPromptManager_Raw_NotFound(t *testing.T) {
 	}
 }
 
+// TestPromptManager_Render_WithNilProducesNoValue verifies that
+// Render(key, nil) replaces template variables with "<no value>". This is
+// intentional — templates that need runtime data must use Raw() instead.
+// This test documents the behavior to prevent accidental misuse of Render
+// for templates consumed by external renderers (e.g. goframe reranker).
 func TestPromptManager_Render_WithNilProducesNoValue(t *testing.T) {
 	pm, err := NewPromptManager()
 	if err != nil {

--- a/internal/llm/prompt_manager_test.go
+++ b/internal/llm/prompt_manager_test.go
@@ -1,0 +1,73 @@
+package llm
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPromptManager_Raw(t *testing.T) {
+	pm, err := NewPromptManager()
+	if err != nil {
+		t.Fatalf("NewPromptManager() error = %v", err)
+	}
+
+	raw, err := pm.Raw("rerank_precision")
+	if err != nil {
+		t.Fatalf("Raw(rerank_precision) error = %v", err)
+	}
+
+	if !strings.Contains(raw, "{{.Query}}") {
+		t.Error("Raw() should contain {{.Query}} template variable, got rendered output without it")
+	}
+	if !strings.Contains(raw, "{{.Source}}") {
+		t.Error("Raw() should contain {{.Source}} template variable")
+	}
+	if !strings.Contains(raw, "{{.Content}}") {
+		t.Error("Raw() should contain {{.Content}} template variable")
+	}
+}
+
+func TestPromptManager_Raw_NotFound(t *testing.T) {
+	pm, err := NewPromptManager()
+	if err != nil {
+		t.Fatalf("NewPromptManager() error = %v", err)
+	}
+
+	_, err = pm.Raw("nonexistent_prompt")
+	if err == nil {
+		t.Error("expected error for nonexistent prompt key")
+	}
+}
+
+func TestPromptManager_Render_WithNilProducesNoValue(t *testing.T) {
+	pm, err := NewPromptManager()
+	if err != nil {
+		t.Fatalf("NewPromptManager() error = %v", err)
+	}
+
+	rendered, err := pm.Render("rerank_precision", nil)
+	if err != nil {
+		t.Fatalf("Render(rerank_precision, nil) error = %v", err)
+	}
+
+	if strings.Contains(rendered, "{{.Query}}") {
+		t.Error("Render(nil) should NOT contain {{.Query}} — it should be rendered")
+	}
+	if !strings.Contains(rendered, "<no value>") {
+		t.Error("Render(nil) should produce '<no value>' for missing keys, confirming the bug scenario")
+	}
+}
+
+func TestPromptManager_Raw_Vs_Render_Nil(t *testing.T) {
+	pm, err := NewPromptManager()
+	if err != nil {
+		t.Fatalf("NewPromptManager() error = %v", err)
+	}
+
+	raw, _ := pm.Raw("rerank_precision")
+	rendered, _ := pm.Render("rerank_precision", nil)
+
+	if raw == rendered {
+		t.Error("Raw() and Render(nil) should differ — Render(nil) replaces template vars with <no value>")
+	}
+}

--- a/internal/mcp/tools/run_command.go
+++ b/internal/mcp/tools/run_command.go
@@ -52,9 +52,10 @@ func (t *RunCommand) Name() string {
 }
 
 func (t *RunCommand) Description() string {
-	return `Run a whitelisted verification command in the project workspace.
+	allowed := t.allowedCommands()
+	return fmt.Sprintf(`Run a whitelisted verification command in the project workspace.
 
-Allowed commands: make build, make lint, make test.
+Allowed commands: %s.
 
 Use "make build" after editing files to verify they compile and all
 imports/exports are correct. Use "make lint" and "make test" for full
@@ -64,7 +65,7 @@ Returns stdout, stderr, exit_code, and a boolean success field.
 
 Note: commands are split on whitespace; quoted arguments with spaces are not
 supported. Whitelist entries should use simple space-separated tokens only
-(e.g. "make test" not "go test -run 'My Test'").`
+(e.g. "make test" not "go test -run 'My Test'").`, strings.Join(allowed, ", "))
 }
 
 func (t *RunCommand) ParametersSchema() map[string]any {

--- a/internal/mcp/tools/run_command.go
+++ b/internal/mcp/tools/run_command.go
@@ -23,7 +23,11 @@ const (
 
 // defaultVerifyCommands are the commands used when no verify_commands are
 // configured in .code-warden.yml.
-var defaultVerifyCommands = []string{"make lint", "make test"}
+var defaultVerifyCommands = []string{
+	"make build",
+	"make lint",
+	"make test",
+}
 
 // RunCommand executes a whitelisted shell command in the session workspace and
 // returns stdout, stderr, and the exit code.  Only commands listed in
@@ -50,11 +54,11 @@ func (t *RunCommand) Name() string {
 func (t *RunCommand) Description() string {
 	return `Run a whitelisted verification command in the project workspace.
 
-Only commands defined in the repository's verify_commands configuration are
-allowed (defaults: "make lint", "make test").
+Allowed commands: make build, make lint, make test.
 
-Use this tool to verify that the code compiles and all tests pass before
-calling review_code or create_pull_request.
+Use "make build" after editing files to verify they compile and all
+imports/exports are correct. Use "make lint" and "make test" for full
+verification before calling review_code.
 
 Returns stdout, stderr, exit_code, and a boolean success field.
 

--- a/internal/mcp/tools/run_command_test.go
+++ b/internal/mcp/tools/run_command_test.go
@@ -13,16 +13,16 @@ import (
 func TestRunCommand_Whitelist(t *testing.T) {
 	dir := t.TempDir()
 	tool := &RunCommand{
-		RepoConfig:  &core.RepoConfig{VerifyCommands: []string{"make lint", "make test"}},
+		RepoConfig:  &core.RepoConfig{VerifyCommands: []string{"make build", "make lint", "make test"}},
 		ProjectRoot: dir,
 		Logger:      slog.Default(),
 	}
 
-	allowed := []string{"make lint", "make test"}
+	allowed := []string{"make lint", "make test", "make build"}
 	rejected := []string{
 		"make lint; rm -rf /",
 		"sh -c 'rm -rf /'",
-		"make build",
+		"go build ./...",
 		"",
 	}
 

--- a/internal/wire/wire.go
+++ b/internal/wire/wire.go
@@ -347,15 +347,12 @@ func provideReranker(ctx context.Context, cfg *config.Config, logger *slog.Logge
 		return nil, fmt.Errorf("failed to create reranker LLM: %w", err)
 	}
 
-	const RerankPromptKey = "rerank_precision"
-
-	prompt, err := promptMgr.Render("rerank_precision", nil)
+	prompt, err := promptMgr.Raw("rerank_precision")
 	if err != nil {
-		logger.Debug("Loaded rerank prompt", "prompt_len", len(prompt))
+		logger.Warn("failed to load rerank prompt, using default", "error", err)
+		return llms.NewLLMReranker(rerankLLM, llms.WithConcurrency(3)), nil
 	}
 
-	if prompt != "" {
-		return llms.NewLLMReranker(rerankLLM, llms.WithConcurrency(3), llms.WithPrompt(prompt)), nil
-	}
-	return llms.NewLLMReranker(rerankLLM, llms.WithConcurrency(3)), nil
+	logger.Debug("Loaded rerank prompt", "prompt_len", len(prompt))
+	return llms.NewLLMReranker(rerankLLM, llms.WithConcurrency(3), llms.WithPrompt(prompt)), nil
 }

--- a/internal/wire/wire_gen.go
+++ b/internal/wire/wire_gen.go
@@ -398,16 +398,12 @@ func provideReranker(ctx context.Context, cfg *config.Config, logger2 *slog.Logg
 		return nil, fmt.Errorf("failed to create reranker LLM: %w", err)
 	}
 
-	const RerankPromptKey = "rerank_precision"
-
-	prompt, err := promptMgr.Render("rerank_precision", nil)
+	prompt, err := promptMgr.Raw("rerank_precision")
 	if err != nil {
-		logger2.
-			Debug("Loaded rerank prompt", "prompt_len", len(prompt))
+		logger2.Warn("failed to load rerank prompt, using default", "error", err)
+		return llms.NewLLMReranker(rerankLLM, llms.WithConcurrency(3)), nil
 	}
 
-	if prompt != "" {
-		return llms.NewLLMReranker(rerankLLM, llms.WithConcurrency(3), llms.WithPrompt(prompt)), nil
-	}
-	return llms.NewLLMReranker(rerankLLM, llms.WithConcurrency(3)), nil
+	logger2.Debug("Loaded rerank prompt", "prompt_len", len(prompt))
+	return llms.NewLLMReranker(rerankLLM, llms.WithConcurrency(3), llms.WithPrompt(prompt)), nil
 }


### PR DESCRIPTION
## Summary

Three fixes discovered during the second live agent test (issue #262):

### 1. `run_command` whitelist: `make build` instead of `go build ./...`
Changed `defaultVerifyCommands` from `go build ./...` to `make build` for consistency with `make lint` and `make test`. Updated the implement loop system prompt to include `make build` as the first verification step. The agent now follows: implement → `make build` → `make lint` → `make test` → `review_code`.

### 2. Reranker `<no value>` bug
`promptMgr.Render("rerank_precision", nil)` was pre-rendering template variables (`{{.Query}}`, `{{.Source}}`, `{{.Content}}`) as `<no value>`, making every rerank call send meaningless prompts to the LLM — wasting tokens and returning garbage scores for all RAG context retrieval.

**Fix**: Added `PromptManager.Raw()` method that returns the un-rendered template string (with `{{.Query}}` etc. intact). Changed `wire.go`/`wire_gen.go` to use `Raw()` instead of `Render(nil)`. Also disabled reranking (`enable_reranking: false`) since it provides little value for small repos.

### 3. Multi-edit partial application
When one edit in a multi-edit batch fails to match, the entire batch was rejected — wasting the LLM iteration. Now `applyMultiEdit` applies successful edits and returns a `partialEditError` listing which indices failed. The `edit_file` tool writes the partial result to disk and returns structured feedback (`applied_edits`, `failed_edits`, `total_edits`, `diff`) so the agent can retry only the failures instead of the whole batch.

## Test plan
- [x] `make build` passes
- [x] `make lint` passes (0 issues)
- [x] `go test ./...` passes (all packages)
- [x] New tests for `PromptManager.Raw()` (4 tests)
- [x] New tests for `partialEditError` and partial edit scenarios (4 tests)
- [x] Existing `run_command` tests updated for `make build` whitelist