### PR TITLE
fix(agent): fix 4 bugs in implement flow review pipeline

### DIFF
--- a/internal/agent/progress_test.go
+++ b/internal/agent/progress_test.go
@@ -133,17 +133,21 @@ func TestCompactionFilterText(t *testing.T) {
 		input     string
 		wantStrip bool
 	}{
-		{"read_file: {\"content\": \"...\"}", true},
-		{"search_code: {\"results\": []}", true},
-		{"list_dir: {\"entries\": []}", true},
-		{"write_file: {\"ok\": true}", false},
-		{"edit_file: {\"ok\": true}", false},
-		{"review_code: {\"verdict\": \"APPROVE\"}", false},
-		{"run_command: {\"output\": \"ok\"}", false},
+		// goframe formats tool results as "Tool '<name>' returned: <json>"
+		{"Tool 'read_file' returned: {\"content\": \"...\"}", true},
+		{"Tool 'search_code' returned: {\"results\": []}", true},
+		{"Tool 'list_dir' returned: {\"entries\": []}", true},
+		{"Tool 'grep' returned: {\"matches\": []}", true},
+		{"Tool 'find' returned: {\"files\": []}", true},
+		{"Tool 'get_symbol' returned: {\"name\": \"foo\"}", true},
+		{"Tool 'write_file' returned: {\"ok\": true}", false},
+		{"Tool 'edit_file' returned: {\"ok\": true}", false},
+		{"Tool 'review_code' returned: {\"verdict\": \"APPROVE\"}", false},
+		{"Tool 'run_command' returned: {\"output\": \"ok\"}", false},
 		{"some random assistant message", false},
 		// Coordinate LSP tools were removed from the explorer set;
 		// lsp_diagnostics is also not stripped (it belongs to verification).
-		{"lsp_diagnostics: {\"ok\": true}", false},
+		{"Tool 'lsp_diagnostics' returned: {\"ok\": true}", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.input[:min(20, len(tc.input))], func(t *testing.T) {

--- a/internal/agent/warden.go
+++ b/internal/agent/warden.go
@@ -255,13 +255,20 @@ func (o *Orchestrator) runReviewPhase(
 	lastVerdict := ""
 
 	for round := 1; round <= maxRounds; round++ {
-		verdict, reviewResult, ok := o.runReviewRound(
+		verdict, reviewResult, roundErr := o.runReviewRound(
 			ctx, session, ws, round, maxRounds,
 			executor, tracker,
 		)
-		if !ok {
-			// Empty diff after edit loop — yield a draft PR instead of approving nothing.
-			o.yieldDraftPR(ctx, session, ws, branch, editIters+totalFixIters, editObs.totalIn, editObs.totalOut, changedFiles)
+		if roundErr != nil {
+			if errors.Is(roundErr, errEmptyDiff) {
+				// No workspace changes after the edit loop — yield a draft PR
+				// instead of approving nothing.
+				o.yieldDraftPR(ctx, session, ws, branch, editIters+totalFixIters, editObs.totalIn, editObs.totalOut, changedFiles)
+			} else {
+				// Git or review executor failure — fail the session without
+				// attempting to push unreviewed code.
+				o.failSession(ctx, session, roundErr.Error())
+			}
 			return 0, nil, "", false
 		}
 		lastVerdict = verdict
@@ -306,8 +313,12 @@ func (o *Orchestrator) runReviewPhase(
 }
 
 // runReviewRound executes a single review round: gets the workspace diff and
-// runs the RAG review. Returns the verdict and review result. ok is false when
-// the round should abort (git error, empty diff, or review failure).
+// runs the RAG review. Returns the verdict and review result on success.
+//
+// On failure it returns a non-nil error without calling failSession — the
+// caller is responsible for deciding how to handle each error type:
+//   - errors.Is(err, errEmptyDiff): no workspace changes → yield a draft PR
+//   - any other error: an actual failure → fail the session
 func (o *Orchestrator) runReviewRound(
 	ctx context.Context,
 	session *Session,
@@ -315,7 +326,7 @@ func (o *Orchestrator) runReviewRound(
 	round, maxRounds int,
 	executor *reviewpkg.Executor,
 	tracker *progressTracker,
-) (verdict string, review *core.StructuredReview, ok bool) {
+) (verdict string, review *core.StructuredReview, err error) {
 	sessionCtx := tools.WithSessionID(ctx, session.ID)
 	tracker.setPhase(fmt.Sprintf("reviewing (round %d/%d)", round, maxRounds))
 
@@ -323,13 +334,12 @@ func (o *Orchestrator) runReviewRound(
 	if diffErr != nil {
 		o.logger.Error("warden: git diff HEAD failed",
 			"session_id", session.ID, "round", round, "error", diffErr)
-		o.failSession(ctx, session, fmt.Sprintf("git diff failed in review round %d: %v", round, diffErr))
-		return "", nil, false
+		return "", nil, fmt.Errorf("git diff failed in review round %d: %w", round, diffErr)
 	}
 	if diff == "" {
 		o.logger.Warn("warden: no diff detected in workspace after edit loop",
 			"session_id", session.ID, "round", round)
-		return "", nil, false
+		return "", nil, errEmptyDiff
 	}
 
 	o.logger.Info("warden: running code review",
@@ -341,18 +351,17 @@ func (o *Orchestrator) runReviewRound(
 		RepoFullName: session.Issue.RepoOwner + "/" + session.Issue.RepoName,
 		HeadSHA:      "agent-workspace",
 	}
-	result, err := executor.Execute(ctx, reviewpkg.Params{
+	result, execErr := executor.Execute(ctx, reviewpkg.Params{
 		RepoConfig:   o.repoConfig,
 		Repo:         o.repo,
 		Event:        event,
 		Diff:         diff,
 		ChangedFiles: parsedFiles,
 	})
-	if err != nil {
+	if execErr != nil {
 		o.logger.Error("warden: code review failed",
-			"session_id", session.ID, "round", round, "error", err)
-		o.failSession(ctx, session, fmt.Sprintf("code review round %d: %v", round, err))
-		return "", nil, false
+			"session_id", session.ID, "round", round, "error", execErr)
+		return "", nil, fmt.Errorf("code review round %d: %w", round, execErr)
 	}
 
 	verdict = result.Review.Verdict
@@ -363,7 +372,7 @@ func (o *Orchestrator) runReviewRound(
 	o.mcpServer.RecordReviewBySession(sessionCtx, result.Review.Verdict, result.DiffHash)
 	o.mcpServer.RecordReviewFiles(sessionCtx, changedFileNames(parsedFiles))
 
-	return verdict, result.Review, true
+	return verdict, result.Review, nil
 }
 
 // runPublishPhase builds and runs the publish loop, assembles the final result,
@@ -1195,6 +1204,11 @@ func (o *Orchestrator) compactMessages(ctx context.Context, llm llms.Model, msgs
 // uncommitted changes to push. The caller should skip PR creation and post
 // a "no changes were made" comment instead.
 var errNoChanges = fmt.Errorf("no changes to commit")
+
+// errEmptyDiff is returned by runReviewRound when git diff HEAD produces no
+// output. The caller should yield a draft PR rather than fail the session —
+// the agent may have made partial changes that are worth preserving.
+var errEmptyDiff = fmt.Errorf("no diff detected in workspace")
 
 // yieldDraftPR is called when the implement loop ends without an APPROVE verdict.
 // Instead of silently failing, it commits any pending changes, pushes the branch,

--- a/internal/agent/warden.go
+++ b/internal/agent/warden.go
@@ -253,63 +253,34 @@ func (o *Orchestrator) runReviewPhase(
 
 	totalFixIters := 0
 	lastVerdict := ""
-	// Use a session-scoped context so review tracking is scoped to this session.
-	sessionCtx := tools.WithSessionID(ctx, session.ID)
 
 	for round := 1; round <= maxRounds; round++ {
-		tracker.setPhase(fmt.Sprintf("reviewing (round %d/%d)", round, maxRounds))
-
-		// Step 1: get the diff of all workspace changes since the last commit.
-		// The edit loop edits files directly without committing, so git diff HEAD
-		// captures all changes made since the workspace was cloned.
-		diff := o.getWorkspaceDiff(ctx, ws.dir)
-		if diff == "" {
-			o.logger.Warn("warden: no diff detected in workspace, skipping review",
-				"session_id", session.ID, "round", round)
-			lastVerdict = core.VerdictApprove
-			break
-		}
-
-		// Step 2: run the proven RAG-based code review.
-		o.logger.Info("warden: running code review",
-			"session_id", session.ID, "round", round, "diff_bytes", len(diff))
-		parsedFiles := ragreview.ParseDiff(diff)
-		event := &core.GitHubEvent{
-			PRTitle:      fmt.Sprintf("Implement #%d: %s", session.Issue.Number, session.Issue.Title),
-			PRBody:       session.Issue.Body,
-			RepoFullName: session.Issue.RepoOwner + "/" + session.Issue.RepoName,
-			HeadSHA:      "agent-workspace",
-		}
-		result, err := executor.Execute(ctx, reviewpkg.Params{
-			RepoConfig:   o.repoConfig,
-			Repo:         o.repo,
-			Event:        event,
-			Diff:         diff,
-			ChangedFiles: parsedFiles,
-		})
-		if err != nil {
-			o.logger.Error("warden: code review failed",
-				"session_id", session.ID, "round", round, "error", err)
-			o.failSession(ctx, session, fmt.Sprintf("code review round %d: %v", round, err))
+		verdict, reviewResult, ok := o.runReviewRound(
+			ctx, session, ws, round, maxRounds,
+			executor, tracker,
+		)
+		if !ok {
+			// Empty diff after edit loop — yield a draft PR instead of approving nothing.
+			o.yieldDraftPR(ctx, session, ws, branch, editIters+totalFixIters, editObs.totalIn, editObs.totalOut, changedFiles)
 			return 0, nil, "", false
 		}
-
-		lastVerdict = result.Review.Verdict
-		o.logger.Info("warden: review complete",
-			"session_id", session.ID, "round", round,
-			"verdict", lastVerdict, "confidence", result.Review.Confidence,
-		)
-
-		// Step 3: record the review result so create_pull_request can enforce it.
-		o.mcpServer.RecordReviewBySession(sessionCtx, result.Review.Verdict, result.DiffHash)
-		o.mcpServer.RecordReviewFiles(sessionCtx, changedFileNames(parsedFiles))
+		lastVerdict = verdict
 
 		if lastVerdict == core.VerdictApprove {
 			break
 		}
 
-		// Step 4: reviewer requested changes — run a focused fix loop.
-		addedIters, addedFiles, fixErr := o.runFixRound(ctx, agentLLM, session, ws, tracker, editObs, round, result.Review, formatNote)
+		// COMMENT means the reviewer left observations but did not request
+		// changes. There is nothing to fix, but the code is not explicitly
+		// approved either — break out and yield a draft PR.
+		if lastVerdict == core.VerdictComment {
+			o.logger.Info("warden: review verdict COMMENT, skipping fix round",
+				"session_id", session.ID, "round", round)
+			break
+		}
+
+		// Reviewer requested changes — run a focused fix loop.
+		addedIters, addedFiles, fixErr := o.runFixRound(ctx, agentLLM, session, ws, tracker, editObs, round, reviewResult, formatNote)
 		if fixErr != nil {
 			o.failSession(ctx, session, fixErr.Error())
 			return 0, nil, "", false
@@ -332,6 +303,67 @@ func (o *Orchestrator) runReviewPhase(
 	}
 
 	return totalIters, editObs, lastVerdict, true
+}
+
+// runReviewRound executes a single review round: gets the workspace diff and
+// runs the RAG review. Returns the verdict and review result. ok is false when
+// the round should abort (git error, empty diff, or review failure).
+func (o *Orchestrator) runReviewRound(
+	ctx context.Context,
+	session *Session,
+	ws *agentWorkspace,
+	round, maxRounds int,
+	executor *reviewpkg.Executor,
+	tracker *progressTracker,
+) (verdict string, review *core.StructuredReview, ok bool) {
+	sessionCtx := tools.WithSessionID(ctx, session.ID)
+	tracker.setPhase(fmt.Sprintf("reviewing (round %d/%d)", round, maxRounds))
+
+	diff, diffErr := o.getWorkspaceDiff(ctx, ws.dir)
+	if diffErr != nil {
+		o.logger.Error("warden: git diff HEAD failed",
+			"session_id", session.ID, "round", round, "error", diffErr)
+		o.failSession(ctx, session, fmt.Sprintf("git diff failed in review round %d: %v", round, diffErr))
+		return "", nil, false
+	}
+	if diff == "" {
+		o.logger.Warn("warden: no diff detected in workspace after edit loop",
+			"session_id", session.ID, "round", round)
+		return "", nil, false
+	}
+
+	o.logger.Info("warden: running code review",
+		"session_id", session.ID, "round", round, "diff_bytes", len(diff))
+	parsedFiles := ragreview.ParseDiff(diff)
+	event := &core.GitHubEvent{
+		PRTitle:      fmt.Sprintf("Implement #%d: %s", session.Issue.Number, session.Issue.Title),
+		PRBody:       session.Issue.Body,
+		RepoFullName: session.Issue.RepoOwner + "/" + session.Issue.RepoName,
+		HeadSHA:      "agent-workspace",
+	}
+	result, err := executor.Execute(ctx, reviewpkg.Params{
+		RepoConfig:   o.repoConfig,
+		Repo:         o.repo,
+		Event:        event,
+		Diff:         diff,
+		ChangedFiles: parsedFiles,
+	})
+	if err != nil {
+		o.logger.Error("warden: code review failed",
+			"session_id", session.ID, "round", round, "error", err)
+		o.failSession(ctx, session, fmt.Sprintf("code review round %d: %v", round, err))
+		return "", nil, false
+	}
+
+	verdict = result.Review.Verdict
+	o.logger.Info("warden: review complete",
+		"session_id", session.ID, "round", round,
+		"verdict", verdict, "confidence", result.Review.Confidence,
+	)
+	o.mcpServer.RecordReviewBySession(sessionCtx, result.Review.Verdict, result.DiffHash)
+	o.mcpServer.RecordReviewFiles(sessionCtx, changedFileNames(parsedFiles))
+
+	return verdict, result.Review, true
 }
 
 // runPublishPhase builds and runs the publish loop, assembles the final result,
@@ -621,18 +653,17 @@ func (o *Orchestrator) runFixRound(
 }
 
 // getWorkspaceDiff returns the full git diff of all changes made since the
-// workspace was cloned (git diff HEAD). Returns empty string on error or when
-// there are no changes.
-func (o *Orchestrator) getWorkspaceDiff(ctx context.Context, workspaceDir string) string {
+// workspace was cloned (git diff HEAD). Returns empty string when there are no
+// changes. Returns a non-nil error when the git command itself fails (e.g.
+// corrupt repo, missing git binary).
+func (o *Orchestrator) getWorkspaceDiff(ctx context.Context, workspaceDir string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", "diff", "HEAD")
 	cmd.Dir = workspaceDir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		o.logger.Warn("warden: git diff HEAD failed",
-			"workspace", workspaceDir, "error", err, "output", string(out))
-		return ""
+		return "", fmt.Errorf("git diff HEAD: %w (output: %s)", err, string(out))
 	}
-	return string(out)
+	return string(out), nil
 }
 
 // buildFixSystemPrompt returns the system prompt for a focused fix loop.
@@ -834,9 +865,12 @@ func extractPreviousSummary(msgs []schema.MessageContent) (previousSummary strin
 // truncated rather than omitted entirely.
 func compactionFilterText(text string) string {
 	for name := range compactionExplorationTools {
-		prefix := name + ":"
+		// goframe formats tool results as "Tool '<name>' returned: <json>".
+		// Match on "Tool '<name>'" prefix to strip exploration outputs during
+		// compaction, regardless of what follows the tool name.
+		prefix := "Tool '" + name + "'"
 		if strings.HasPrefix(text, prefix) {
-			return prefix + " [output omitted during compaction]"
+			return name + ": [output omitted during compaction]"
 		}
 	}
 	if len(text) > compactionMaxOutputLen {
@@ -1382,9 +1416,17 @@ func yieldCommitAndPush(ctx context.Context, workspaceDir, branch string, edited
 	logger.Info("yieldCommitAndPush: staging changes", "files", editedFiles)
 	if len(editedFiles) > 0 {
 		args := append([]string{"add", "--"}, editedFiles...)
-		_, _ = run(args...)
+		if addOut, addErr := run(args...); addErr != nil {
+			logger.Error("yieldCommitAndPush: git add failed",
+				"files", editedFiles, "error", addErr, "output", addOut)
+			return fmt.Errorf("git add %v: %w (output: %s)", editedFiles, addErr, addOut)
+		}
 	} else {
-		_, _ = run("add", ".")
+		if addOut, addErr := run("add", "."); addErr != nil {
+			logger.Error("yieldCommitAndPush: git add . failed",
+				"error", addErr, "output", addOut)
+			return fmt.Errorf("git add .: %w (output: %s)", addErr, addOut)
+		}
 	}
 
 	// Commit — detect "nothing to commit" and surface it as errNoChanges so the

--- a/internal/agent/warden.go
+++ b/internal/agent/warden.go
@@ -1257,14 +1257,14 @@ func (o *Orchestrator) yieldDraftPR(
 	// The workspace remote already has the GitHub token embedded in its URL
 	// (set by prepareAgentWorkspace), so no token injection is needed here.
 	pushErr := yieldCommitAndPush(ctx, ws.dir, branch, editedFiles, session.Issue.Number, session.Issue.Title, o.logger)
-	if pushErr != nil && !strings.Contains(pushErr.Error(), errNoChanges.Error()) {
+	if pushErr != nil && !errors.Is(pushErr, errNoChanges) {
 		o.logger.Warn("warden: yieldDraftPR: push failed, session will still be marked draft",
 			"session_id", session.ID, "error", pushErr)
 	}
 
 	// When the agent made no file changes at all, a draft PR would be empty and
 	// confusing. Skip PR creation and fall through to a descriptive failure comment.
-	if pushErr != nil && strings.Contains(pushErr.Error(), errNoChanges.Error()) {
+	if errors.Is(pushErr, errNoChanges) {
 		o.logger.Info("warden: no changes to push, marking session failed instead of creating empty draft",
 			"session_id", session.ID)
 		o.failSession(ctx, session, fmt.Sprintf(


### PR DESCRIPTION
## Summary

- **Empty diff auto-approve bug**: `getWorkspaceDiff` now returns `(string, error)`. A git error fails the session; an empty diff after the edit loop yields a draft PR instead of auto-approving and creating an empty PR.
- **COMMENT verdict triggers unnecessary fix rounds**: A `COMMENT` verdict (default when the LLM omits a verdict) now breaks out of the review loop and yields a draft PR, instead of falling through to `runFixRound` where it wastes iterations trying to fix non-actionable observations.
- **Compaction filter prefix mismatch**: The filter checked for `"read_file:"` but goframe formats tool results as `"Tool 'read_file' returned: ..."`. Exploration tool outputs were never stripped during compaction, filling the context window. Now matches the actual `"Tool '<name>'"` prefix.
- **git add errors silently discarded**: `yieldCommitAndPush` now checks and propagates `git add` errors instead of ignoring them, preventing commits with no staged changes from proceeding.
- **Double-handling bug in runReviewRound refactor**: The extracted `runReviewRound` helper was calling `failSession` internally AND the caller was also calling `yieldDraftPR` for all `!ok` cases — producing both a failure comment and a draft PR on GitHub for git/executor errors. Fixed by changing the return type from `bool` to `error`, using an `errEmptyDiff` sentinel so the caller can distinguish "no changes → yield draft PR" from "actual error → fail session".
- **errNoChanges detection**: Replaced `strings.Contains(err.Error(), errNoChanges.Error())` with `errors.Is(pushErr, errNoChanges)` in `yieldDraftPR` — the idiomatic Go approach since the sentinel is returned directly without wrapping.

Also extracted `runReviewRound` helper from `runReviewPhase` to keep it under the `funlen` limit.

## Test plan

- [x] `make test` passes
- [x] `make lint` passes (0 issues)
- [ ] Integration test: run `/implement` on a GitHub issue and verify the review loop handles COMMENT verdict and empty diffs correctly
- [ ] Verify compaction strips exploration tool outputs in long agent sessions
- [ ] Verify git/executor errors in the review phase fail the session without creating a spurious draft PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)