### PR TITLE
feat(agent): post-write auto-formatting for coding agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,3 +239,18 @@ Main branch requires status checks (lint, test, build) but no PR approval. Direc
 1. Create tool struct in `internal/agent/` implementing the `mcp.Tool` interface
 2. Add to `searchTools()` or `fileTools()` helper function
 3. Tool is automatically registered in planner, implement, and native agent loops
+
+### Adding Per-Write Formatting for a New Language
+
+The agent has two formatting mechanisms:
+
+1. **Per-write formatting** (Go only): `internal/agent/formatter.go` runs `goimports` or `gofmt` on `.go` files after every `write_file`/`edit_file`. This is reserved for Go because `goimports` resolves imports without an LSP — uniquely saving iterations. To add per-write formatting for another language:
+   - Add the extension and formatter specs to `defaultFormatters` in `formatter.go`
+   - Per-write formatters are alternative chains (first matching binary wins), not sequential passes
+   - Keep it simple: one binary, one pass. Sequential multi-pass formatting (like `ruff format` then `ruff check --fix`) is too complex for per-write hooks
+
+2. **Batch format before review** (any language): configured in `.code-warden.yml` via `format_command`. The agent runs this once between the edit and review phases. This is the right mechanism for multi-language projects:
+   ```yaml
+   format_command: "npm run format"  # or "ruff format ." or "cargo fmt"
+   ```
+   To add support in code: the `format_command` field is in `internal/core/repo_config.go`, and the batch format is triggered in `internal/agent/warden.go` via `formatProject()`.

--- a/internal/agent/file_tools.go
+++ b/internal/agent/file_tools.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -105,7 +104,6 @@ func (t *readFileTool) Execute(ctx context.Context, args map[string]any) (any, e
 // writeFileTool writes (or creates) a file in the agent workspace.
 type writeFileTool struct {
 	Formatter *Formatter
-	Logger    *slog.Logger
 }
 
 func (t *writeFileTool) Name() string { return "write_file" }
@@ -157,13 +155,9 @@ func (t *writeFileTool) Execute(ctx context.Context, args map[string]any) (any, 
 
 	// Auto-format the written file if a formatter is available.
 	written := content
-	if t.Formatter != nil {
-		if fmtErr := t.Formatter.Format(ctx, root, abs); fmtErr != nil {
-			t.Logger.Warn("auto-format: skipped", "path", relPath, "err", fmtErr)
-		}
-		if formatted, readErr := os.ReadFile(abs); readErr == nil {
-			written = string(formatted)
-		}
+	t.Formatter.Format(ctx, root, abs)
+	if formatted, readErr := os.ReadFile(abs); readErr == nil {
+		written = string(formatted)
 	}
 
 	result := map[string]any{"ok": true, "path": relPath, "bytes": len(written)}
@@ -175,7 +169,6 @@ func (t *writeFileTool) Execute(ctx context.Context, args map[string]any) (any, 
 // Mirrors Pi's edit tool semantics.
 type editFileTool struct {
 	Formatter *Formatter
-	Logger    *slog.Logger
 }
 
 func (t *editFileTool) Name() string { return "edit_file" }
@@ -278,7 +271,7 @@ func (t *editFileTool) Execute(ctx context.Context, args map[string]any) (any, e
 			return handlePartialEdit(editContext{
 				abs: abs, relPath: relPath, original: original, working: updated,
 				lineEnding: lineEnding, hasBOM: hasBOM, usedFuzzy: usedFuzzy,
-				formatter: t.Formatter, logger: t.Logger, workspaceRoot: root,
+				formatter: t.Formatter, workspaceRoot: root,
 			}, pe, err)
 		}
 		return nil, fmt.Errorf("edit_file: %w", err)
@@ -291,14 +284,10 @@ func (t *editFileTool) Execute(ctx context.Context, args map[string]any) (any, e
 		return nil, fmt.Errorf("edit_file: write: %w", err)
 	}
 
-	// Auto-format the written file if a formatter is available.
-	if t.Formatter != nil {
-		if fmtErr := t.Formatter.Format(ctx, root, abs); fmtErr != nil {
-			t.Logger.Warn("auto-format: skipped", "path", relPath, "err", fmtErr)
-		}
-		if formatted, readErr := os.ReadFile(abs); readErr == nil {
-			updated = string(formatted)
-		}
+	// Auto-format the written file and re-read so the diff is accurate.
+	t.Formatter.Format(ctx, root, abs)
+	if formatted, readErr := os.ReadFile(abs); readErr == nil {
+		updated = string(formatted)
 	}
 
 	result := map[string]any{"ok": true, "path": relPath}
@@ -451,20 +440,12 @@ func (t *listDirTool) Execute(ctx context.Context, args map[string]any) (any, er
 }
 
 // fileTools returns all workspace file manipulation tools.
-// The formatter is used to auto-format files after write/edit; pass nil to disable.
-func fileTools(formatter *Formatter, logger *slog.Logger) []mcp.Tool {
-	if formatter == nil {
-		return []mcp.Tool{
-			&readFileTool{},
-			&writeFileTool{},
-			&editFileTool{},
-			&listDirTool{},
-		}
-	}
+// The formatter is used to auto-format Go files after write/edit; pass nil to disable.
+func fileTools(formatter *Formatter) []mcp.Tool {
 	return []mcp.Tool{
 		&readFileTool{},
-		&writeFileTool{Formatter: formatter, Logger: logger},
-		&editFileTool{Formatter: formatter, Logger: logger},
+		&writeFileTool{Formatter: formatter},
+		&editFileTool{Formatter: formatter},
 		&listDirTool{},
 	}
 }
@@ -503,7 +484,6 @@ type editContext struct {
 	abs, relPath, original, working, lineEnding string
 	hasBOM, usedFuzzy                           bool
 	formatter                                   *Formatter
-	logger                                      *slog.Logger
 	workspaceRoot                               string
 }
 
@@ -534,7 +514,7 @@ func handlePartialEdit(ctx editContext, pe *partialEditError, origErr error) (ma
 	}
 
 	// Auto-format the partially-edited file.
-	partialResult = formatAndReadback(ctx.formatter, ctx.logger, ctx.workspaceRoot, ctx.abs, ctx.relPath, partialResult)
+	partialResult = formatAndReadback(ctx.formatter, ctx.workspaceRoot, ctx.abs, ctx.relPath, partialResult)
 
 	diffStr := buildUnifiedDiff(ctx.original, partialResult, ctx.relPath)
 	if diffStr != "" {
@@ -545,15 +525,10 @@ func handlePartialEdit(ctx editContext, pe *partialEditError, origErr error) (ma
 }
 
 // formatAndReadback runs the auto-formatter on the given file and re-reads it.
-// Returns the (possibly formatted) content, or the original content if the
-// formatter is nil or fails.
-func formatAndReadback(formatter *Formatter, logger *slog.Logger, workspaceRoot, absPath, relPath, current string) string {
-	if formatter == nil {
-		return current
-	}
-	if fmtErr := formatter.Format(context.Background(), workspaceRoot, absPath); fmtErr != nil {
-		logger.Warn("auto-format: skipped", "path", relPath, "err", fmtErr)
-	}
+// Returns the (possibly formatted) content, or the original content if formatting
+// didn't change the file or the formatter is nil.
+func formatAndReadback(formatter *Formatter, workspaceRoot, absPath, _ string, current string) string {
+	formatter.Format(context.Background(), workspaceRoot, absPath)
 	if formatted, readErr := os.ReadFile(absPath); readErr == nil {
 		return string(formatted)
 	}

--- a/internal/agent/file_tools.go
+++ b/internal/agent/file_tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -102,7 +103,10 @@ func (t *readFileTool) Execute(ctx context.Context, args map[string]any) (any, e
 }
 
 // writeFileTool writes (or creates) a file in the agent workspace.
-type writeFileTool struct{}
+type writeFileTool struct {
+	Formatter *Formatter
+	Logger    *slog.Logger
+}
 
 func (t *writeFileTool) Name() string { return "write_file" }
 
@@ -151,14 +155,28 @@ func (t *writeFileTool) Execute(ctx context.Context, args map[string]any) (any, 
 		return nil, fmt.Errorf("write_file: %w", err)
 	}
 
-	result := map[string]any{"ok": true, "path": relPath, "bytes": len(content)}
+	// Auto-format the written file if a formatter is available.
+	written := content
+	if t.Formatter != nil {
+		if fmtErr := t.Formatter.Format(ctx, root, abs); fmtErr != nil {
+			t.Logger.Warn("auto-format: skipped", "path", relPath, "err", fmtErr)
+		}
+		if formatted, readErr := os.ReadFile(abs); readErr == nil {
+			written = string(formatted)
+		}
+	}
+
+	result := map[string]any{"ok": true, "path": relPath, "bytes": len(written)}
 	return result, nil
 }
 
 // editFileTool replaces text in a file. Accepts either a single old_string/new_string
 // pair (backwards-compatible) or an edits array for atomic multi-replacement.
 // Mirrors Pi's edit tool semantics.
-type editFileTool struct{}
+type editFileTool struct {
+	Formatter *Formatter
+	Logger    *slog.Logger
+}
 
 func (t *editFileTool) Name() string { return "edit_file" }
 
@@ -260,6 +278,7 @@ func (t *editFileTool) Execute(ctx context.Context, args map[string]any) (any, e
 			return handlePartialEdit(editContext{
 				abs: abs, relPath: relPath, original: original, working: updated,
 				lineEnding: lineEnding, hasBOM: hasBOM, usedFuzzy: usedFuzzy,
+				formatter: t.Formatter, logger: t.Logger, workspaceRoot: root,
 			}, pe, err)
 		}
 		return nil, fmt.Errorf("edit_file: %w", err)
@@ -270,6 +289,16 @@ func (t *editFileTool) Execute(ctx context.Context, args map[string]any) (any, e
 	updated = prependBOM(updated, hasBOM)
 	if err := os.WriteFile(abs, []byte(updated), 0o644); err != nil { //nolint:gosec // G306: 0644 is intentional for source files
 		return nil, fmt.Errorf("edit_file: write: %w", err)
+	}
+
+	// Auto-format the written file if a formatter is available.
+	if t.Formatter != nil {
+		if fmtErr := t.Formatter.Format(ctx, root, abs); fmtErr != nil {
+			t.Logger.Warn("auto-format: skipped", "path", relPath, "err", fmtErr)
+		}
+		if formatted, readErr := os.ReadFile(abs); readErr == nil {
+			updated = string(formatted)
+		}
 	}
 
 	result := map[string]any{"ok": true, "path": relPath}
@@ -422,11 +451,20 @@ func (t *listDirTool) Execute(ctx context.Context, args map[string]any) (any, er
 }
 
 // fileTools returns all workspace file manipulation tools.
-func fileTools() []mcp.Tool {
+// The formatter is used to auto-format files after write/edit; pass nil to disable.
+func fileTools(formatter *Formatter, logger *slog.Logger) []mcp.Tool {
+	if formatter == nil {
+		return []mcp.Tool{
+			&readFileTool{},
+			&writeFileTool{},
+			&editFileTool{},
+			&listDirTool{},
+		}
+	}
 	return []mcp.Tool{
 		&readFileTool{},
-		&writeFileTool{},
-		&editFileTool{},
+		&writeFileTool{Formatter: formatter, Logger: logger},
+		&editFileTool{Formatter: formatter, Logger: logger},
 		&listDirTool{},
 	}
 }
@@ -464,6 +502,9 @@ func parseIntArg(args map[string]any, key string) int {
 type editContext struct {
 	abs, relPath, original, working, lineEnding string
 	hasBOM, usedFuzzy                           bool
+	formatter                                   *Formatter
+	logger                                      *slog.Logger
+	workspaceRoot                               string
 }
 
 func handlePartialEdit(ctx editContext, pe *partialEditError, origErr error) (map[string]any, error) {
@@ -482,17 +523,39 @@ func handlePartialEdit(ctx editContext, pe *partialEditError, origErr error) (ma
 	}
 
 	// Only write to disk if at least one edit succeeded.
-	if appliedCount > 0 {
-		partialResult := restoreLineEndings(ctx.working, ctx.lineEnding)
-		partialResult = prependBOM(partialResult, ctx.hasBOM)
-		if writeErr := os.WriteFile(ctx.abs, []byte(partialResult), 0o644); writeErr != nil { //nolint:gosec // G306: 0644 is intentional for source files
-			return nil, fmt.Errorf("edit_file: partial edit write failed: %w", writeErr)
-		}
-		diffStr := buildUnifiedDiff(ctx.original, partialResult, ctx.relPath)
-		if diffStr != "" {
-			result["diff"] = diffStr
-		}
+	if appliedCount == 0 {
+		return result, nil
+	}
+
+	partialResult := restoreLineEndings(ctx.working, ctx.lineEnding)
+	partialResult = prependBOM(partialResult, ctx.hasBOM)
+	if writeErr := os.WriteFile(ctx.abs, []byte(partialResult), 0o644); writeErr != nil { //nolint:gosec // G306: 0644 is intentional for source files
+		return nil, fmt.Errorf("edit_file: partial edit write failed: %w", writeErr)
+	}
+
+	// Auto-format the partially-edited file.
+	partialResult = formatAndReadback(ctx.formatter, ctx.logger, ctx.workspaceRoot, ctx.abs, ctx.relPath, partialResult)
+
+	diffStr := buildUnifiedDiff(ctx.original, partialResult, ctx.relPath)
+	if diffStr != "" {
+		result["diff"] = diffStr
 	}
 
 	return result, nil
+}
+
+// formatAndReadback runs the auto-formatter on the given file and re-reads it.
+// Returns the (possibly formatted) content, or the original content if the
+// formatter is nil or fails.
+func formatAndReadback(formatter *Formatter, logger *slog.Logger, workspaceRoot, absPath, relPath, current string) string {
+	if formatter == nil {
+		return current
+	}
+	if fmtErr := formatter.Format(context.Background(), workspaceRoot, absPath); fmtErr != nil {
+		logger.Warn("auto-format: skipped", "path", relPath, "err", fmtErr)
+	}
+	if formatted, readErr := os.ReadFile(absPath); readErr == nil {
+		return string(formatted)
+	}
+	return current
 }

--- a/internal/agent/file_tools.go
+++ b/internal/agent/file_tools.go
@@ -153,11 +153,14 @@ func (t *writeFileTool) Execute(ctx context.Context, args map[string]any) (any, 
 		return nil, fmt.Errorf("write_file: %w", err)
 	}
 
-	// Auto-format the written file if a formatter is available.
+	// Auto-format the written file if a formatter is available, then re-read
+	// so the diff the LLM sees matches what's on disk.
 	written := content
-	t.Formatter.Format(ctx, root, abs)
-	if formatted, readErr := os.ReadFile(abs); readErr == nil {
-		written = string(formatted)
+	if t.Formatter != nil {
+		t.Formatter.Format(ctx, root, abs)
+		if formatted, readErr := os.ReadFile(abs); readErr == nil {
+			written = string(formatted)
+		}
 	}
 
 	result := map[string]any{"ok": true, "path": relPath, "bytes": len(written)}
@@ -271,7 +274,7 @@ func (t *editFileTool) Execute(ctx context.Context, args map[string]any) (any, e
 			return handlePartialEdit(editContext{
 				abs: abs, relPath: relPath, original: original, working: updated,
 				lineEnding: lineEnding, hasBOM: hasBOM, usedFuzzy: usedFuzzy,
-				formatter: t.Formatter, workspaceRoot: root,
+				formatter: t.Formatter, workspaceRoot: root, ctx: ctx,
 			}, pe, err)
 		}
 		return nil, fmt.Errorf("edit_file: %w", err)
@@ -285,9 +288,11 @@ func (t *editFileTool) Execute(ctx context.Context, args map[string]any) (any, e
 	}
 
 	// Auto-format the written file and re-read so the diff is accurate.
-	t.Formatter.Format(ctx, root, abs)
-	if formatted, readErr := os.ReadFile(abs); readErr == nil {
-		updated = string(formatted)
+	if t.Formatter != nil {
+		t.Formatter.Format(ctx, root, abs)
+		if formatted, readErr := os.ReadFile(abs); readErr == nil {
+			updated = string(formatted)
+		}
 	}
 
 	result := map[string]any{"ok": true, "path": relPath}
@@ -485,6 +490,7 @@ type editContext struct {
 	hasBOM, usedFuzzy                           bool
 	formatter                                   *Formatter
 	workspaceRoot                               string
+	ctx                                         context.Context
 }
 
 func handlePartialEdit(ctx editContext, pe *partialEditError, origErr error) (map[string]any, error) {
@@ -514,7 +520,7 @@ func handlePartialEdit(ctx editContext, pe *partialEditError, origErr error) (ma
 	}
 
 	// Auto-format the partially-edited file.
-	partialResult = formatAndReadback(ctx.formatter, ctx.workspaceRoot, ctx.abs, ctx.relPath, partialResult)
+	partialResult = formatAndReadback(ctx.ctx, ctx.formatter, ctx.workspaceRoot, ctx.abs, partialResult)
 
 	diffStr := buildUnifiedDiff(ctx.original, partialResult, ctx.relPath)
 	if diffStr != "" {
@@ -527,8 +533,11 @@ func handlePartialEdit(ctx editContext, pe *partialEditError, origErr error) (ma
 // formatAndReadback runs the auto-formatter on the given file and re-reads it.
 // Returns the (possibly formatted) content, or the original content if formatting
 // didn't change the file or the formatter is nil.
-func formatAndReadback(formatter *Formatter, workspaceRoot, absPath, _ string, current string) string {
-	formatter.Format(context.Background(), workspaceRoot, absPath)
+func formatAndReadback(ctx context.Context, formatter *Formatter, workspaceRoot, absPath, current string) string {
+	if formatter == nil {
+		return current
+	}
+	formatter.Format(ctx, workspaceRoot, absPath)
 	if formatted, readErr := os.ReadFile(absPath); readErr == nil {
 		return string(formatted)
 	}

--- a/internal/agent/formatter.go
+++ b/internal/agent/formatter.go
@@ -7,37 +7,14 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/sevigo/code-warden/internal/core"
 )
 
-// formatterSpec describes a single formatter pass: the binary name and a
-// function that builds its argument list for a given file path.
-type formatterSpec struct {
-	binary string
-	args   func(filePath string) []string
-}
-
-// defaultFormatters maps file extensions to ordered lists of formatter specs.
-// The first spec whose binary is found on PATH wins (e.g. goimports before gofmt).
-var defaultFormatters = map[string][]formatterSpec{
-	".go": {
-		{binary: "goimports", args: func(f string) []string { return []string{"-w", f} }},
-		{binary: "gofmt", args: func(f string) []string { return []string{"-w", f} }},
-	},
-	".py": {
-		{binary: "ruff", args: func(f string) []string { return []string{"format", f} }},
-		{binary: "ruff", args: func(f string) []string { return []string{"check", "--fix", "--select", "I,F401", f} }},
-	},
-	".ts":   {{binary: "prettier", args: func(f string) []string { return []string{"--write", f} }}},
-	".tsx":  {{binary: "prettier", args: func(f string) []string { return []string{"--write", f} }}},
-	".js":   {{binary: "prettier", args: func(f string) []string { return []string{"--write", f} }}},
-	".jsx":  {{binary: "prettier", args: func(f string) []string { return []string{"--write", f} }}},
-	".rs":   {{binary: "rustfmt", args: func(f string) []string { return []string{f} }}},
-	".java": {{binary: "google-java-format", args: func(f string) []string { return []string{"--replace", f} }}},
-}
-
-// Formatter runs language-specific formatters on files after they are written
-// by the agent. If a formatter binary is not installed it is silently skipped.
-// Errors are logged but never propagated to callers — formatting is best-effort.
+// Formatter runs language-specific formatters on files written by the agent.
+// Only Go files are auto-formatted per-write (goimports resolves imports without
+// an LSP — a unique capability). All other formatting is handled by a batch
+// format_command run once before the review phase (configured in .code-warden.yml).
 type Formatter struct {
 	logger *slog.Logger
 }
@@ -47,42 +24,76 @@ func NewFormatter(logger *slog.Logger) *Formatter {
 	return &Formatter{logger: logger}
 }
 
-// Format runs the appropriate formatter for filePath's extension.
-// The cmd is executed with workspaceRoot as its working directory so that
-// project-local config files (.prettierrc, pyproject.toml, etc.) are respected.
-// Returns nil if no formatter is available or the formatter succeeds.
-// Returns an error only if something unexpected happens (context cancelled, etc.).
-func (f *Formatter) Format(ctx context.Context, workspaceRoot, filePath string) error {
-	if f == nil || f.logger == nil {
+// newFormatterFromConfig creates a Formatter unless DisableAutoFormat is set.
+func newFormatterFromConfig(logger *slog.Logger, cfg *core.RepoConfig) *Formatter {
+	if cfg != nil && cfg.DisableAutoFormat {
 		return nil
+	}
+	return NewFormatter(logger)
+}
+
+// Format runs the appropriate formatter for filePath's extension.
+// For Go files: try goimports first (resolves imports), fall back to gofmt.
+// All other extensions are skipped — formatting for those is handled by the
+// batch format_command before the review phase.
+// Nil receiver is a no-op.
+func (f *Formatter) Format(ctx context.Context, workspaceRoot, filePath string) {
+	if f == nil {
+		return
 	}
 	ext := strings.ToLower(filepath.Ext(filePath))
-	specs, ok := defaultFormatters[ext]
-	if !ok {
-		return nil
+	if ext != ".go" {
+		return
 	}
 
-	for _, spec := range specs {
-		if _, err := exec.LookPath(spec.binary); err != nil {
+	for _, binary := range []string{"goimports", "gofmt"} {
+		if _, err := exec.LookPath(binary); err != nil {
 			continue
 		}
-
-		args := spec.args(filePath)
-		formatCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		defer cancel()
-
-		cmd := exec.CommandContext(formatCtx, spec.binary, args...) //nolint:gosec // G204: binary is from our hardcoded map, not user input
-		cmd.Dir = workspaceRoot
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			f.logger.Warn("auto-format: formatter failed",
-				"binary", spec.binary, "path", filePath, "error", err, "output", string(out))
-			return err
-		}
-		f.logger.Debug("auto-format: formatted", "binary", spec.binary, "path", filePath)
-		return nil
+		f.runSpec(ctx, binary, []string{"-w", filePath}, workspaceRoot, filePath)
+		return
 	}
+	f.logger.Debug("auto-format: no Go formatter available", "path", filePath)
+}
 
-	f.logger.Debug("auto-format: no formatter found", "ext", ext, "path", filePath)
-	return nil
+// FormatProject runs a single batch format command on the workspace root.
+// This is called once between the edit and review phases, using the project's
+// own format_command from .code-warden.yml (e.g. "npm run format", "ruff format .").
+// Nil receiver or empty command is a no-op.
+func (f *Formatter) FormatProject(ctx context.Context, workspaceRoot, command string) {
+	if f == nil || command == "" {
+		return
+	}
+	parts := strings.SplitN(command, " ", 2)
+	binary := parts[0]
+	args := parts[1:]
+
+	fmtCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(fmtCtx, binary, args...)
+	cmd.Dir = workspaceRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		f.logger.Warn("auto-format: project format command failed",
+			"command", command, "error", err, "output", string(out))
+		return
+	}
+	f.logger.Info("auto-format: project formatted", "command", command)
+}
+
+// runSpec executes a single formatter pass with a scoped 30-second timeout.
+func (f *Formatter) runSpec(ctx context.Context, binary string, args []string, workspaceRoot, filePath string) {
+	fmtCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(fmtCtx, binary, args...)
+	cmd.Dir = workspaceRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		f.logger.Warn("auto-format: formatter failed",
+			"binary", binary, "path", filePath, "error", err, "output", string(out))
+		return
+	}
+	f.logger.Debug("auto-format: formatted", "binary", binary, "path", filePath)
 }

--- a/internal/agent/formatter.go
+++ b/internal/agent/formatter.go
@@ -24,9 +24,11 @@ func NewFormatter(logger *slog.Logger) *Formatter {
 	return &Formatter{logger: logger}
 }
 
-// newFormatterFromConfig creates a Formatter unless DisableAutoFormat is set.
+// newFormatterFromConfig creates a Formatter unless per-write formatting is
+// disabled by the repo config. The batch format_command is independent and
+// controlled by its own field.
 func newFormatterFromConfig(logger *slog.Logger, cfg *core.RepoConfig) *Formatter {
-	if cfg != nil && cfg.DisableAutoFormat {
+	if cfg != nil && cfg.DisableFormatOnWrite {
 		return nil
 	}
 	return NewFormatter(logger)
@@ -50,7 +52,7 @@ func (f *Formatter) Format(ctx context.Context, workspaceRoot, filePath string) 
 		if _, err := exec.LookPath(binary); err != nil {
 			continue
 		}
-		f.runSpec(ctx, binary, []string{"-w", filePath}, workspaceRoot, filePath)
+		f.runSpec(ctx, binary, []string{"-w", filePath}, workspaceRoot)
 		return
 	}
 	f.logger.Debug("auto-format: no Go formatter available", "path", filePath)
@@ -64,14 +66,15 @@ func (f *Formatter) FormatProject(ctx context.Context, workspaceRoot, command st
 	if f == nil || command == "" {
 		return
 	}
-	parts := strings.SplitN(command, " ", 2)
-	binary := parts[0]
-	args := parts[1:]
+	parts := strings.Fields(command)
+	if len(parts) == 0 {
+		return
+	}
 
 	fmtCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(fmtCtx, binary, args...)
+	cmd := exec.CommandContext(fmtCtx, parts[0], parts[1:]...) //nolint:gosec // G204: command from repo config
 	cmd.Dir = workspaceRoot
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -83,7 +86,7 @@ func (f *Formatter) FormatProject(ctx context.Context, workspaceRoot, command st
 }
 
 // runSpec executes a single formatter pass with a scoped 30-second timeout.
-func (f *Formatter) runSpec(ctx context.Context, binary string, args []string, workspaceRoot, filePath string) {
+func (f *Formatter) runSpec(ctx context.Context, binary string, args []string, workspaceRoot string) {
 	fmtCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
@@ -92,8 +95,8 @@ func (f *Formatter) runSpec(ctx context.Context, binary string, args []string, w
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		f.logger.Warn("auto-format: formatter failed",
-			"binary", binary, "path", filePath, "error", err, "output", string(out))
+			"binary", binary, "args", args, "error", err, "output", string(out))
 		return
 	}
-	f.logger.Debug("auto-format: formatted", "binary", binary, "path", filePath)
+	f.logger.Debug("auto-format: formatted", "binary", binary, "args", args)
 }

--- a/internal/agent/formatter.go
+++ b/internal/agent/formatter.go
@@ -1,0 +1,88 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// formatterSpec describes a single formatter pass: the binary name and a
+// function that builds its argument list for a given file path.
+type formatterSpec struct {
+	binary string
+	args   func(filePath string) []string
+}
+
+// defaultFormatters maps file extensions to ordered lists of formatter specs.
+// The first spec whose binary is found on PATH wins (e.g. goimports before gofmt).
+var defaultFormatters = map[string][]formatterSpec{
+	".go": {
+		{binary: "goimports", args: func(f string) []string { return []string{"-w", f} }},
+		{binary: "gofmt", args: func(f string) []string { return []string{"-w", f} }},
+	},
+	".py": {
+		{binary: "ruff", args: func(f string) []string { return []string{"format", f} }},
+		{binary: "ruff", args: func(f string) []string { return []string{"check", "--fix", "--select", "I,F401", f} }},
+	},
+	".ts":   {{binary: "prettier", args: func(f string) []string { return []string{"--write", f} }}},
+	".tsx":  {{binary: "prettier", args: func(f string) []string { return []string{"--write", f} }}},
+	".js":   {{binary: "prettier", args: func(f string) []string { return []string{"--write", f} }}},
+	".jsx":  {{binary: "prettier", args: func(f string) []string { return []string{"--write", f} }}},
+	".rs":   {{binary: "rustfmt", args: func(f string) []string { return []string{f} }}},
+	".java": {{binary: "google-java-format", args: func(f string) []string { return []string{"--replace", f} }}},
+}
+
+// Formatter runs language-specific formatters on files after they are written
+// by the agent. If a formatter binary is not installed it is silently skipped.
+// Errors are logged but never propagated to callers — formatting is best-effort.
+type Formatter struct {
+	logger *slog.Logger
+}
+
+// NewFormatter creates a Formatter with the given logger.
+func NewFormatter(logger *slog.Logger) *Formatter {
+	return &Formatter{logger: logger}
+}
+
+// Format runs the appropriate formatter for filePath's extension.
+// The cmd is executed with workspaceRoot as its working directory so that
+// project-local config files (.prettierrc, pyproject.toml, etc.) are respected.
+// Returns nil if no formatter is available or the formatter succeeds.
+// Returns an error only if something unexpected happens (context cancelled, etc.).
+func (f *Formatter) Format(ctx context.Context, workspaceRoot, filePath string) error {
+	if f == nil || f.logger == nil {
+		return nil
+	}
+	ext := strings.ToLower(filepath.Ext(filePath))
+	specs, ok := defaultFormatters[ext]
+	if !ok {
+		return nil
+	}
+
+	for _, spec := range specs {
+		if _, err := exec.LookPath(spec.binary); err != nil {
+			continue
+		}
+
+		args := spec.args(filePath)
+		formatCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		cmd := exec.CommandContext(formatCtx, spec.binary, args...) //nolint:gosec // G204: binary is from our hardcoded map, not user input
+		cmd.Dir = workspaceRoot
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			f.logger.Warn("auto-format: formatter failed",
+				"binary", spec.binary, "path", filePath, "error", err, "output", string(out))
+			return err
+		}
+		f.logger.Debug("auto-format: formatted", "binary", spec.binary, "path", filePath)
+		return nil
+	}
+
+	f.logger.Debug("auto-format: no formatter found", "ext", ext, "path", filePath)
+	return nil
+}

--- a/internal/agent/formatter_test.go
+++ b/internal/agent/formatter_test.go
@@ -10,23 +10,19 @@ import (
 	"testing"
 )
 
-func TestFormatter_NilReceiver(t *testing.T) {
+func TestFormatter_NilReceiver(_ *testing.T) {
 	var f *Formatter
-	if err := f.Format(context.Background(), "/tmp", "/tmp/test.go"); err != nil {
-		t.Errorf("nil Formatter should be a no-op: %v", err)
-	}
+	f.Format(context.Background(), "/tmp", "/tmp/test.go")
 }
 
-func TestFormatter_Format_SkipsUnknownExtension(t *testing.T) {
+func TestFormatter_Format_SkipsNonGo(t *testing.T) {
 	f := NewFormatter(slog.Default())
 	dir := t.TempDir()
-	filePath := filepath.Join(dir, "test.txt")
-	if err := os.WriteFile(filePath, []byte("hello"), 0o644); err != nil {
+	filePath := filepath.Join(dir, "test.py")
+	if err := os.WriteFile(filePath, []byte("x=1\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.Format(context.Background(), dir, filePath); err != nil {
-		t.Errorf("Format should skip unknown extensions: %v", err)
-	}
+	f.Format(context.Background(), dir, filePath)
 }
 
 func TestFormatter_Format_FormatsGoFile(t *testing.T) {
@@ -41,10 +37,7 @@ func TestFormatter_Format_FormatsGoFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := f.Format(context.Background(), dir, filePath)
-	if err != nil {
-		t.Fatalf("Format failed: %v", err)
-	}
+	f.Format(context.Background(), dir, filePath)
 
 	formatted, err := os.ReadFile(filePath)
 	if err != nil {
@@ -67,26 +60,19 @@ func TestFormatter_Format_PrefersGoimports(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := f.Format(context.Background(), dir, filePath)
-	if err != nil {
-		t.Fatalf("Format failed: %v", err)
-	}
+	f.Format(context.Background(), dir, filePath)
 }
 
-func TestFormatter_FormatsPythonWithRuff(t *testing.T) {
-	if _, err := exec.LookPath("ruff"); err != nil {
-		t.Skip("ruff not available")
+func TestFormatter_FormatProject_EmptyCommand(_ *testing.T) {
+	var f *Formatter
+	f.FormatProject(context.Background(), "/tmp", "")
+}
+
+func TestFormatter_FormatProject_RunsCommand(t *testing.T) {
+	if _, err := exec.LookPath("echo"); err != nil {
+		t.Skip("echo not available")
 	}
 	f := NewFormatter(slog.Default())
 	dir := t.TempDir()
-	filePath := filepath.Join(dir, "test.py")
-	content := "x=1\n"
-	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	err := f.Format(context.Background(), dir, filePath)
-	if err != nil {
-		t.Fatalf("Format failed: %v", err)
-	}
+	f.FormatProject(context.Background(), dir, "echo formatted")
 }

--- a/internal/agent/formatter_test.go
+++ b/internal/agent/formatter_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/sevigo/code-warden/internal/core"
 )
 
 func TestFormatter_NilReceiver(_ *testing.T) {
@@ -23,6 +25,10 @@ func TestFormatter_Format_SkipsNonGo(t *testing.T) {
 		t.Fatal(err)
 	}
 	f.Format(context.Background(), dir, filePath)
+	data, _ := os.ReadFile(filePath)
+	if string(data) != "x=1\n" {
+		t.Error("non-Go files should not be formatted")
+	}
 }
 
 func TestFormatter_Format_FormatsGoFile(t *testing.T) {
@@ -55,12 +61,20 @@ func TestFormatter_Format_PrefersGoimports(t *testing.T) {
 	f := NewFormatter(slog.Default())
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, "test.go")
-	content := "package test\n\nimport \"fmt\"\n\nfunc Foo() {fmt.Println(\"hi\")}\n"
+	content := "package test\n\nfunc Foo(){}\n"
 	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	f.Format(context.Background(), dir, filePath)
+
+	formatted, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(formatted), "func Foo(){}") {
+		t.Error("goimports did not format the file")
+	}
 }
 
 func TestFormatter_FormatProject_EmptyCommand(_ *testing.T) {
@@ -68,11 +82,45 @@ func TestFormatter_FormatProject_EmptyCommand(_ *testing.T) {
 	f.FormatProject(context.Background(), "/tmp", "")
 }
 
-func TestFormatter_FormatProject_RunsCommand(t *testing.T) {
+func TestFormatter_FormatProject_MultiWordCommand(t *testing.T) {
 	if _, err := exec.LookPath("echo"); err != nil {
 		t.Skip("echo not available")
 	}
 	f := NewFormatter(slog.Default())
 	dir := t.TempDir()
+	testFile := filepath.Join(dir, "hello.txt")
+	if err := os.WriteFile(testFile, []byte("before\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Use a multi-word command that strings.Fields splits correctly.
+	// "touch" with a path that has spaces would also work, but "echo" is simpler.
 	f.FormatProject(context.Background(), dir, "echo formatted")
+	// The command should execute without error; we just verify it doesn't crash.
+}
+
+func TestStringsFieldsSplitsMultiWordCommand(t *testing.T) {
+	parts := strings.Fields("npm run format")
+	if len(parts) != 3 || parts[0] != "npm" || parts[1] != "run" || parts[2] != "format" {
+		t.Errorf("strings.Fields splits incorrectly: %v", parts)
+	}
+}
+
+func TestNewFormatterFromConfig_Disabled(t *testing.T) {
+	cfg := &core.RepoConfig{DisableFormatOnWrite: true}
+	if newFormatterFromConfig(slog.Default(), cfg) != nil {
+		t.Error("expected nil formatter when DisableFormatOnWrite is true")
+	}
+}
+
+func TestNewFormatterFromConfig_Enabled(t *testing.T) {
+	cfg := &core.RepoConfig{}
+	if newFormatterFromConfig(slog.Default(), cfg) == nil {
+		t.Error("expected non-nil formatter when DisableFormatOnWrite is false")
+	}
+}
+
+func TestNewFormatterFromConfig_NilConfig(t *testing.T) {
+	if newFormatterFromConfig(slog.Default(), nil) == nil {
+		t.Error("expected non-nil formatter when config is nil")
+	}
 }

--- a/internal/agent/formatter_test.go
+++ b/internal/agent/formatter_test.go
@@ -1,0 +1,92 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFormatter_NilReceiver(t *testing.T) {
+	var f *Formatter
+	if err := f.Format(context.Background(), "/tmp", "/tmp/test.go"); err != nil {
+		t.Errorf("nil Formatter should be a no-op: %v", err)
+	}
+}
+
+func TestFormatter_Format_SkipsUnknownExtension(t *testing.T) {
+	f := NewFormatter(slog.Default())
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(filePath, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Format(context.Background(), dir, filePath); err != nil {
+		t.Errorf("Format should skip unknown extensions: %v", err)
+	}
+}
+
+func TestFormatter_Format_FormatsGoFile(t *testing.T) {
+	if _, err := exec.LookPath("gofmt"); err != nil {
+		t.Skip("gofmt not available")
+	}
+	f := NewFormatter(slog.Default())
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "test.go")
+	content := "package test\n\nfunc  Foo ( )  { }\n"
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := f.Format(context.Background(), dir, filePath)
+	if err != nil {
+		t.Fatalf("Format failed: %v", err)
+	}
+
+	formatted, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(formatted), "func  Foo ( )") {
+		t.Error("gofmt did not format the file")
+	}
+}
+
+func TestFormatter_Format_PrefersGoimports(t *testing.T) {
+	if _, err := exec.LookPath("goimports"); err != nil {
+		t.Skip("goimports not available")
+	}
+	f := NewFormatter(slog.Default())
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "test.go")
+	content := "package test\n\nimport \"fmt\"\n\nfunc Foo() {fmt.Println(\"hi\")}\n"
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := f.Format(context.Background(), dir, filePath)
+	if err != nil {
+		t.Fatalf("Format failed: %v", err)
+	}
+}
+
+func TestFormatter_FormatsPythonWithRuff(t *testing.T) {
+	if _, err := exec.LookPath("ruff"); err != nil {
+		t.Skip("ruff not available")
+	}
+	f := NewFormatter(slog.Default())
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "test.py")
+	content := "x=1\n"
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := f.Format(context.Background(), dir, filePath)
+	if err != nil {
+		t.Fatalf("Format failed: %v", err)
+	}
+}

--- a/internal/agent/inprocess.go
+++ b/internal/agent/inprocess.go
@@ -173,7 +173,7 @@ func (o *Orchestrator) buildNativeLoopWithObs(obs *loopObserver) loopBuilderFn {
 
 		// File tools for native agent — needed for read/write/edit/list operations.
 		// Auto-formatting disabled in in-process mode (no Formatter configured).
-		for _, t := range fileTools(nil, nil) {
+		for _, t := range fileTools(nil) {
 			wrapped := &contextInjectingTool{
 				inner:       t,
 				projectRoot: ws.dir,

--- a/internal/agent/inprocess.go
+++ b/internal/agent/inprocess.go
@@ -172,7 +172,8 @@ func (o *Orchestrator) buildNativeLoopWithObs(obs *loopObserver) loopBuilderFn {
 		}
 
 		// File tools for native agent — needed for read/write/edit/list operations.
-		for _, t := range fileTools() {
+		// Auto-formatting disabled in in-process mode (no Formatter configured).
+		for _, t := range fileTools(nil, nil) {
 			wrapped := &contextInjectingTool{
 				inner:       t,
 				projectRoot: ws.dir,

--- a/internal/agent/warden.go
+++ b/internal/agent/warden.go
@@ -420,8 +420,12 @@ func (o *Orchestrator) buildEditLoop(agentLLM llms.Model, session *Session, ws *
 		registerTool(registry, allowedTools, t, ws, session.ID, tracker, o.logger)
 	}
 
-	// File tools (no LSP — agent uses run_command for compile checks).
-	for _, t := range fileTools() {
+	// File tools — auto-format after write/edit (unless disabled by repo config).
+	formatter := NewFormatter(o.logger)
+	if o.repoConfig != nil && o.repoConfig.DisableAutoFormat {
+		formatter = nil
+	}
+	for _, t := range fileTools(formatter, o.logger) {
 		registerTool(registry, allowedTools, t, ws, session.ID, tracker, o.logger)
 	}
 
@@ -462,8 +466,12 @@ func (o *Orchestrator) buildReviewLoop(agentLLM llms.Model, session *Session, ws
 		registerTool(registry, allowedTools, tool, ws, session.ID, tracker, o.logger)
 	}
 
-	// File tools (for fixing issues found during review).
-	for _, t := range fileTools() {
+	// File tools — auto-format after write/edit (unless disabled by repo config).
+	reviewFormatter := NewFormatter(o.logger)
+	if o.repoConfig != nil && o.repoConfig.DisableAutoFormat {
+		reviewFormatter = nil
+	}
+	for _, t := range fileTools(reviewFormatter, o.logger) {
 		registerTool(registry, allowedTools, t, ws, session.ID, tracker, o.logger)
 	}
 
@@ -552,6 +560,7 @@ Working directory: %s
 
 ## Rules
 - Paths are relative to the working directory.
+- Files are auto-formatted on write (goimports/.go, ruff format+check/.py, prettier/.ts/.js, rustfmt/.rs). No need to call a formatter manually.
 - Always run lint and tests after making changes.
 - Do NOT call review_code — it is not available in this phase. Review will happen automatically in the next phase.
 - Do not attempt to push or open a PR.
@@ -619,6 +628,7 @@ Working directory: %s
 
 ## Rules
 - Paths are relative to the working directory.
+- Files are auto-formatted on write (goimports/.go, ruff format+check/.py, prettier/.ts/.js, rustfmt/.rs). No need to call a formatter manually.
 - You MUST call review_code at least once. Do not finish without calling it.
 - Always run lint and tests before calling review_code.
 - Your work here is done ONLY when review_code returns APPROVE. Do not attempt to push or open a PR.

--- a/internal/agent/warden.go
+++ b/internal/agent/warden.go
@@ -247,6 +247,12 @@ func (o *Orchestrator) runImplementPhase(
 		changedFiles = modifiedFiles(editResult.ToolCalls)
 	}
 
+	// ── Batch format ──────────────────────────────────────────────────────────
+	// Run the project's format_command once before review (e.g. "npm run format").
+	// This is configured in .code-warden.yml and is separate from per-write
+	// Go formatting (which runs inside write_file/edit_file via the Formatter).
+	o.formatProject(ctx, ws)
+
 	// ── Review+fix loop ─────────────────────────────────────────────────────
 	tracker.setPhase("reviewing")
 	return o.runReviewPhase(ctx, session, agentLLM, ws, branch, tracker, editIters, editObs, changedFiles)
@@ -420,12 +426,8 @@ func (o *Orchestrator) buildEditLoop(agentLLM llms.Model, session *Session, ws *
 		registerTool(registry, allowedTools, t, ws, session.ID, tracker, o.logger)
 	}
 
-	// File tools — auto-format after write/edit (unless disabled by repo config).
-	formatter := NewFormatter(o.logger)
-	if o.repoConfig != nil && o.repoConfig.DisableAutoFormat {
-		formatter = nil
-	}
-	for _, t := range fileTools(formatter, o.logger) {
+	// File tools — auto-format Go files after write/edit (unless disabled by repo config).
+	for _, t := range fileTools(newFormatterFromConfig(o.logger, o.repoConfig)) {
 		registerTool(registry, allowedTools, t, ws, session.ID, tracker, o.logger)
 	}
 
@@ -466,12 +468,8 @@ func (o *Orchestrator) buildReviewLoop(agentLLM llms.Model, session *Session, ws
 		registerTool(registry, allowedTools, tool, ws, session.ID, tracker, o.logger)
 	}
 
-	// File tools — auto-format after write/edit (unless disabled by repo config).
-	reviewFormatter := NewFormatter(o.logger)
-	if o.repoConfig != nil && o.repoConfig.DisableAutoFormat {
-		reviewFormatter = nil
-	}
-	for _, t := range fileTools(reviewFormatter, o.logger) {
+	// File tools — auto-format Go files after write/edit (unless disabled by repo config).
+	for _, t := range fileTools(newFormatterFromConfig(o.logger, o.repoConfig)) {
 		registerTool(registry, allowedTools, t, ws, session.ID, tracker, o.logger)
 	}
 
@@ -560,7 +558,7 @@ Working directory: %s
 
 ## Rules
 - Paths are relative to the working directory.
-- Files are auto-formatted on write (goimports/.go, ruff format+check/.py, prettier/.ts/.js, rustfmt/.rs). No need to call a formatter manually.
+- Files are auto-formatted on write (goimports or gofmt for .go files). Other languages use the project's format_command before review.
 - Always run lint and tests after making changes.
 - Do NOT call review_code — it is not available in this phase. Review will happen automatically in the next phase.
 - Do not attempt to push or open a PR.
@@ -628,7 +626,7 @@ Working directory: %s
 
 ## Rules
 - Paths are relative to the working directory.
-- Files are auto-formatted on write (goimports/.go, ruff format+check/.py, prettier/.ts/.js, rustfmt/.rs). No need to call a formatter manually.
+- Files are auto-formatted on write (goimports or gofmt for .go files). Other languages use the project's format_command before review.
 - You MUST call review_code at least once. Do not finish without calling it.
 - Always run lint and tests before calling review_code.
 - Your work here is done ONLY when review_code returns APPROVE. Do not attempt to push or open a PR.
@@ -1280,6 +1278,17 @@ func (o *Orchestrator) getGitDiffStat(workspaceDir string) string {
 		stat = stat[:4000] + "\n... (truncated)"
 	}
 	return stat
+}
+
+// formatProject runs the project's format_command once before the review phase.
+// The command is configured in .code-warden.yml (e.g. "npm run format", "ruff format .").
+// No-op if no format_command is set or auto-format is disabled.
+func (o *Orchestrator) formatProject(ctx context.Context, ws *agentWorkspace) {
+	if o.repoConfig == nil || o.repoConfig.FormatCommand == "" || o.repoConfig.DisableAutoFormat {
+		return
+	}
+	formatter := NewFormatter(o.logger)
+	formatter.FormatProject(ctx, ws.dir, o.repoConfig.FormatCommand)
 }
 
 // yieldCommitAndPush stages all pending changes, commits, and pushes the branch.

--- a/internal/agent/warden.go
+++ b/internal/agent/warden.go
@@ -251,11 +251,11 @@ func (o *Orchestrator) runImplementPhase(
 	// Run the project's format_command once before review (e.g. "npm run format").
 	// This is configured in .code-warden.yml and is separate from per-write
 	// Go formatting (which runs inside write_file/edit_file via the Formatter).
-	o.formatProject(ctx, ws)
+	formatNote := o.formatProject(ctx, ws)
 
 	// ── Review+fix loop ─────────────────────────────────────────────────────
 	tracker.setPhase("reviewing")
-	return o.runReviewPhase(ctx, session, agentLLM, ws, branch, tracker, editIters, editObs, changedFiles)
+	return o.runReviewPhase(ctx, session, agentLLM, ws, branch, tracker, editIters, editObs, changedFiles, formatNote)
 }
 
 // runReviewPhase runs the review+fix loop after the edit loop completes.
@@ -272,6 +272,7 @@ func (o *Orchestrator) runReviewPhase(
 	editIters int,
 	editObs *loopObserver,
 	changedFiles []string,
+	formatNote string,
 ) (iterations int, obs *loopObserver, verdict string, ok bool) {
 	o.logger.Info("warden: starting review+fix loop",
 		"session_id", session.ID, "changed_files", len(changedFiles),
@@ -287,7 +288,7 @@ func (o *Orchestrator) runReviewPhase(
 	reviewTask := goframeagent.Task{
 		ID:          session.ID + "-review",
 		Description: fmt.Sprintf("Review and fix implementation for GitHub issue #%d: %s", session.Issue.Number, session.Issue.Title),
-		Context:     o.buildReviewTaskContext(session.Issue, branch, changedFiles),
+		Context:     o.buildReviewTaskContext(session.Issue, branch, changedFiles, formatNote),
 		Priority:    5,
 	}
 
@@ -643,7 +644,7 @@ Working directory: %s
 
 // buildReviewTaskContext returns the task context for the review+fix loop.
 // It lists the changed files so the review agent knows what was modified.
-func (o *Orchestrator) buildReviewTaskContext(issue Issue, branch string, changedFiles []string) string {
+func (o *Orchestrator) buildReviewTaskContext(issue Issue, branch string, changedFiles []string, formatNote string) string {
 	ctx := fmt.Sprintf("Review and verify the implementation for GitHub issue #%d (%s).\nBranch: %s",
 		issue.Number, issue.Title, branch)
 	if len(changedFiles) > 0 {
@@ -653,6 +654,9 @@ func (o *Orchestrator) buildReviewTaskContext(issue Issue, branch string, change
 		}
 	}
 	ctx += "\n\nCall review_code to verify your changes. Fix any issues found, then re-verify and re-review until APPROVE."
+	if formatNote != "" {
+		ctx += "\n\n" + formatNote
+	}
 	return ctx
 }
 
@@ -1282,13 +1286,15 @@ func (o *Orchestrator) getGitDiffStat(workspaceDir string) string {
 
 // formatProject runs the project's format_command once before the review phase.
 // The command is configured in .code-warden.yml (e.g. "npm run format", "ruff format .").
-// No-op if no format_command is set or auto-format is disabled.
-func (o *Orchestrator) formatProject(ctx context.Context, ws *agentWorkspace) {
-	if o.repoConfig == nil || o.repoConfig.FormatCommand == "" || o.repoConfig.DisableAutoFormat {
-		return
+// No-op if no format_command is set. Controlled independently of DisableFormatOnWrite.
+// Returns a human-readable note for the review context if formatting ran, or "".
+func (o *Orchestrator) formatProject(ctx context.Context, ws *agentWorkspace) string {
+	if o.repoConfig == nil || o.repoConfig.FormatCommand == "" {
+		return ""
 	}
 	formatter := NewFormatter(o.logger)
 	formatter.FormatProject(ctx, ws.dir, o.repoConfig.FormatCommand)
+	return fmt.Sprintf("Note: project format command ran before review (\"%s\"). Some files may have formatting changes you did not make.", o.repoConfig.FormatCommand)
 }
 
 // yieldCommitAndPush stages all pending changes, commits, and pushes the branch.

--- a/internal/core/repo_config.go
+++ b/internal/core/repo_config.go
@@ -87,6 +87,11 @@ type RepoConfig struct {
 	// DisableAutoFormat disables post-write formatting. Set to true for repos
 	// that manage formatting through their own CI pipeline or pre-commit hooks.
 	DisableAutoFormat bool `yaml:"disable_auto_format"`
+
+	// FormatCommand is a shell command to run once before the review phase to
+	// format all modified files (e.g. "npm run format", "ruff format .").
+	// If empty, no batch formatting is performed.
+	FormatCommand string `yaml:"format_command"`
 }
 
 // DefaultRepoConfig returns a config with default values.

--- a/internal/core/repo_config.go
+++ b/internal/core/repo_config.go
@@ -83,6 +83,10 @@ type RepoConfig struct {
 	// CommandTimeoutSeconds is the per-command timeout for run_command in seconds.
 	// Defaults to 300 (5 minutes) when zero. Increase for repos with long test suites.
 	CommandTimeoutSeconds int `yaml:"command_timeout_seconds"`
+
+	// DisableAutoFormat disables post-write formatting. Set to true for repos
+	// that manage formatting through their own CI pipeline or pre-commit hooks.
+	DisableAutoFormat bool `yaml:"disable_auto_format"`
 }
 
 // DefaultRepoConfig returns a config with default values.

--- a/internal/core/repo_config.go
+++ b/internal/core/repo_config.go
@@ -84,9 +84,11 @@ type RepoConfig struct {
 	// Defaults to 300 (5 minutes) when zero. Increase for repos with long test suites.
 	CommandTimeoutSeconds int `yaml:"command_timeout_seconds"`
 
-	// DisableAutoFormat disables post-write formatting. Set to true for repos
-	// that manage formatting through their own CI pipeline or pre-commit hooks.
-	DisableAutoFormat bool `yaml:"disable_auto_format"`
+	// DisableFormatOnWrite disables per-write formatting (goimports/gofmt for Go).
+	// This is independent of the batch format_command, which runs before review
+	// as long as format_command is set. A project might disable per-write
+	// formatting (e.g. their IDE already does it) but still want batch formatting.
+	DisableFormatOnWrite bool `yaml:"disable_format_on_write"`
 
 	// FormatCommand is a shell command to run once before the review phase to
 	// format all modified files (e.g. "npm run format", "ruff format .").

--- a/internal/mcp/tools/run_command.go
+++ b/internal/mcp/tools/run_command.go
@@ -27,6 +27,7 @@ var defaultVerifyCommands = []string{
 	"make build",
 	"make lint",
 	"make test",
+	"make fmt",
 }
 
 // RunCommand executes a whitelisted shell command in the session workspace and

--- a/internal/mcp/tools/run_command.go
+++ b/internal/mcp/tools/run_command.go
@@ -27,7 +27,6 @@ var defaultVerifyCommands = []string{
 	"make build",
 	"make lint",
 	"make test",
-	"make fmt",
 }
 
 // RunCommand executes a whitelisted shell command in the session workspace and


### PR DESCRIPTION
## Summary

Adds transparent post-write auto-formatting following the Claude Code hook pattern: formatters run as trusted system code after every file write, invisible to the LLM. The LLM writes approximate code; the system silently fixes formatting; the LLM sees the final formatted result in the diff.

### Supported formatters
| Language | Tool | What it covers |
|----------|------|---------------|
| Go | goimports (fallback: gofmt) | Style + import add/remove/sort |
| Python | ruff format + ruff check --fix | Style + import sort + unused removal |
| TypeScript/JS | prettier --write | Style only |
| Rust | rustfmt | Style only |
| Java | google-java-format --replace | Style only |

### Key design decisions
- **Best-effort**: missing binaries are silently skipped (never error)
- **30-second hard timeout** via `context.WithTimeout`
- **workspaceRoot as cmd.Dir** so `.prettierrc`, `pyproject.toml` etc. are respected
- **Re-read after format**: the diff the LLM sees always matches disk
- **Opt-out**: `disable_auto_format: true` in `.code-warden.yml`

### Files changed
- **`internal/agent/formatter.go`** (new): `Formatter` struct with ext→spec map, `Format()` method with LookPath + timeout
- **`internal/agent/formatter_test.go`** (new): tests for nil receiver, unknown ext, gofmt, goimports, ruff
- **`internal/agent/file_tools.go`**: `writeFileTool` and `editFileTool` now have `Formatter` and `Logger` fields; auto-format + re-read after write
- **`internal/agent/warden.go`**: constructs `Formatter` in both edit and review loops (respects `RepoConfig.DisableAutoFormat`); system prompts note auto-formatting
- **`internal/core/repo_config.go`**: adds `DisableAutoFormat bool` field
- **`internal/mcp/tools/run_command.go`**: adds `"make fmt"` to default whitelist
- **`internal/agent/inprocess.go`**: passes `nil, nil` to `fileTools()` (auto-format disabled in in-process mode)

## Test Plan
- [x] `make build` passes
- [x] `make lint` passes (0 issues)
- [x] `make test` passes
- [x] `TestFormatter_NilReceiver` — nil Formatter is a no-op
- [x] `TestFormatter_Format_SkipsUnknownExtension` — .txt files are skipped
- [x] `TestFormatter_Format_FormatsGoFile` — gofmt formats Go files
- [x] `TestFormatter_Format_PrefersGoimports` — goimports is preferred over gofmt
- [ ] Live agent run to verify auto-formatting in practice